### PR TITLE
Added neverAskAgain permission status for android devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,9 @@ enum PermissionStatus {
 
   /// Permission is in an unknown state
   unknown
+  
+  /// Permission to access the requested feature is denied by the user and never show selected (only on Android).
+  neverAskAgain
 }
 ```
 

--- a/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
+++ b/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
@@ -206,6 +206,12 @@ public class PermissionHandlerPlugin implements MethodCallHandler {
     }
   }
 
+    private final Registrar mRegistrar;
+    private Result mResult;
+    private ArrayList<String> mRequestedPermissions;
+    @SuppressLint("UseSparseArrays")
+    private Map<Integer, Integer> mRequestResults = new HashMap<>();
+
   @Override
   public void onMethodCall(MethodCall call, Result result) {
     switch (call.method) {

--- a/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
+++ b/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
@@ -206,11 +206,11 @@ public class PermissionHandlerPlugin implements MethodCallHandler {
     }
   }
 
-    private final Registrar mRegistrar;
-    private Result mResult;
-    private ArrayList<String> mRequestedPermissions;
-    @SuppressLint("UseSparseArrays")
-    private Map<Integer, Integer> mRequestResults = new HashMap<>();
+  private final Registrar mRegistrar;
+  private Result mResult;
+  private ArrayList<String> mRequestedPermissions;
+  @SuppressLint("UseSparseArrays")
+  private Map<Integer, Integer> mRequestResults = new HashMap<>();
 
   @Override
   public void onMethodCall(MethodCall call, Result result) {

--- a/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
+++ b/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
@@ -748,7 +748,7 @@ public class PermissionHandlerPlugin implements MethodCallHandler {
     }
 
     for (String name : names) {
-      PermissionUtils.setShouldShowStatus(context, name);
+      PermissionUtils.setRequestedPermission(context, name);
     }
   }
 

--- a/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
+++ b/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
@@ -1,0 +1,31 @@
+package com.baseflow.permissionhandler;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Build;
+
+import androidx.annotation.RequiresApi;
+import androidx.core.app.ActivityCompat;
+
+public class PermissionUtils {
+
+  @RequiresApi(api = Build.VERSION_CODES.M)
+   static boolean neverAskAgainSelected(final Activity activity, final String permission) {
+    final boolean prevShouldShowStatus = getRationaleDisplayStatus(activity, permission);
+    final boolean currShouldShowStatus = ActivityCompat.shouldShowRequestPermissionRationale(activity, permission);
+    return prevShouldShowStatus != currShouldShowStatus;
+  }
+
+   static void setShouldShowStatus(final Context context, final String permission) {
+    SharedPreferences genPrefs = context.getSharedPreferences("GENERIC_PREFERENCES", Context.MODE_PRIVATE);
+    SharedPreferences.Editor editor = genPrefs.edit();
+    editor.putBoolean(permission, true);
+    editor.apply();
+  }
+
+  private static boolean getRationaleDisplayStatus(final Context context, final String permission) {
+    SharedPreferences genPrefs = context.getSharedPreferences("GENERIC_PREFERENCES", Context.MODE_PRIVATE);
+    return genPrefs.getBoolean(permission, false);
+  }
+}

--- a/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
+++ b/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
@@ -17,7 +17,7 @@ public class PermissionUtils {
     return prevShouldShowStatus != currShouldShowStatus;
   }
 
-   static void setShouldShowStatus(final Context context, final String permission) {
+  static void setRequestedPermission(final Context context, final String permission) {
     SharedPreferences genPrefs = context.getSharedPreferences("GENERIC_PREFERENCES", Context.MODE_PRIVATE);
     SharedPreferences.Editor editor = genPrefs.edit();
     editor.putBoolean(permission, true);

--- a/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
+++ b/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
@@ -24,7 +24,7 @@ public class PermissionUtils {
     editor.apply();
   }
 
-  private static boolean getRationaleDisplayStatus(final Context context, final String permission) {
+  private static boolean getRequestedPermissionBefore(final Context context, final String permission) {
     SharedPreferences genPrefs = context.getSharedPreferences("GENERIC_PREFERENCES", Context.MODE_PRIVATE);
     return genPrefs.getBoolean(permission, false);
   }

--- a/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
+++ b/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
@@ -12,7 +12,7 @@ public class PermissionUtils {
 
   @RequiresApi(api = Build.VERSION_CODES.M)
    static boolean neverAskAgainSelected(final Activity activity, final String permission) {
-    final boolean prevShouldShowStatus = getRationaleDisplayStatus(activity, permission);
+    final boolean hasRequestedPermissionBefore = getRequestedPermissionBefore(activity, permission);
     final boolean currShouldShowStatus = ActivityCompat.shouldShowRequestPermissionRationale(activity, permission);
     return prevShouldShowStatus != currShouldShowStatus;
   }

--- a/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
+++ b/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
@@ -11,7 +11,7 @@ import androidx.core.app.ActivityCompat;
 public class PermissionUtils {
 
   @RequiresApi(api = Build.VERSION_CODES.M)
-   static boolean neverAskAgainSelected(final Activity activity, final String permission) {
+  static boolean neverAskAgainSelected(final Activity activity, final String permission) {
     final boolean hasRequestedPermissionBefore = getRequestedPermissionBefore(activity, permission);
     final boolean currShouldShowStatus = ActivityCompat.shouldShowRequestPermissionRationale(activity, permission);
     return prevShouldShowStatus != currShouldShowStatus;

--- a/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
+++ b/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
@@ -13,8 +13,8 @@ public class PermissionUtils {
   @RequiresApi(api = Build.VERSION_CODES.M)
   static boolean neverAskAgainSelected(final Activity activity, final String permission) {
     final boolean hasRequestedPermissionBefore = getRequestedPermissionBefore(activity, permission);
-    final boolean currShouldShowStatus = ActivityCompat.shouldShowRequestPermissionRationale(activity, permission);
-    return prevShouldShowStatus != currShouldShowStatus;
+    final boolean shouldShowRequestPermissionRationale = ActivityCompat.shouldShowRequestPermissionRationale(activity, permission);
+    return hasRequestedPermissionBefore != shouldShowRequestPermissionRationale;
   }
 
   static void setRequestedPermission(final Context context, final String permission) {

--- a/lib/src/permission_enums.dart
+++ b/lib/src/permission_enums.dart
@@ -21,12 +21,16 @@ class PermissionStatus {
   /// Permission is in an unknown state
   static const PermissionStatus unknown = PermissionStatus._(4);
 
+  /// Permission to access the requested feature is denied by the user and never show selected (only on Android).
+  static const PermissionStatus neverAskAgain = PermissionStatus._(5);
+
   static const List<PermissionStatus> values = <PermissionStatus>[
     denied,
     disabled,
     granted,
     restricted,
     unknown,
+    neverAskAgain,
   ];
 
   static const List<String> _names = <String>[
@@ -35,6 +39,7 @@ class PermissionStatus {
     'granted',
     'restricted',
     'unknown',
+    'neverAskAgain',
   ];
 
   @override


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Added new permission state on android devices when user denied permission request with selected checkbox "Never ask again"

### :arrow_heading_down: What is the current behavior?
When user "Never ask again" it returns  status of  permission "denied", so we can't understand actual state of permission and after permission request we got nothing 

### :new: What is the new behavior (if this is a feature change)?
When user "Never ask again" it returns new permission status neverAskAgain

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
https://github.com/Baseflow/flutter-permission-handler/issues/96

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
