### PR TITLE
iOS NotificationPermissionStrategy: Fixes wrong completionHandler call

### DIFF
--- a/permission_handler/ios/Classes/strategies/NotificationPermissionStrategy.m
+++ b/permission_handler/ios/Classes/strategies/NotificationPermissionStrategy.m
@@ -37,7 +37,11 @@
           completionHandler(PermissionStatusDenied);
           return;
         }
+
+        [[UIApplication sharedApplication] registerForRemoteNotifications];
+        completionHandler(PermissionStatusGranted);
       }];
+
     } else {
       UIUserNotificationType notificationTypes = 0;
       notificationTypes |= UIUserNotificationTypeSound;
@@ -45,9 +49,10 @@
       notificationTypes |= UIUserNotificationTypeBadge;
       UIUserNotificationSettings *settings = [UIUserNotificationSettings settingsForTypes:notificationTypes categories:nil];
       [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
+
+      [[UIApplication sharedApplication] registerForRemoteNotifications];
+      completionHandler(PermissionStatusGranted);
     }
-    [[UIApplication sharedApplication] registerForRemoteNotifications];
-    completionHandler(PermissionStatusGranted);
   });
 }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
In case of iOS 10+ the call to grant permission was made outside of the `requestAuthorizationWithOptions(..)` block and returned immediately always with `PermissionStatusGranted`, which leads to a totally useless permission request.

### :new: What is the new behavior (if this is a feature change)?
This fix moves the call to the correct place - inside of `requestAuthorizationWithOptions(..)`'s block.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
