### PR TITLE
Fixes the fix of wrong completionHandler call

### DIFF
--- a/permission_handler/ios/Classes/strategies/NotificationPermissionStrategy.m
+++ b/permission_handler/ios/Classes/strategies/NotificationPermissionStrategy.m
@@ -38,8 +38,10 @@
           return;
         }
 
-        [[UIApplication sharedApplication] registerForRemoteNotifications];
-        completionHandler(PermissionStatusGranted);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[UIApplication sharedApplication] registerForRemoteNotifications];
+            completionHandler(PermissionStatusGranted);
+        });
       }];
 
     } else {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Unfortunately, my last fix introduced a new bug! The call for `[[UIApplication sharedApplication] registerForRemoteNotifications]` **MUST** be handled on main thread! It wasn't.

### :new: What is the new behavior (if this is a feature change)?
It's called on main thread now.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
n/a

### :memo: Links to relevant issues/docs
n/a

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
