### PR TITLE
kCLAuthorizationStatusAuthorizedWhenInUse was returning PermissionStatusDenied

### DIFF
--- a/permission_handler/ios/Classes/strategies/LocationPermissionStrategy.m
+++ b/permission_handler/ios/Classes/strategies/LocationPermissionStrategy.m
@@ -102,20 +102,6 @@
 
 + (PermissionStatus)determinePermissionStatus:(PermissionGroup)permission authorizationStatus:(CLAuthorizationStatus)authorizationStatus {
     if (@available(iOS 8.0, *)) {
-        if (permission == PermissionGroupLocationAlways) {
-            switch (authorizationStatus) {
-                case kCLAuthorizationStatusNotDetermined:
-                    return PermissionStatusNotDetermined;
-                case kCLAuthorizationStatusRestricted:
-                    return PermissionStatusRestricted;
-                case kCLAuthorizationStatusDenied:
-                case kCLAuthorizationStatusAuthorizedWhenInUse:
-                    return PermissionStatusDenied;
-                case kCLAuthorizationStatusAuthorizedAlways:
-                    return PermissionStatusGranted;
-            }
-        }
-        
         switch (authorizationStatus) {
             case kCLAuthorizationStatusNotDetermined:
                 return PermissionStatusNotDetermined;
@@ -123,8 +109,8 @@
                 return PermissionStatusRestricted;
             case kCLAuthorizationStatusDenied:
                 return PermissionStatusDenied;
-            case kCLAuthorizationStatusAuthorizedAlways:
             case kCLAuthorizationStatusAuthorizedWhenInUse:
+            case kCLAuthorizationStatusAuthorizedAlways:
                 return PermissionStatusGranted;
         }
     }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix (back porting fix done in https://github.com/Baseflow/flutter-permission-plugins/pull/25 to permission-handler)

### :arrow_heading_down: What is the current behavior?
kCLAuthorizationStatusAuthorizedWhenInUse was returning PermissionStatusDenied

### :new: What is the new behavior (if this is a feature change)?
kCLAuthorizationStatusAuthorizedWhenInUse is now returning PermissionStatusGranted

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
https://github.com/Baseflow/flutter-permission-plugins/pull/25

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
