### PR TITLE
Null safety fixes #419

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 6.0.0-nullsafety.0
+* Make package null-safe in pre-release mode.
+
 # 5.0.1+1
 
 * Fixes Typo

--- a/permission_handler/example/lib/main.dart
+++ b/permission_handler/example/lib/main.dart
@@ -74,18 +74,18 @@ class BaseflowPluginExample extends StatelessWidget {
         1,
       );
     }
-    return MaterialColor(color.value, swatch);
+    return MaterialColor(color.value, swatch as Map<int, Color>);
   }
 }
 
 /// A Flutter example demonstrating how the [pluginName] plugin could be used
 class AppHome extends StatefulWidget {
   /// Constructs the [AppHome] class
-  AppHome({Key key, this.title}) : super(key: key);
+  AppHome({Key? key, this.title}) : super(key: key);
 
   /// The [title] of the application, which is shown in the application's
   /// title bar.
-  final String title;
+  final String? title;
 
   @override
   _AppHomeState createState() => _AppHomeState();

--- a/permission_handler/example/lib/plugin_example/permission_widget.dart
+++ b/permission_handler/example/lib/plugin_example/permission_widget.dart
@@ -17,7 +17,7 @@ class _PermissionState extends State<PermissionWidget> {
   _PermissionState(this._permission);
 
   final Permission _permission;
-  PermissionStatus _permissionStatus = PermissionStatus.undetermined;
+  PermissionStatus? _permissionStatus = PermissionStatus.undetermined;
 
   @override
   void initState() {

--- a/permission_handler/example/pubspec.yaml
+++ b/permission_handler/example/pubspec.yaml
@@ -2,7 +2,7 @@ name: permission_handler_example
 description: Demonstrates how to use the permission_handler plugin.
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: '>=2.12.0-0 <3.0.0'
 
 dependencies:
   flutter:
@@ -15,7 +15,7 @@ dev_dependencies:
   permission_handler:
     path: ../
 
-  url_launcher: ^5.4.11
+  url_launcher: ^6.0.0-nullsafety.1
 
 flutter:
   uses-material-design: true

--- a/permission_handler/lib/permission_handler.dart
+++ b/permission_handler/lib/permission_handler.dart
@@ -18,7 +18,7 @@ PermissionHandlerPlatform get _handler => PermissionHandlerPlatform.instance;
 /// Opens the app settings page.
 ///
 /// Returns [true] if the app settings page could be opened, otherwise [false].
-Future<bool> openAppSettings() => _handler.openAppSettings();
+Future<bool?> openAppSettings() => _handler.openAppSettings();
 
 /// Actions that can be executed on a permission.
 extension PermissionActions on Permission {
@@ -33,7 +33,7 @@ extension PermissionActions on Permission {
   ///
   /// This is only implemented on Android, calling this on iOS always returns
   /// [false].
-  Future<bool> get shouldShowRequestRationale async {
+  Future<bool?> get shouldShowRequestRationale async {
     if (!Platform.isAndroid) {
       return false;
     }
@@ -45,7 +45,7 @@ extension PermissionActions on Permission {
   /// been grant access before.
   ///
   /// Returns the new [PermissionStatus].
-  Future<PermissionStatus> request() async {
+  Future<PermissionStatus?> request() async {
     return (await [this].request())[this];
   }
 }

--- a/permission_handler/lib/permission_handler.dart
+++ b/permission_handler/lib/permission_handler.dart
@@ -23,8 +23,8 @@ Future<bool?> openAppSettings() => _handler.openAppSettings();
 /// Actions that can be executed on a permission.
 extension PermissionActions on Permission {
   /// The current status of this permission.
-  /// 
-  /// The Android-only [PermissionStatus.permanentlyDenied] status will only be 
+  ///
+  /// The Android-only [PermissionStatus.permanentlyDenied] status will only be
   /// calculated if the active context is an Activity. If it isn't,
   /// [PermissionStatus.denied] will be returned.
   Future<PermissionStatus> get status => _handler.checkPermissionStatus(this);

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-version: 5.0.1+1
+version: 6.0.0-nullsafety.0
 homepage: https://github.com/baseflowit/flutter-permission-handler
 
 flutter:
@@ -16,12 +16,12 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.1.6
-  permission_handler_platform_interface: ^2.0.1
-
+  permission_handler_platform_interface: ^3.0.0-nullsafety.0
+  
 dev_dependencies:
   effective_dart: ^1.2.1
   plugin_platform_interface: ^1.0.1
-
+  
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: '>=2.12.0-0 <3.0.0'
   flutter: ">=1.12.8 <2.0.0"

--- a/permission_handler_platform_interface/CHANGELOG.md
+++ b/permission_handler_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.0-nullsafety.0
+
+* Make package nullsafe in pre-release mode.
+
 ## 2.0.1
 
 * Update `platform_interface 1.0.2`

--- a/permission_handler_platform_interface/lib/src/method_channel/method_channel_permission_handler.dart
+++ b/permission_handler_platform_interface/lib/src/method_channel/method_channel_permission_handler.dart
@@ -50,7 +50,7 @@ class MethodChannelPermissionHandler extends PermissionHandlerPlatform {
   ///
   /// Returns [true] if the app settings page could be opened, otherwise
   /// [false].
-  Future<bool> openAppSettings() async {
+  Future<bool?> openAppSettings() async {
     final wasOpened = await _methodChannel.invokeMethod('openAppSettings');
     return wasOpened;
   }
@@ -72,7 +72,7 @@ class MethodChannelPermissionHandler extends PermissionHandlerPlatform {
   ///
   /// This method is only implemented on Android, calling this on iOS always
   /// returns [false].
-  Future<bool> shouldShowRequestPermissionRationale(
+  Future<bool?> shouldShowRequestPermissionRationale(
       Permission permission) async {
     final shouldShowRationale = await _methodChannel.invokeMethod(
         'shouldShowRequestPermissionRationale', permission.value);

--- a/permission_handler_platform_interface/lib/src/permission_handler_platform_interface.dart
+++ b/permission_handler_platform_interface/lib/src/permission_handler_platform_interface.dart
@@ -64,7 +64,7 @@ abstract class PermissionHandlerPlatform extends PlatformInterface {
   ///
   /// Returns [true] if the app settings page could be opened, otherwise
   /// [false].
-  Future<bool> openAppSettings() {
+  Future<bool?> openAppSettings() {
     throw UnimplementedError('openAppSettings() has not been implemented.');
   }
 
@@ -81,7 +81,7 @@ abstract class PermissionHandlerPlatform extends PlatformInterface {
   ///
   /// This method is only implemented on Android, calling this on iOS always
   /// returns [false].
-  Future<bool> shouldShowRequestPermissionRationale(Permission permission) {
+  Future<bool?> shouldShowRequestPermissionRationale(Permission permission) {
     throw UnimplementedError(
         'shouldShowRequestPermissionRationale() has not been implemented.');
   }

--- a/permission_handler_platform_interface/pubspec.yaml
+++ b/permission_handler_platform_interface/pubspec.yaml
@@ -3,13 +3,13 @@ description: A common platform interface for the permission_handler plugin.
 homepage: https://github.com/baseflow/flutter-permission-handler/tree/master/permission_handler_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.1
+version: 3.0.0-nullsafety.0
 
 dependencies:
   flutter:
     sdk: flutter
   meta: ^1.0.5
-  plugin_platform_interface: ^1.0.2
+  plugin_platform_interface: ^1.1.0-nullsafety.1
 
 dev_dependencies:
   flutter_test:
@@ -18,5 +18,5 @@ dev_dependencies:
   effective_dart: ^1.2.1
 
 environment:
-  sdk: ">=2.6.0 <3.0.0"
-  flutter: ">=1.9.1+hotfix.4 <2.0.0"
+  sdk: '>=2.12.0-0 <3.0.0'
+  flutter: '>=1.9.1+hotfix.4 <2.0.0'


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Support null safety issue #419

Guide: https://dart.dev/null-safety/migration-guide
To support nullsafety the package needs to be published in pre-release mode.

### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?
Yes. Downward dependencies will continue to operate in a [unsound nullsafe way](https://dart.dev/null-safety/unsound-null-safety) until they themselves migrate.

### :bug: Recommendations for testing
The platform interface needs to published to pub.dev to be able to test this locally other just point the dep to the local path for testing. I tested using the same.

### :memo: Links to relevant issues/docs
issue #419

### :thinking: Checklist before submitting

- [x] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/develop/CONTRIBUTING.md))
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
