### PR TITLE
iOS: Replace the deprecated getValue call with a simple typecast

### DIFF
--- a/permission_handler/ios/Classes/PermissionManager.m
+++ b/permission_handler/ios/Classes/PermissionManager.m
@@ -32,13 +32,19 @@
 }
 
 - (void)requestPermissions:(NSArray *)permissions completion:(PermissionRequestCompletion)completion {
-    NSMutableSet *requestQueue = [[NSMutableSet alloc] initWithArray:permissions];
     NSMutableDictionary *permissionStatusResult = [[NSMutableDictionary alloc] init];
+
+    if (permissions.count == 0) {
+        completion(permissionStatusResult);
+        return;
+    }
     
+    NSMutableSet *requestQueue = [[NSMutableSet alloc] initWithArray:permissions];
+        
     for (int i = 0; i < permissions.count; ++i) {
-        PermissionGroup value;
-        [permissions[i] getValue:&value];
-        PermissionGroup permission = value;
+        NSNumber *rawNumberValue = permissions[i];
+        int rawValue = rawNumberValue.intValue;
+        PermissionGroup permission = (PermissionGroup) rawValue;
         
         id <PermissionStrategy> permissionStrategy = [PermissionManager createPermissionStrategy:permission];
         [_strategyInstances addObject:permissionStrategy];


### PR DESCRIPTION


### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Should fix issue #202 . 

### :arrow_heading_down: What is the current behavior?

Deprecated ([see doc](https://developer.apple.com/documentation/foundation/nsvalue/1415141-getvalue?language=objc)) call for getValue is being used.

### :new: What is the new behavior (if this is a feature change)?

Replaced deprecated call with typecast.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

Issue #202 

[Apple documentation](https://developer.apple.com/documentation/foundation/nsvalue/1415141-getvalue?language=objc) 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
