### PR TITLE
Fallback on application context if activity is null

### DIFF
--- a/permission_handler/android/src/main/java/com/baseflow/permissionhandler/MethodCallHandlerImpl.java
+++ b/permission_handler/android/src/main/java/com/baseflow/permissionhandler/MethodCallHandlerImpl.java
@@ -56,6 +56,7 @@ final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
                 @PermissionConstants.PermissionStatus final int permissionStatus =
                         permissionManager.checkPermissionStatus(
                                 permission,
+                                applicationContext,
                                 activity);
 
                 result.success(permissionStatus);
@@ -66,7 +67,7 @@ final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
                 @PermissionConstants.ServiceStatus final int serviceStatus =
                         serviceManager.checkServiceStatus(
                                 permission,
-                                activity);
+                                applicationContext);
 
                 result.success(serviceStatus);
                 break;
@@ -79,9 +80,10 @@ final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
                         activityRegistry,
                         permissionRegistry,
                         result::success,
-                        (String errorCode, String errorDescription) -> {
-                            result.error(errorCode, errorDescription, null);
-                        });
+                        (String errorCode, String errorDescription) -> result.error(
+                                errorCode,
+                                errorDescription,
+                                null));
 
                 break;
             case "shouldShowRequestPermissionRationale": {

--- a/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
+++ b/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
@@ -11,6 +11,7 @@ import android.util.Log;
 
 import androidx.annotation.RequiresApi;
 import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/permission_handler/android/src/main/java/com/baseflow/permissionhandler/ServiceManager.java
+++ b/permission_handler/android/src/main/java/com/baseflow/permissionhandler/ServiceManager.java
@@ -1,6 +1,5 @@
 package com.baseflow.permissionhandler;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -21,8 +20,8 @@ final class ServiceManager {
     @PermissionConstants.ServiceStatus
     int checkServiceStatus(
             int permission,
-            Activity activity) {
-        if (activity == null) {
+            Context context) {
+        if (context == null) {
             Log.d(PermissionConstants.LOG_TAG, "Unable to detect current Activity or App Context.");
             return PermissionConstants.SERVICE_STATUS_UNKNOWN;
         }
@@ -30,18 +29,18 @@ final class ServiceManager {
         if (permission == PermissionConstants.PERMISSION_GROUP_LOCATION ||
             permission == PermissionConstants.PERMISSION_GROUP_LOCATION_ALWAYS ||
             permission == PermissionConstants.PERMISSION_GROUP_LOCATION_WHEN_IN_USE) {
-                return isLocationServiceEnabled(activity)
+                return isLocationServiceEnabled(context)
                         ? PermissionConstants.SERVICE_STATUS_ENABLED
                         : PermissionConstants.SERVICE_STATUS_DISABLED;
         }
 
         if (permission == PermissionConstants.PERMISSION_GROUP_PHONE) {
-            PackageManager pm = activity.getPackageManager();
+            PackageManager pm = context.getPackageManager();
             if (!pm.hasSystemFeature(PackageManager.FEATURE_TELEPHONY)) {
                 return PermissionConstants.SERVICE_STATUS_NOT_APPLICABLE;
             }
 
-            TelephonyManager telephonyManager = (TelephonyManager) activity
+            TelephonyManager telephonyManager = (TelephonyManager) context
                     .getSystemService(Context.TELEPHONY_SERVICE);
 
             if (telephonyManager == null || telephonyManager.getPhoneType() == TelephonyManager.PHONE_TYPE_NONE) {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix (Android only)

### :arrow_heading_down: What is the current behavior?

Currently the `checkPermissionStatus` requires an activity as context which results in an error when an App is running isolated (or as a background service). 

### :new: What is the new behavior (if this is a feature change)?

The new behavior is that the plugin will use the ApplicationContext to check the permission status. It will only use the `Activity` to try to determine if permissions are denied and should not be asked again (using `shouldShowRequestPermissionRationale`). In case the `Activity` is not available this check will be skipped. This means that in cases where the App is running isolated the permissions can either be `granted` or `denied` and you will not be informed about the never ask again state.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

-

### :memo: Links to relevant issues/docs

Solves #233 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
