### PR TITLE
Assistant Permission Addition: SiriKit/Intents on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ enum PermissionGroup {
   /// The unknown permission only used for return type, never requested
   unknown,
 
+  /// Android: Nothing
+  /// iOS: SiriKit/Intents
+  assistant,
+
   /// Android: Calendar
   /// iOS: Calendar (Events)
   calendar,
@@ -218,3 +222,5 @@ If you would like to contribute to the plugin (e.g. by improving the documentati
 ## Author
 
 This Permission handler plugin for Flutter is developed by [Baseflow](https://baseflow.com). You can contact us at <hello@baseflow.com>
+
+The Assistant/SiriKit/Intents was added by Voltaire, Inc(https://voltaireapp.com).

--- a/example/ios/Flutter/flutter_export_environment.sh
+++ b/example/ios/Flutter/flutter_export_environment.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# This is a generated file; do not edit or check into version control.
+export "FLUTTER_ROOT=/Applications/flutter"
+export "FLUTTER_APPLICATION_PATH=/Users/basitmustafa/GitHub/flutter-permission-handler/example"
+export "FLUTTER_TARGET=/Users/basitmustafa/GitHub/flutter-permission-handler/example/lib/main.dart"
+export "FLUTTER_BUILD_DIR=build"
+export "SYMROOT=${SOURCE_ROOT}/../build/ios"
+export "FLUTTER_FRAMEWORK_DIR=/Applications/flutter/bin/cache/artifacts/engine/ios"
+export "TRACK_WIDGET_CREATION=true"

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D132729FF349998420355A35 /* libPods-Runner.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Runner.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F6A98E7E232CA616004A3199 /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -116,6 +117,7 @@
 		97C146F01CF9000F007C117D /* Runner */ = {
 			isa = PBXGroup;
 			children = (
+				F6A98E7E232CA616004A3199 /* Runner.entitlements */,
 				7AFFD8ED1D35381100E5BB4D /* AppDelegate.h */,
 				7AFFD8EE1D35381100E5BB4D /* AppDelegate.m */,
 				97C146FA1CF9000F007C117D /* Main.storyboard */,
@@ -379,7 +381,8 @@
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -392,6 +395,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
+				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.permissionHandlerExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				VERSIONING_SYSTEM = "apple-generic";
@@ -511,7 +515,8 @@
 			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -524,6 +529,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
+				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.permissionHandlerExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				VERSIONING_SYSTEM = "apple-generic";
@@ -535,7 +541,8 @@
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -548,6 +555,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
+				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.permissionHandlerExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				VERSIONING_SYSTEM = "apple-generic";

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -15,13 +15,41 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(FLUTTER_BUILD_NAME)</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppleMusicUsageDescription</key>
+	<string>Music!</string>
+	<key>NSBluetoothPeripheralUsageDescription</key>
+	<string>bluetooth</string>
+	<key>NSCalendarsUsageDescription</key>
+	<string>Calendars</string>
+	<key>NSCameraUsageDescription</key>
+	<string>camera</string>
+	<key>NSContactsUsageDescription</key>
+	<string>contacts</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Always and when in use!</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>Can I haz location always?</string>
+	<key>NSLocationUsageDescription</key>
+	<string>Older devices need location.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Need location when in use</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>microphone</string>
+	<key>NSMotionUsageDescription</key>
+	<string>motion</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>photos</string>
+	<key>NSRemindersUsageDescription</key>
+	<string>reminders</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>speech</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -40,36 +68,10 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
-    <false/>
-    <key>NSLocationWhenInUseUsageDescription</key>
-    <string>Need location when in use</string>
-    <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-    <string>Always and when in use!</string>
-    <key>NSLocationUsageDescription</key>
-    <string>Older devices need location.</string>
-    <key>NSLocationAlwaysUsageDescription</key>
-    <string>Can I haz location always?</string>
-    <key>NSAppleMusicUsageDescription</key>
-    <string>Music!</string>
-    <key>NSBluetoothPeripheralUsageDescription</key>
-    <string>bluetooth</string>
-    <key>NSCalendarsUsageDescription</key>
-    <string>Calendars</string>
-    <key>NSCameraUsageDescription</key>
-    <string>camera</string>
-    <key>NSContactsUsageDescription</key>
-    <string>contacts</string>
-    <key>kTCCServiceMediaLibrary</key>
-    <string>media</string>
-    <key>NSMicrophoneUsageDescription</key>
-    <string>microphone</string>
-    <key>NSMotionUsageDescription</key>
-    <string>motion</string>
-    <key>NSPhotoLibraryUsageDescription</key>
-    <string>photos</string>
-    <key>NSRemindersUsageDescription</key>
-    <string>reminders</string>
-    <key>NSSpeechRecognitionUsageDescription</key>
-    <string>speech</string>
+	<false/>
+	<key>NSSiriUsageDescription</key>
+	<string>Talk to me!</string>
+	<key>kTCCServiceMediaLibrary</key>
+	<string>media</string>
 </dict>
 </plist>

--- a/example/ios/Runner/Runner.entitlements
+++ b/example/ios/Runner/Runner.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.siri</key>
+	<true/>
+</dict>
+</plist>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -36,7 +36,7 @@ class MyApp extends StatelessWidget {
                       return permission != PermissionGroup.unknown &&
                           permission != PermissionGroup.mediaLibrary &&
                           permission != PermissionGroup.photos &&
-                          permission != PermissionGroup.reminders;
+                          permission != PermissionGroup.reminders && permission != PermissionGroup.assistant;
                     }
                   })
                   .map((PermissionGroup permission) =>

--- a/ios/Classes/PermissionHandlerEnums.h
+++ b/ios/Classes/PermissionHandlerEnums.h
@@ -23,6 +23,7 @@ typedef NS_ENUM(int, PermissionGroup) {
     PermissionGroupStorage,
     PermissionGroupIgnoreBatteryOptimizations,
     PermissionGroupUnknown,
+    PermissionGroupAssistant
 };
 
 typedef NS_ENUM(int, PermissionStatus) {

--- a/ios/Classes/PermissionManager.h
+++ b/ios/Classes/PermissionManager.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+#import "AssistantPermissionStrategy.h"
 #import "AudioVideoPermissionStrategy.h"
 #import "ContactPermissionStrategy.h"
 #import "EventPermissionStrategy.h"

--- a/ios/Classes/PermissionManager.m
+++ b/ios/Classes/PermissionManager.m
@@ -75,6 +75,8 @@
 
 + (id)createPermissionStrategy:(PermissionGroup)permission {
     switch (permission) {
+            case PermissionGroupAssistant:
+            return [AssistantPermissionStrategy new];
             case PermissionGroupCalendar:
             return [EventPermissionStrategy new];
             case PermissionGroupCamera:

--- a/ios/Classes/strategies/AssistantPermissionStrategy.h
+++ b/ios/Classes/strategies/AssistantPermissionStrategy.h
@@ -1,0 +1,12 @@
+//
+// Created by Basit Mustafa (24601@GitHub) on 2019-09-13.
+// Copyright (c) 2019 The Chromium Authors. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <Intents/Intents.h>
+#import "PermissionStrategy.h"
+
+
+@interface AssistantPermissionStrategy : NSObject <PermissionStrategy>
+@end

--- a/ios/Classes/strategies/AssistantPermissionStrategy.m
+++ b/ios/Classes/strategies/AssistantPermissionStrategy.m
@@ -1,0 +1,81 @@
+//
+// Created by Basit Mustafa (24601@GitHub) on 2019-09-13.
+// Copyright (c) 2019 The Chromium Authors. All rights reserved.
+//
+
+#import "AssistantPermissionStrategy.h"
+
+
+@implementation AssistantPermissionStrategy
+
+- (PermissionStatus)checkPermissionStatus:(PermissionGroup)permission {
+    if (permission == PermissionGroupAssistant) {
+        if (@available(iOS 10.0, *)) {
+            return [AssistantPermissionStrategy permissionStatus];
+        } else {
+            // Fallback on earlier versions
+        }
+    }
+    return PermissionStatusUnknown;
+}
+
+- (ServiceStatus)checkServiceStatus:(PermissionGroup)permission {
+    return ServiceStatusNotApplicable;
+}
+
+- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {
+    PermissionStatus status = [self checkPermissionStatus:permission];
+
+    if (status != PermissionStatusUnknown) {
+        completionHandler(status);
+        return;
+    }
+
+    if (permission != PermissionGroupAssistant) {
+        completionHandler(PermissionStatusUnknown);
+        return;
+    }
+
+    if (@available(iOS 10.0, *)) {
+        [INPreferences requestSiriAuthorization:^(INSiriAuthorizationStatus status) {
+            if (status == INSiriAuthorizationStatusAuthorized) {
+                completionHandler(PermissionStatusGranted);
+            } else {
+                completionHandler(PermissionStatusDenied);
+            }
+        }];
+    } else {
+        // Fallback on earlier versions
+    }
+
+}
+
++ (PermissionStatus)permissionStatus {
+    if (@available(iOS 10.0, *)) {
+        INSiriAuthorizationStatus status = [INPreferences siriAuthorizationStatus];
+        
+        switch (status) {
+            case INSiriAuthorizationStatusNotDetermined:
+                return PermissionStatusUnknown;
+                break;
+            case INSiriAuthorizationStatusRestricted:
+                return PermissionStatusRestricted;
+                break;
+            case INSiriAuthorizationStatusDenied:
+                return PermissionStatusDenied;
+                break;
+            case INSiriAuthorizationStatusAuthorized:
+                return PermissionStatusGranted;
+                break;
+            case kCLAuthorizationStatusAuthorizedWhenInUse:
+                return PermissionStatusUnknown;
+                break;
+        }
+    } else {
+        // Fallback on earlier versions
+    }
+
+    return PermissionStatusUnknown;
+}
+
+@end

--- a/lib/src/permission_enums.dart
+++ b/lib/src/permission_enums.dart
@@ -83,6 +83,7 @@ class PermissionGroup {
 
   final int value;
 
+
   /// Android: Calendar
   /// iOS: Calendar (Events)
   static const PermissionGroup calendar = PermissionGroup._(0);
@@ -150,6 +151,10 @@ class PermissionGroup {
   /// The unknown permission only used for return type, never requested
   static const PermissionGroup unknown = PermissionGroup._(16);
 
+  /// Android: Nothing
+  /// iOS: SiriKit
+  static const PermissionGroup assistant = PermissionGroup._(17);
+
   static const List<PermissionGroup> values = <PermissionGroup>[
     calendar,
     camera,
@@ -168,6 +173,7 @@ class PermissionGroup {
     storage,
     ignoreBatteryOptimizations,
     unknown,
+    assistant
   ];
 
   static const List<String> _names = <String>[
@@ -188,6 +194,7 @@ class PermissionGroup {
     'storage',
     'ignoreBatteryOptimizations',
     'unknown',
+    'assistant'
   ];
 
   @override


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Adds support for requesting permission to SiriKit/Intents on iOS. In the future we may add the equivalent needs/permissions for Google Assistant on Android, however we are not that far yet but is in the plan. 

### :arrow_heading_down: What is the current behavior?

Does not support requesting SiriKit/IntentsKit permissions or checking said permissions.

### :new: What is the new behavior (if this is a feature change)?

Allows user to support SiriKit/IntentsKit permission on iOS

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Code some Siri Intents and use them. It is important to ensure you use/have the proper permissions/entitlements on the iOS side for SiriKit/Intents (as with any other item you'd use), but that is beyond the scope of this software.

### :memo: Links to relevant issues/docs

None

### :thinking: Checklist before submitting

- [ X] All projects build
- [ X] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [X ] Relevant documentation was updated
- [X ] Rebased onto current develop