### PR TITLE
Moved updating showing permission status after detecting it status

### DIFF
--- a/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
+++ b/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
@@ -461,7 +461,6 @@ public class PermissionHandlerPlugin implements MethodCallHandler {
         continue;
 
       final int result = grantResults[i];
-      updatePermissionShouldShowStatus(permission);
 
       if (permission == PERMISSION_GROUP_MICROPHONE) {
         if (!mRequestResults.containsKey(PERMISSION_GROUP_MICROPHONE)) {
@@ -493,6 +492,8 @@ public class PermissionHandlerPlugin implements MethodCallHandler {
       } else if (!mRequestResults.containsKey(permission)) {
         mRequestResults.put(permission, toPermissionStatus(permission, result));
       }
+
+      updatePermissionShouldShowStatus(permission);
     }
 
     processResult();


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
 ```updatePermissionShouldShowStatus``` calls before detect it status so we got ```PermissionStatus.neverAskAgain``` when we have asked  permission fist time

### :new: What is the new behavior (if this is a feature change)?
```PermissionStatus.neverAskAgain``` returns only when user checks neverAskAgain

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
