### PR TITLE
Added ACCESS_MEDIA_LOCATION permission handling for Android >= 10

### DIFF
--- a/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
+++ b/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
@@ -62,7 +62,8 @@ public class PermissionHandlerPlugin implements MethodCallHandler {
   private static final int PERMISSION_GROUP_STORAGE = 14;
   private static final int PERMISSION_GROUP_IGNORE_BATTERY_OPTIMIZATIONS = 15;
   private static final int PERMISSION_GROUP_NOTIFICATION = 16;
-  private static final int PERMISSION_GROUP_UNKNOWN = 17;
+  private static final int PERMISSION_GROUP_ACCESS_MEDIA_LOCATION = 17;
+  private static final int PERMISSION_GROUP_UNKNOWN = 18;
 
   private PermissionHandlerPlugin(Registrar mRegistrar) {
     this.mRegistrar = mRegistrar;
@@ -87,6 +88,7 @@ public class PermissionHandlerPlugin implements MethodCallHandler {
       PERMISSION_GROUP_STORAGE,
       PERMISSION_GROUP_IGNORE_BATTERY_OPTIMIZATIONS,
       PERMISSION_GROUP_NOTIFICATION,
+      PERMISSION_GROUP_ACCESS_MEDIA_LOCATION,
       PERMISSION_GROUP_UNKNOWN,
   })
   private @interface PermissionGroup {
@@ -195,6 +197,8 @@ public class PermissionHandlerPlugin implements MethodCallHandler {
       case Manifest.permission.READ_EXTERNAL_STORAGE:
       case Manifest.permission.WRITE_EXTERNAL_STORAGE:
         return PERMISSION_GROUP_STORAGE;
+      case Manifest.permission.ACCESS_MEDIA_LOCATION:
+        return PERMISSION_GROUP_ACCESS_MEDIA_LOCATION;
       default:
         return PERMISSION_GROUP_UNKNOWN;
     }
@@ -661,6 +665,11 @@ public class PermissionHandlerPlugin implements MethodCallHandler {
       case PERMISSION_GROUP_IGNORE_BATTERY_OPTIMIZATIONS:
         if (VERSION.SDK_INT >= VERSION_CODES.M && hasPermissionInManifest(Manifest.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS))
           permissionNames.add(Manifest.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS);
+        break;
+
+      case PERMISSION_GROUP_ACCESS_MEDIA_LOCATION:
+        if (VERSION.SDK_INT >= VERSION_CODES.Q && hasPermissionInManifest(Manifest.permission.ACCESS_MEDIA_LOCATION))
+            permissionNames.add(Manifest.permission.ACCESS_MEDIA_LOCATION);
         break;
 
       case PERMISSION_GROUP_NOTIFICATION:

--- a/example/android/app/src/debug/AndroidManifest.xml
+++ b/example/android/app/src/debug/AndroidManifest.xml
@@ -46,4 +46,8 @@
 
     <!-- Permissions options for the `sensors` group -->
     <uses-permission android:name="android.permission.BODY_SENSORS" />
+
+    <!-- Permissions options for the `access_media_location` group -->
+    <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
+
 </manifest>

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -51,6 +51,9 @@
     <!-- Permissions options for the `sensors` group -->
     <uses-permission android:name="android.permission.BODY_SENSORS" />
 
+    <!-- Permissions options for the `access_media_location` group -->
+    <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
+
     <application
         android:name="io.flutter.app.FlutterApplication"
         android:icon="@mipmap/ic_launcher"

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -30,8 +30,8 @@ class MyApp extends StatelessWidget {
                       return permission != PermissionGroup.unknown &&
                           permission != PermissionGroup.sms &&
                           permission != PermissionGroup.storage &&
-                          permission !=
-                              PermissionGroup.ignoreBatteryOptimizations;
+                          permission != PermissionGroup.ignoreBatteryOptimizations &&
+                          permission != PermissionGroup.access_media_location;
                     } else {
                       return permission != PermissionGroup.unknown &&
                           permission != PermissionGroup.mediaLibrary &&

--- a/ios/Classes/PermissionHandlerEnums.h
+++ b/ios/Classes/PermissionHandlerEnums.h
@@ -23,6 +23,7 @@ typedef NS_ENUM(int, PermissionGroup) {
     PermissionGroupStorage,
     PermissionGroupIgnoreBatteryOptimizations,
     PermissionGroupNotification,
+    PermissionGroupAccessMediaLocation,
     PermissionGroupUnknown,
 };
 

--- a/lib/src/permission_enums.dart
+++ b/lib/src/permission_enums.dart
@@ -153,8 +153,11 @@ class PermissionGroup {
   /// iOS: Notification
   static const PermissionGroup notification = PermissionGroup._(16);
 
+  /// Android: Allows an application to access any geographic locations persisted in the user's shared collection.
+  static const PermissionGroup access_media_location = PermissionGroup._(17);
+
   /// The unknown permission only used for return type, never requested
-  static const PermissionGroup unknown = PermissionGroup._(17);
+  static const PermissionGroup unknown = PermissionGroup._(18);
 
   static const List<PermissionGroup> values = <PermissionGroup>[
     calendar,
@@ -174,6 +177,7 @@ class PermissionGroup {
     storage,
     ignoreBatteryOptimizations,
     notification,
+    access_media_location,
     unknown,
   ];
 
@@ -195,6 +199,7 @@ class PermissionGroup {
     'storage',
     'ignoreBatteryOptimizations',
     'notification',
+    'access_media_location',
     'unknown',
   ];
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature

### :arrow_heading_down: What is the current behavior?

New scoped storage in Android 10 restricts access to media location. In order to get permission to read it, app should request `ACCESS_MEDIA_LOCATION`.

### :new: What is the new behavior (if this is a feature change)?

We now have a new permission that framework can handle: `ACCESS_MEDIA_LOCATION` (Android only). This permission introduced a new enum value on `PermissionGroup` named `access_media_location`

### :boom: Does this PR introduce a breaking change?

No, unless anyone was relying on `PermissionGroup.unknown = 17`. Now it is 18 on the enum.

### :bug: Recommendations for testing

In Android, ask for permission `access_media_location`. After granting that permission you should be able to read GPS information from image

### :memo: Links to relevant issues/docs

None

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop