### PR TITLE
- Added ANSWER_PHONE_CALLS permission for API 26 and above to support…

### DIFF
--- a/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
+++ b/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
@@ -623,6 +623,9 @@ public class PermissionHandlerPlugin implements MethodCallHandler {
         if (hasPermissionInManifest(Manifest.permission.BIND_CALL_REDIRECTION_SERVICE))
           permissionNames.add(Manifest.permission.BIND_CALL_REDIRECTION_SERVICE);
 
+        if (VERSION.SDK_INT >= VERSION_CODES.O && hasPermissionInManifest(Manifest.permission.ANSWER_PHONE_CALLS))
+            permissionNames.add(Manifest.permission.ANSWER_PHONE_CALLS);
+
         break;
 
       case PERMISSION_GROUP_SENSORS:


### PR DESCRIPTION
… call disconnect feature.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

It includes the support for above mentions permission.

### :arrow_heading_down: What is the current behavior?
Currently, it's not asking for the permission for 26 and above in PHONE group permission. Which is limiting my application to disconnect the call on API level 26 and above.

### :new: What is the new behavior (if this is a feature change)?

After this change application would be allowed to use the latest feature of newly published build.

### :boom: Does this PR introduce a breaking change?
NOPE.

### :bug: Recommendations for testing
YES

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop