### PR TITLE
Issue/277

### DIFF
--- a/permission_handler/ios/Classes/strategies/NotificationPermissionStrategy.m
+++ b/permission_handler/ios/Classes/strategies/NotificationPermissionStrategy.m
@@ -68,8 +68,7 @@
     UIUserNotificationSettings * setting = [[UIApplication sharedApplication] currentUserNotificationSettings];
     if (setting.types == UIUserNotificationTypeNone) permissionStatus = PermissionStatusDenied;
   } else {
-    UIRemoteNotificationType type = [[UIApplication sharedApplication] enabledRemoteNotificationTypes];
-    if (type == UIUserNotificationTypeNone) permissionStatus = PermissionStatusDenied;
+      permissionStatus = PermissionStatusDenied;
   }
   return permissionStatus;
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

The iOS implementation makes use of the deprecated `enableRemoteNotificationTypes` API. This API has been deprecated since iOS 8.0. Since Flutter doesn't support iOS versions lower then 8 this results in compile errors for developers in certain configurations.

### :new: What is the new behavior (if this is a feature change)?

Remove the usage of the `enableRemoteNotificationTypes` API and instead alway return `PermissionStatusDenied` when using this plugin on iOS versions lower then 8 (which should never happen since Flutter doesn't run on iOS lower then 8).

### :boom: Does this PR introduce a breaking change?

Yes, when running on iOS lower then 8 requesting Notification permissions are no longer supported. This should not affect any users since Flutter doesn't run on iOS versions below 8.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

- Fixes #277

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
