### PR TITLE
Removed isUndetermined from PermissionCheckShortcuts

### DIFF
--- a/permission_handler/example/lib/plugin_example/permission_widget.dart
+++ b/permission_handler/example/lib/plugin_example/permission_widget.dart
@@ -17,7 +17,7 @@ class _PermissionState extends State<PermissionWidget> {
   _PermissionState(this._permission);
 
   final Permission _permission;
-  PermissionStatus _permissionStatus = PermissionStatus.undetermined;
+  late PermissionStatus _permissionStatus;
 
   @override
   void initState() {

--- a/permission_handler/lib/permission_handler.dart
+++ b/permission_handler/lib/permission_handler.dart
@@ -53,9 +53,6 @@ extension PermissionActions on Permission {
 
 /// Shortcuts for checking the [status] of a [Permission].
 extension PermissionCheckShortcuts on Permission {
-  /// If this permission was never requested before.
-  Future<bool> get isUndetermined => status.isUndetermined;
-
   /// If the user granted this permission.
   Future<bool> get isGranted => status.isGranted;
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix, the `undetermined` permission status was used for `PermissionCheckShortcuts`'s `isUndetermined` extension method. Also, minor change in example for `PermissionStatus`, now it uses the `late` keyword for initialization, part of the null-safety migration.

### :arrow_heading_down: What is the current behavior?

There's an error in the `isUndetermined` method for the `PermissionCheckShortcuts` and the `PermissionStatus` on example is throwing an error because it initializes the `PermissionStatus` as `undetermined`, which is not defined.

### :new: What is the new behavior (if this is a feature change)?

`PermissionStatus` doesn't have any undetermined value, therefore you will have an error if you use that value in your apps.

### :boom: Does this PR introduce a breaking change?

Not a big one, you can say a deprecated property was removed.

### :bug: Recommendations for testing

Have Flutter 2 and Dart 2.12 installed.

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [ ✅] All projects build
- [✅ ] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/develop/CONTRIBUTING.md))
- [ ✅] Relevant documentation was updated
- [✅ ] Rebased onto current develop
