### PR TITLE
Add Android Q Activity Recognition support

### DIFF
--- a/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
+++ b/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
@@ -695,7 +695,7 @@ public class PermissionHandlerPlugin implements MethodCallHandler {
 
       case PERMISSION_GROUP_ACTIVITY_RECOGNITION:
         if (VERSION.SDK_INT >= VERSION_CODES.Q && hasPermissionInManifest(Manifest.permission.ACTIVITY_RECOGNITION))
-          permissionNames.add(Manifest.permission.ACCESS_MEDIA_LOCATION);
+          permissionNames.add(Manifest.permission.ACTIVITY_RECOGNITION);
         break;
 
       case PERMISSION_GROUP_NOTIFICATION:

--- a/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
+++ b/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
@@ -65,7 +65,8 @@ public class PermissionHandlerPlugin implements MethodCallHandler {
   private static final int PERMISSION_GROUP_IGNORE_BATTERY_OPTIMIZATIONS = 15;
   private static final int PERMISSION_GROUP_NOTIFICATION = 16;
   private static final int PERMISSION_GROUP_ACCESS_MEDIA_LOCATION = 17;
-  private static final int PERMISSION_GROUP_UNKNOWN = 18;
+  private static final int PERMISSION_GROUP_ACTIVITY_RECOGNITION = 18;
+  private static final int PERMISSION_GROUP_UNKNOWN = 19;
 
   private PermissionHandlerPlugin(Registrar mRegistrar) {
     this.mRegistrar = mRegistrar;
@@ -91,6 +92,7 @@ public class PermissionHandlerPlugin implements MethodCallHandler {
       PERMISSION_GROUP_IGNORE_BATTERY_OPTIMIZATIONS,
       PERMISSION_GROUP_NOTIFICATION,
       PERMISSION_GROUP_ACCESS_MEDIA_LOCATION,
+      PERMISSION_GROUP_ACTIVITY_RECOGNITION,
       PERMISSION_GROUP_UNKNOWN,
   })
   private @interface PermissionGroup {
@@ -202,6 +204,8 @@ public class PermissionHandlerPlugin implements MethodCallHandler {
         return PERMISSION_GROUP_STORAGE;
       case Manifest.permission.ACCESS_MEDIA_LOCATION:
         return PERMISSION_GROUP_ACCESS_MEDIA_LOCATION;
+      case Manifest.permission.ACTIVITY_RECOGNITION:
+        return PERMISSION_GROUP_ACTIVITY_RECOGNITION;
       default:
         return PERMISSION_GROUP_UNKNOWN;
     }
@@ -319,7 +323,6 @@ public class PermissionHandlerPlugin implements MethodCallHandler {
         return PERMISSION_STATUS_DISABLED;
       }
     }
-
     return PERMISSION_STATUS_GRANTED;
   }
 
@@ -688,6 +691,11 @@ public class PermissionHandlerPlugin implements MethodCallHandler {
       case PERMISSION_GROUP_ACCESS_MEDIA_LOCATION:
         if (VERSION.SDK_INT >= VERSION_CODES.Q && hasPermissionInManifest(Manifest.permission.ACCESS_MEDIA_LOCATION))
             permissionNames.add(Manifest.permission.ACCESS_MEDIA_LOCATION);
+        break;
+
+      case PERMISSION_GROUP_ACTIVITY_RECOGNITION:
+        if (VERSION.SDK_INT >= VERSION_CODES.Q && hasPermissionInManifest(Manifest.permission.ACTIVITY_RECOGNITION))
+          permissionNames.add(Manifest.permission.ACCESS_MEDIA_LOCATION);
         break;
 
       case PERMISSION_GROUP_NOTIFICATION:

--- a/lib/src/permission_enums.dart
+++ b/lib/src/permission_enums.dart
@@ -161,8 +161,13 @@ class PermissionGroup {
   /// Android: Allows an application to access any geographic locations persisted in the user's shared collection.
   static const PermissionGroup access_media_location = PermissionGroup._(17);
 
+  /// When running on Android Q and above: Activity Recognition
+  /// When running on Android < Q: Nothing
+  /// iOS: Nothing
+  static const PermissionGroup activity_recognition = PermissionGroup._(18);
+
   /// The unknown permission only used for return type, never requested
-  static const PermissionGroup unknown = PermissionGroup._(18);
+  static const PermissionGroup unknown = PermissionGroup._(19);
 
   static const List<PermissionGroup> values = <PermissionGroup>[
     calendar,
@@ -183,6 +188,7 @@ class PermissionGroup {
     ignoreBatteryOptimizations,
     notification,
     access_media_location,
+    activity_recognition,
     unknown,
   ];
 
@@ -205,6 +211,7 @@ class PermissionGroup {
     'ignoreBatteryOptimizations',
     'notification',
     'access_media_location',
+    'activity_recognition',
     'unknown',
   ];
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature - New permission for Android Q Activity Recognition, which is dangerous on Android Q and above

### :arrow_heading_down: What is the current behavior?
Unable to request permissions for Activity Recognition API when targeting Android Q / 29

### :new: What is the new behavior (if this is a feature change)?
Support for ACTIVITY_RECOGNITION permission

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
https://developer.android.com/about/versions/10/privacy/changes#physical-activity-recognition

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/develop/CONTRIBUTING.md))
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
