### PR TITLE
Removed PermissionStatus.undetermined

### DIFF
--- a/permission_handler_platform_interface/CHANGELOG.md
+++ b/permission_handler_platform_interface/CHANGELOG.md
@@ -1,7 +1,10 @@
+## 3.0.0+1
+
+* **BREAKING**: Removed PermissionStatus.undetermined. This is now replaced by PermissionStatus.denied.
+
 ## 3.0.0
 
 * Migrated to null safety.
-* Removed PermissionStatus.undetermined. This is now replaced by PermissionStatus.denied.
 
 ## 2.0.2
 

--- a/permission_handler_platform_interface/CHANGELOG.md
+++ b/permission_handler_platform_interface/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.0.0
 
 * Migrated to null safety.
+* Removed PermissionStatus.undetermined. This is now replaced by PermissionStatus.denied.
 
 ## 2.0.2
 

--- a/permission_handler_platform_interface/lib/src/permission_status.dart
+++ b/permission_handler_platform_interface/lib/src/permission_status.dart
@@ -2,9 +2,6 @@ part of permission_handler_platform_interface;
 
 /// Defines the state of a [Permission].
 enum PermissionStatus {
-  /// The permission wasn't requested yet.
-  undetermined,
-
   /// The user granted access to the requested feature.
   granted,
 
@@ -37,7 +34,7 @@ extension PermissionStatusValue on PermissionStatus {
         return 1;
       case PermissionStatus.restricted:
         return 2;
-      case PermissionStatus.undetermined:
+      case PermissionStatus.denied:
         return 3;
       case PermissionStatus.permanentlyDenied:
         return 5;
@@ -53,7 +50,6 @@ extension PermissionStatusValue on PermissionStatus {
       PermissionStatus.denied,
       PermissionStatus.granted,
       PermissionStatus.restricted,
-      PermissionStatus.undetermined,
       PermissionStatus.limited,
       PermissionStatus.permanentlyDenied,
     ][value];
@@ -61,9 +57,6 @@ extension PermissionStatusValue on PermissionStatus {
 }
 
 extension PermissionStatusGetters on PermissionStatus {
-  /// If the permission was never requested before.
-  bool get isUndetermined => this == PermissionStatus.undetermined;
-
   /// If the user granted access to the requested feature.
   bool get isGranted => this == PermissionStatus.granted;
 
@@ -86,9 +79,6 @@ extension PermissionStatusGetters on PermissionStatus {
 }
 
 extension FuturePermissionStatusGetters on Future<PermissionStatus> {
-  /// If the permission was never requested before.
-  Future<bool> get isUndetermined async => (await this).isUndetermined;
-
   /// If the user granted access to the requested feature.
   Future<bool> get isGranted async => (await this).isGranted;
 

--- a/permission_handler_platform_interface/pubspec.yaml
+++ b/permission_handler_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the permission_handler plugin.
 homepage: https://github.com/baseflow/flutter-permission-handler/tree/master/permission_handler_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 3.0.0
+version: 3.0.0+1
 
 dependencies:
   flutter:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
PermissionStatus.undetermined has been removes in favor of PermissionStatus.denied. 

### :arrow_heading_down: What is the current behavior?
PermissionStatus.undetermined is returned

### :new: What is the new behavior (if this is a feature change)?
PermissionStatus.undetermined doesn't exist

### :boom: Does this PR introduce a breaking change?
Yes

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
