### PR TITLE
Issue/323

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.0.0+hotfix.9
+
+* Solved an issue where kCLAuthorizationStatusAuthorizedWhenInUse was returning PermissionStatusDenied (see [#317](https://github.com/Baseflow/flutter-permission-handler/pull/317))
+
 ## 5.0.0+hotfix.8
 
 * Solved an issue on iOS where requesting notifcation permissions returned prematurely (see pull-request [#297](https://github.com/Baseflow/flutter-permission-handler/pull/297))

--- a/permission_handler/example/lib/main.dart
+++ b/permission_handler/example/lib/main.dart
@@ -71,7 +71,7 @@ class _PermissionState extends State<PermissionWidget> {
   void initState() {
     super.initState();
 
-    //_listenForPermissionStatus();
+    _listenForPermissionStatus();
   }
 
   void _listenForPermissionStatus() async {

--- a/permission_handler/ios/Classes/strategies/LocationPermissionStrategy.m
+++ b/permission_handler/ios/Classes/strategies/LocationPermissionStrategy.m
@@ -102,6 +102,20 @@
 
 + (PermissionStatus)determinePermissionStatus:(PermissionGroup)permission authorizationStatus:(CLAuthorizationStatus)authorizationStatus {
     if (@available(iOS 8.0, *)) {
+        if (permission == PermissionGroupLocationAlways) {
+            switch (authorizationStatus) {
+                case kCLAuthorizationStatusNotDetermined:
+                    return PermissionStatusNotDetermined;
+                case kCLAuthorizationStatusRestricted:
+                    return PermissionStatusRestricted;
+                case kCLAuthorizationStatusAuthorizedWhenInUse:
+                case kCLAuthorizationStatusDenied:
+                    return PermissionStatusDenied;
+                case kCLAuthorizationStatusAuthorizedAlways:
+                    return PermissionStatusGranted;
+            }
+        }
+        
         switch (authorizationStatus) {
             case kCLAuthorizationStatusNotDetermined:
                 return PermissionStatusNotDetermined;

--- a/permission_handler/ios/permission_handler.podspec
+++ b/permission_handler/ios/permission_handler.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'permission_handler'
-  s.version          = '5.0.0+hotfix.8'
+  s.version          = '5.0.0+hotfix.9'
   s.summary          = 'Permission plugin for Flutter.'
   s.description      = <<-DESC
 Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-version: 5.0.0+hotfix.8
+version: 5.0.0+hotfix.9
 homepage: https://github.com/baseflowit/flutter-permission-handler
 
 flutter:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

Currently the plugin will return `granted` for the `locationAlways` permission even when the user only allowed `locationWhenInUse`permissions. This behavior was accidentally introduced with PR #317.

### :new: What is the new behavior (if this is a feature change)?

Permissions for `locationAlways` will return `denied` when the user only allowed `locationWhenInUse` permissions.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Run the example app

### :memo: Links to relevant issues/docs

Resolves #323 
Reverts #317 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
