### PR TITLE
Suppress warnings in favor of backwards compatibility

### DIFF
--- a/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
+++ b/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
@@ -770,20 +770,46 @@ public class PermissionHandlerPlugin implements MethodCallHandler {
 
       return locationManager.isLocationEnabled();
     } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+      return isLocationServiceEnablePrePie(context);
+    } else {
+      return isLocationServiceEnablePreKitKat(context);
+    }
+  }
+
+  // Suppress deprecation warnings since it's purpose is to support to be backwards compatible with
+  // pre Pie versions of Android.
+  @SuppressWarnings("deprecation")
+  private static boolean isLocationServiceEnablePrePie(Context context)
+  {
+      if (VERSION.SDK_INT < VERSION_CODES.P)
+          return false;
+
       final int locationMode;
 
       try {
-        locationMode = Settings.Secure.getInt(context.getContentResolver(), Settings.Secure.LOCATION_MODE);
+          locationMode = Settings.Secure.getInt(
+                  context.getContentResolver(),
+                  Settings.Secure.LOCATION_MODE);
       } catch (Settings.SettingNotFoundException e) {
-        e.printStackTrace();
-        return false;
+          e.printStackTrace();
+          return false;
       }
 
       return locationMode != Settings.Secure.LOCATION_MODE_OFF;
-    } else {
-      final String locationProviders = Settings.Secure.getString(context.getContentResolver(), Settings.Secure.LOCATION_PROVIDERS_ALLOWED);
+  }
+
+  // Suppress deprecation warnings since it's purpose is to support to be backwards compatible with
+  // pre KitKat versions of Android.
+  @SuppressWarnings("deprecation")
+  private static boolean isLocationServiceEnablePreKitKat(Context context)
+  {
+      if (VERSION.SDK_INT >= VERSION_CODES.KITKAT)
+          return false;
+
+      final String locationProviders = Settings.Secure.getString(
+              context.getContentResolver(),
+              Settings.Secure.LOCATION_PROVIDERS_ALLOWED);
       return !TextUtils.isEmpty(locationProviders);
-    }
   }
 
   private int checkNotificationPermissionStatus(Context context) {

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -10,6 +10,12 @@ buildscript {
 }
 
 allprojects {
+    gradle.projectsEvaluated {
+        tasks.withType(JavaCompile) {
+            options.compilerArgs << "-Xlint:deprecation"
+        }
+    }
+
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug

### :arrow_heading_down: What is the current behavior?

Java compiler shows warnings regarding deprecated methods which are required to support pre Android KitKat and pre Android Pie versions.

### :new: What is the new behavior (if this is a feature change)?

Code is isolated and warnings are suppressed.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Compile the Example application using:

```
flutter build apk
```

### :memo: Links to relevant issues/docs

- Solves #206 
- Solves #225 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
