### PR TITLE
adding READ_PHONE_NUMBERS permission to PHONE group

### DIFF
--- a/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
+++ b/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
@@ -38,6 +38,7 @@ public class PermissionUtils {
             case Manifest.permission.RECORD_AUDIO:
                 return PermissionConstants.PERMISSION_GROUP_MICROPHONE;
             case Manifest.permission.READ_PHONE_STATE:
+            case Manifest.permission.READ_PHONE_NUMBERS:
             case Manifest.permission.CALL_PHONE:
             case Manifest.permission.READ_CALL_LOG:
             case Manifest.permission.WRITE_CALL_LOG:
@@ -117,6 +118,10 @@ public class PermissionUtils {
             case PermissionConstants.PERMISSION_GROUP_PHONE:
                 if (hasPermissionInManifest(context, permissionNames, Manifest.permission.READ_PHONE_STATE))
                     permissionNames.add(Manifest.permission.READ_PHONE_STATE);
+
+                if (android.os.Build.VERSION.SDK_INT > Build.VERSION_CODES.Q && hasPermissionInManifest(context, permissionNames, Manifest.permission.READ_PHONE_NUMBERS)) {
+                    permissionNames.add(Manifest.permission.READ_PHONE_NUMBERS);
+                }
 
                 if (hasPermissionInManifest(context, permissionNames, Manifest.permission.CALL_PHONE))
                     permissionNames.add(Manifest.permission.CALL_PHONE);


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
It fixes a bug on Android Q+ when READ_PHONE_NUMBERS permission is needed but is not granted immediately with Permission.phone.request()

More info: https://developer.android.com/about/versions/11/privacy/permissions#phone-numbers

### :arrow_heading_down: What is the current behavior?
READ_PHONE_NUMBERS permission is not granted after Permission.phone.request()


### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
