### PR TITLE
Feature/remove permissionstatus disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,8 @@
 # Flutter Permission handler Plugin
 
-[![pub package](https://img.shields.io/pub/v/permission_handler.svg)](https://pub.dartlang.org/packages/permission_handler)
+[![pub package](https://img.shields.io/pub/v/permission_handler.svg)](https://pub.dartlang.org/packages/permission_handler) [![Build Status](https://app.bitrise.io/app/fa4f5d4bf452bcfb/status.svg?token=HorGpL_AOw2llYz39CjmdQ&branch=master)](https://app.bitrise.io/app/fa4f5d4bf452bcfb) [![style: effective dart](https://img.shields.io/badge/style-effective_dart-40c4ff.svg)](https://github.com/tenhobi/effective_dart)
 
 A permissions plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-
-Branch  | Build Status 
-------- | ------------
-develop | [![Build Status](https://app.bitrise.io/app/fa4f5d4bf452bcfb/status.svg?token=HorGpL_AOw2llYz39CjmdQ&branch=develop)](https://app.bitrise.io/app/fa4f5d4bf452bcfb)
-master  | [![Build Status](https://app.bitrise.io/app/fa4f5d4bf452bcfb/status.svg?token=HorGpL_AOw2llYz39CjmdQ&branch=master)](https://app.bitrise.io/app/fa4f5d4bf452bcfb)
 
 ## Features
 

--- a/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
+++ b/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
@@ -100,15 +100,13 @@ public class PermissionHandlerPlugin implements MethodCallHandler {
 
   //PERMISSION_STATUS
   private static final int PERMISSION_STATUS_DENIED = 0;
-  private static final int PERMISSION_STATUS_DISABLED = 1;
-  private static final int PERMISSION_STATUS_GRANTED = 2;
-  private static final int PERMISSION_STATUS_RESTRICTED = 3;
-  private static final int PERMISSION_STATUS_UNKNOWN = 4;
-  private static final int PERMISSION_STATUS_NEWER_ASK_AGAIN = 5;
+  private static final int PERMISSION_STATUS_GRANTED = 1;
+  private static final int PERMISSION_STATUS_RESTRICTED = 2;
+  private static final int PERMISSION_STATUS_UNKNOWN = 3;
+  private static final int PERMISSION_STATUS_NEWER_ASK_AGAIN = 4;
   @Retention(RetentionPolicy.SOURCE)
   @IntDef({
       PERMISSION_STATUS_DENIED,
-      PERMISSION_STATUS_DISABLED,
       PERMISSION_STATUS_GRANTED,
       PERMISSION_STATUS_RESTRICTED,
       PERMISSION_STATUS_UNKNOWN,
@@ -496,23 +494,6 @@ public class PermissionHandlerPlugin implements MethodCallHandler {
     }
 
     processResult();
-  }
-
-  /**
-   * Crosschecks a permission grant result with the location service availability.
-   *
-   * @param grantResult Grant Result as received from the Android system.
-   */
-  @PermissionStatus
-  private int determineActualLocationStatus(@PermissionGroup int permission, int grantResult) {
-    final Context context =
-        mRegistrar.activity() == null ? mRegistrar.activeContext() : mRegistrar.activity();
-    final boolean isLocationServiceEnabled = context != null && isLocationServiceEnabled(context);
-    @PermissionStatus int permissionStatus = toPermissionStatus(permission, grantResult);
-    if (permissionStatus == PERMISSION_STATUS_GRANTED && !isLocationServiceEnabled) {
-      permissionStatus = PERMISSION_STATUS_DISABLED;
-    }
-    return permissionStatus;
   }
 
   private void handleIgnoreBatteryOptimizationsRequest(boolean granted) {

--- a/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
+++ b/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
@@ -317,12 +317,7 @@ public class PermissionHandlerPlugin implements MethodCallHandler {
         }
       }
     }
-
-    if (permission == PERMISSION_GROUP_LOCATION || permission == PERMISSION_GROUP_LOCATION_ALWAYS || permission == PERMISSION_GROUP_LOCATION_WHEN_IN_USE) {
-      if (!isLocationServiceEnabled(context)) {
-        return PERMISSION_STATUS_DISABLED;
-      }
-    }
+    
     return PERMISSION_STATUS_GRANTED;
   }
 
@@ -474,13 +469,13 @@ public class PermissionHandlerPlugin implements MethodCallHandler {
           mRequestResults.put(PERMISSION_GROUP_SPEECH, toPermissionStatus(permission, result));
         }
       } else if (permission == PERMISSION_GROUP_LOCATION_ALWAYS) {
-        @PermissionStatus int permissionStatus = determineActualLocationStatus(permission, result);
+        @PermissionStatus int permissionStatus = toPermissionStatus(permission, result);
 
         if (!mRequestResults.containsKey(PERMISSION_GROUP_LOCATION_ALWAYS)) {
           mRequestResults.put(PERMISSION_GROUP_LOCATION_ALWAYS, permissionStatus);
         }
       } else if (permission == PERMISSION_GROUP_LOCATION) {
-        @PermissionStatus int permissionStatus = determineActualLocationStatus(permission, result);
+        @PermissionStatus int permissionStatus = toPermissionStatus(permission, result);
 
         if (VERSION.SDK_INT < VERSION_CODES.Q) {
           if (!mRequestResults.containsKey(PERMISSION_GROUP_LOCATION_ALWAYS)) {

--- a/example/ios/Flutter/Flutter.podspec
+++ b/example/ios/Flutter/Flutter.podspec
@@ -1,0 +1,18 @@
+#
+# NOTE: This podspec is NOT to be published. It is only used as a local source!
+#
+
+Pod::Spec.new do |s|
+  s.name             = 'Flutter'
+  s.version          = '1.0.0'
+  s.summary          = 'High-performance, high-fidelity mobile apps.'
+  s.description      = <<-DESC
+Flutter provides an easy and productive way to build and deploy high-performance mobile apps for Android and iOS.
+                       DESC
+  s.homepage         = 'https://flutter.io'
+  s.license          = { :type => 'MIT' }
+  s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
+  s.source           = { :git => 'https://github.com/flutter/engine', :tag => s.version.to_s }
+  s.ios.deployment_target = '8.0'
+  s.vendored_frameworks = 'Flutter.framework'
+end

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -241,7 +241,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
-				"${PODS_ROOT}/../.symlinks/flutter/ios/Flutter.framework",
+				"${PODS_ROOT}/../.symlinks/flutter/ios-release/Flutter.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -34,7 +34,7 @@ class MyApp extends StatelessWidget {
                           permission != PermissionGroup.storage &&
                           permission !=
                               PermissionGroup.ignoreBatteryOptimizations &&
-                          permission != PermissionGroup.access_media_location;
+                          permission != PermissionGroup.accessMediaLocation;
                     } else {
                       return permission != PermissionGroup.unknown &&
                           permission != PermissionGroup.mediaLibrary &&

--- a/ios/Classes/PermissionHandlerEnums.h
+++ b/ios/Classes/PermissionHandlerEnums.h
@@ -105,7 +105,6 @@ typedef NS_ENUM(int, PermissionGroup) {
 
 typedef NS_ENUM(int, PermissionStatus) {
     PermissionStatusDenied = 0,
-    PermissionStatusDisabled,
     PermissionStatusGranted,
     PermissionStatusRestricted,
     PermissionStatusUnknown,

--- a/ios/Classes/strategies/LocationPermissionStrategy.m
+++ b/ios/Classes/strategies/LocationPermissionStrategy.m
@@ -96,11 +96,6 @@
     PermissionStatus status = [LocationPermissionStrategy
                                determinePermissionStatus:permission authorizationStatus:authorizationStatus];
     
-    if ((status == PermissionStatusGranted || status == PermissionStatusDenied)
-        && ![CLLocationManager locationServicesEnabled]) {
-        return PermissionStatusDisabled;
-    }
-    
     return status;
 }
 

--- a/ios/Classes/strategies/SensorPermissionStrategy.m
+++ b/ios/Classes/strategies/SensorPermissionStrategy.m
@@ -69,12 +69,7 @@
                 permissionStatus = PermissionStatusGranted;
         }
         
-        
-        if ((permissionStatus == PermissionStatusGranted || permissionStatus == PermissionStatusDenied) && ![CMMotionActivityManager isActivityAvailable]) {
-            return PermissionStatusDisabled;
-        } else {
-            return permissionStatus;
-        }
+        return permissionStatus;
     }
     
     return PermissionStatusUnknown;

--- a/lib/src/permission_enums.dart
+++ b/lib/src/permission_enums.dart
@@ -8,28 +8,24 @@ class PermissionStatus {
   /// Permission to access the requested feature is denied by the user.
   static const PermissionStatus denied = PermissionStatus._(0);
 
-  /// The feature is disabled (or not available) on the device.
-  static const PermissionStatus disabled = PermissionStatus._(1);
-
   /// Permission to access the requested feature is granted by the user.
-  static const PermissionStatus granted = PermissionStatus._(2);
+  static const PermissionStatus granted = PermissionStatus._(1);
 
   /// Permission to access the requested feature is denied by the OS (only on 
   /// iOS). The user cannot change this app's status, possibly due to active 
   /// restrictions such as parental controls being in place.
-  static const PermissionStatus restricted = PermissionStatus._(3);
+  static const PermissionStatus restricted = PermissionStatus._(2);
 
   /// Permission is in an unknown state
-  static const PermissionStatus unknown = PermissionStatus._(4);
+  static const PermissionStatus unknown = PermissionStatus._(3);
 
   /// Permission to access the requested feature is denied by the user and 
   /// never show selected (only on Android).
-  static const PermissionStatus neverAskAgain = PermissionStatus._(5);
+  static const PermissionStatus neverAskAgain = PermissionStatus._(4);
 
   /// Returns a list of all possible [PermissionStatus] values.
   static const List<PermissionStatus> values = <PermissionStatus>[
     denied,
-    disabled,
     granted,
     restricted,
     unknown,
@@ -38,7 +34,6 @@ class PermissionStatus {
 
   static const List<String> _names = <String>[
     'denied',
-    'disabled',
     'granted',
     'restricted',
     'unknown',
@@ -169,12 +164,12 @@ class PermissionGroup {
 
   /// Android: Allows an application to access any geographic locations 
   /// persisted in the user's shared collection.
-  static const PermissionGroup access_media_location = PermissionGroup._(17);
+  static const PermissionGroup accessMediaLocation = PermissionGroup._(17);
 
   /// When running on Android Q and above: Activity Recognition
   /// When running on Android < Q: Nothing
   /// iOS: Nothing
-  static const PermissionGroup activity_recognition = PermissionGroup._(18);
+  static const PermissionGroup activityRecognition = PermissionGroup._(18);
 
   /// The unknown permission only used for return type, never requested
   static const PermissionGroup unknown = PermissionGroup._(19);
@@ -198,8 +193,8 @@ class PermissionGroup {
     storage,
     ignoreBatteryOptimizations,
     notification,
-    access_media_location,
-    activity_recognition,
+    accessMediaLocation,
+    activityRecognition,
     unknown,
   ];
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature

### :arrow_heading_down: What is the current behavior?

Unable to request location permissions when location services are disabled.

### :new: What is the new behavior (if this is a feature change)?

Allow users to request permissions while the location services are disabled.

### :boom: Does this PR introduce a breaking change?

Yes. The `PermissionStatus.disabled` has been removed (is of no use). Also renamed the `access_media_location` (to `accessMediaLocation`) and `activity_recognition` (to `activityRecognition`) permission groups to comply to the Effictive Dart naming conventions.

### :bug: Recommendations for testing

Run the example app with location services disabled.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
