### PR TITLE
Add bluetooth permission.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ You can remove permissions you don't use:
   
            ## dart: PermissionGroup.sensors
            # 'PERMISSION_SENSORS=0'
+           
+           ## dart: PermissionGroup.bluetooth
+           # 'PERMISSION_BLUETOOTH=0'
          ]
   
        end
@@ -128,6 +131,7 @@ You can remove permissions you don't use:
    | PermissionGroup.notification                                                                | PermissionGroupNotification                                                                                   | PERMISSION_NOTIFICATIONS     |
    | PermissionGroup.mediaLibrary                                                                | NSAppleMusicUsageDescription, kTCCServiceMediaLibrary                                                         | PERMISSION_MEDIA_LIBRARY     |
    | PermissionGroup.sensors                                                                     | NSMotionUsageDescription                                                                                      | PERMISSION_SENSORS           |
+   | PermissionGroup.bluetooth                                                                     | NSBluetoothAlwaysUsageDescription,             NSBluetoothPeripheralUsageDescription           | PERMISSION_BLUETOOTH           |
 4. Clean & Rebuild
 
 </details>

--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 6.1.0
 
-* Added support for bluetooth permissions. 
+* Added support for bluetooth permissions;
+* Workaround for ignore battery optimizations on pre-M Android devices (see PR [#376](https://github.com/Baseflow/flutter-permission-handler/pull/376)). 
 
 ## 6.0.1
 

--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.1.0
+
+* Added support for bluetooth permissions. 
+
 ## 6.0.1
 
 * Fixed deprecation warning when building Android project.

--- a/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionConstants.java
+++ b/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionConstants.java
@@ -32,6 +32,7 @@ final class PermissionConstants {
     static final int PERMISSION_GROUP_ACCESS_MEDIA_LOCATION = 18;
     static final int PERMISSION_GROUP_ACTIVITY_RECOGNITION = 19;
     static final int PERMISSION_GROUP_UNKNOWN = 20;
+    static final int PERMISSION_GROUP_BLUETOOTH = 21;
 
     @Retention(RetentionPolicy.SOURCE)
     @IntDef({
@@ -55,6 +56,7 @@ final class PermissionConstants {
             PERMISSION_GROUP_ACCESS_MEDIA_LOCATION,
             PERMISSION_GROUP_ACTIVITY_RECOGNITION,
             PERMISSION_GROUP_UNKNOWN,
+            PERMISSION_GROUP_BLUETOOTH,
     })
     @interface PermissionGroup {
     }

--- a/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
+++ b/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
@@ -160,6 +160,9 @@ final class PermissionManager {
         if (permission == PermissionConstants.PERMISSION_GROUP_NOTIFICATION) {
             return checkNotificationPermissionStatus(context);
         }
+        if(permission == PermissionConstants.PERMISSION_GROUP_BLUETOOTH){
+            return checkBluetoothPermissionStatus(context);
+        }
 
         final List<String> names = PermissionUtils.getManifestNames(context, permission);
 
@@ -242,6 +245,16 @@ final class PermissionManager {
             return PermissionConstants.PERMISSION_STATUS_GRANTED;
         }
         return PermissionConstants.PERMISSION_STATUS_DENIED;
+    }
+
+    private int checkBluetoothPermissionStatus(Context context) {
+        List<String> names = PermissionUtils.getManifestNames(context, PermissionConstants.PERMISSION_GROUP_BLUETOOTH);
+        boolean missingInManifest = names == null || names.isEmpty();
+        if(missingInManifest) {
+            Log.d(PermissionConstants.LOG_TAG, "Bluetooth permission missing in manifest");
+            return PermissionConstants.PERMISSION_STATUS_DENIED;
+        }
+        return PermissionConstants.PERMISSION_STATUS_GRANTED;
     }
 
     @VisibleForTesting

--- a/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
+++ b/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
@@ -193,6 +193,10 @@ public class PermissionUtils {
                     permissionNames.add(Manifest.permission.ACTIVITY_RECOGNITION);
                 break;
 
+            case PermissionConstants.PERMISSION_GROUP_BLUETOOTH:
+                if (hasPermissionInManifest(context, permissionNames, Manifest.permission.BLUETOOTH))
+                    permissionNames.add(Manifest.permission.BLUETOOTH);
+                break;
             case PermissionConstants.PERMISSION_GROUP_NOTIFICATION:
             case PermissionConstants.PERMISSION_GROUP_MEDIA_LIBRARY:
             case PermissionConstants.PERMISSION_GROUP_PHOTOS:

--- a/permission_handler/android/src/main/java/com/baseflow/permissionhandler/ServiceManager.java
+++ b/permission_handler/android/src/main/java/com/baseflow/permissionhandler/ServiceManager.java
@@ -1,5 +1,6 @@
 package com.baseflow.permissionhandler;
 
+import android.bluetooth.BluetoothAdapter;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -42,6 +43,13 @@ final class ServiceManager {
 
             successCallback.onSuccess(serviceStatus);
             return;
+        }
+        if(permission == PermissionConstants.PERMISSION_GROUP_BLUETOOTH){
+            final int serviceStatus = isBluetoothServiceEnabled()
+                    ? PermissionConstants.SERVICE_STATUS_ENABLED
+                    : PermissionConstants.SERVICE_STATUS_DISABLED;
+
+            successCallback.onSuccess(serviceStatus);
         }
 
         if (permission == PermissionConstants.PERMISSION_GROUP_PHONE) {
@@ -138,5 +146,10 @@ final class ServiceManager {
                 context.getContentResolver(),
                 Settings.Secure.LOCATION_PROVIDERS_ALLOWED);
         return !TextUtils.isEmpty(locationProviders);
+    }
+
+    private boolean isBluetoothServiceEnabled() {
+        final BluetoothAdapter bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
+        return bluetoothAdapter.isEnabled();
     }
 }

--- a/permission_handler/example/android/app/src/main/AndroidManifest.xml
+++ b/permission_handler/example/android/app/src/main/AndroidManifest.xml
@@ -60,6 +60,9 @@
     <!-- Permissions options for the `ignoreBatteryOptimizations` group -->
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
+    <!-- Permissions options for the `bluetooth` group -->
+    <uses-permission android:name="android.permission.BLUETOOTH" />
+
     <application
         android:name="io.flutter.app.FlutterApplication"
         android:icon="@mipmap/ic_launcher"

--- a/permission_handler/ios/Classes/PermissionHandlerEnums.h
+++ b/permission_handler/ios/Classes/PermissionHandlerEnums.h
@@ -108,7 +108,9 @@ typedef NS_ENUM(int, PermissionGroup) {
     PermissionGroupIgnoreBatteryOptimizations,
     PermissionGroupNotification,
     PermissionGroupAccessMediaLocation,
+    PermissionGroupActivityRecognition,
     PermissionGroupUnknown,
+    PermissionGroupBluetooth,
 };
 
 typedef NS_ENUM(int, PermissionStatus) {

--- a/permission_handler/ios/Classes/PermissionHandlerEnums.h
+++ b/permission_handler/ios/Classes/PermissionHandlerEnums.h
@@ -88,6 +88,13 @@
     #define PERMISSION_SENSORS 1
 #endif
 
+// ios: PermissionGroupBluetooth
+// Info.plist: [NSBluetoothAlwaysUsageDescription, NSBluetoothPeripheralUsageDescription]
+// dart: PermissionGroup.bluetooth
+#ifndef PERMISSION_BLUETOOTH
+    #define PERMISSION_BLUETOOTH 1
+#endif
+
 typedef NS_ENUM(int, PermissionGroup) {
     PermissionGroupCalendar = 0,
     PermissionGroupCamera,

--- a/permission_handler/ios/Classes/PermissionManager.h
+++ b/permission_handler/ios/Classes/PermissionManager.h
@@ -10,6 +10,7 @@
 #import <UIKit/UIKit.h>
 
 #import "AudioVideoPermissionStrategy.h"
+#import "BluetoothPermissionStrategy.h"
 #import "ContactPermissionStrategy.h"
 #import "EventPermissionStrategy.h"
 #import "LocationPermissionStrategy.h"

--- a/permission_handler/ios/Classes/PermissionManager.m
+++ b/permission_handler/ios/Classes/PermissionManager.m
@@ -123,6 +123,8 @@
             return [NotificationPermissionStrategy new];
         case PermissionGroupStorage:
             return [StoragePermissionStrategy new];
+        case PermissionGroupBluetooth:
+            return [BluetoothPermissionStrategy new];
         default:
             return [UnknownPermissionStrategy new];
     }

--- a/permission_handler/ios/Classes/strategies/BluetoothPermissionStrategy.h
+++ b/permission_handler/ios/Classes/strategies/BluetoothPermissionStrategy.h
@@ -6,9 +6,20 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <CoreBluetooth/CoreBluetooth.h>
 #import "PermissionStrategy.h"
 
+#if PERMISSION_BLUETOOTH
+
+#import <CoreBluetooth/CoreBluetooth.h>
 
 @interface BluetoothPermissionStrategy : NSObject <PermissionStrategy>
 @end
+
+#else
+
+#import "UnknownPermissionStrategy.h"
+
+@interface BluetoothPermissionStrategy : UnknownPermissionStrategy
+@end
+
+#endif

--- a/permission_handler/ios/Classes/strategies/BluetoothPermissionStrategy.h
+++ b/permission_handler/ios/Classes/strategies/BluetoothPermissionStrategy.h
@@ -1,0 +1,14 @@
+//
+//  BluetoothPermissionStrategy.h
+//  permission_handler
+//
+//  Created by Rene Floor on 12/03/2021.
+//
+
+#import <Foundation/Foundation.h>
+#import <CoreBluetooth/CoreBluetooth.h>
+#import "PermissionStrategy.h"
+
+
+@interface BluetoothPermissionStrategy : NSObject <PermissionStrategy>
+@end

--- a/permission_handler/ios/Classes/strategies/BluetoothPermissionStrategy.m
+++ b/permission_handler/ios/Classes/strategies/BluetoothPermissionStrategy.m
@@ -1,0 +1,50 @@
+//
+//  BluetoothPermissionStrategy.m
+//  permission_handler
+//
+//  Created by Rene Floor on 12/03/2021.
+//
+
+#import "BluetoothPermissionStrategy.h"
+
+
+@implementation BluetoothPermissionStrategy
+
+- (PermissionStatus)checkPermissionStatus:(PermissionGroup)permission {
+    if (@available(iOS 13.1, *)) {
+        CBManagerAuthorization blePermission = [CBCentralManager authorization];
+        return [BluetoothPermissionStrategy parsePermission:blePermission];
+    } else if (@available(iOS 13.0, *)){
+        CBCentralManager* manager = [[CBCentralManager alloc] init];
+        CBManagerAuthorization blePermission =  [manager authorization];
+        return [BluetoothPermissionStrategy parsePermission:blePermission];
+    }
+    return PermissionStatusGranted;
+}
+
+- (ServiceStatus)checkServiceStatus:(PermissionGroup)permission {
+    CBCentralManager* manager = [[CBCentralManager alloc] init];
+    if (@available(iOS 10, *)) {
+        return [manager state] == CBManagerStatePoweredOn ? ServiceStatusEnabled : ServiceStatusDisabled;
+    }
+    return [manager state] == CBCentralManagerStatePoweredOn ? ServiceStatusEnabled : ServiceStatusDisabled;
+    
+}
+
+- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {
+    completionHandler([self checkPermissionStatus:permission]);
+}
+
++ (PermissionStatus)parsePermission:(CBManagerAuthorization)bluetoothPermission API_AVAILABLE(ios(13)){
+    switch(bluetoothPermission){
+        case CBManagerAuthorizationNotDetermined:
+            return PermissionStatusDenied;
+        case CBManagerAuthorizationRestricted:
+            return PermissionStatusRestricted;
+        case CBManagerAuthorizationDenied:
+            return PermissionStatusDenied;
+        case CBManagerAuthorizationAllowedAlways:
+            return PermissionStatusGranted;
+    }
+}
+@end

--- a/permission_handler/ios/Classes/strategies/BluetoothPermissionStrategy.m
+++ b/permission_handler/ios/Classes/strategies/BluetoothPermissionStrategy.m
@@ -7,6 +7,7 @@
 
 #import "BluetoothPermissionStrategy.h"
 
+#if PERMISSION_BLUETOOTH
 
 @implementation BluetoothPermissionStrategy
 
@@ -48,3 +49,10 @@
     }
 }
 @end
+
+#else
+
+@implementation BluetoothPermissionStrategy
+@end
+
+#endif

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -23,5 +23,5 @@ dev_dependencies:
   plugin_platform_interface: ^2.0.0
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
-  flutter: ">=1.12.8 <2.0.0"
+  sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=1.12.8"

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-version: 6.0.1
+version: 6.1.0
 homepage: https://github.com/baseflowit/flutter-permission-handler
 
 flutter:

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -16,8 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
-  permission_handler_platform_interface:
-    path: ../permission_handler_platform_interface
+  permission_handler_platform_interface: ^3.1.0
 
 dev_dependencies:
   effective_dart: ^1.3.0

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -16,7 +16,8 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
-  permission_handler_platform_interface: ^3.0.0+1
+  permission_handler_platform_interface:
+    path: ../permission_handler_platform_interface
 
 dev_dependencies:
   effective_dart: ^1.3.0

--- a/permission_handler_platform_interface/CHANGELOG.md
+++ b/permission_handler_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.0
+
+* Added support for bluetooth permissions. 
+
 ## 3.0.0+1
 
 * **BREAKING**: Removed PermissionStatus.undetermined. This is now replaced by PermissionStatus.denied.

--- a/permission_handler_platform_interface/lib/src/permissions.dart
+++ b/permission_handler_platform_interface/lib/src/permissions.dart
@@ -103,6 +103,10 @@ class Permission {
   /// The unknown only used for return type, never requested
   static const unknown = Permission._(20);
 
+  /// iOS 13 and above: The authorization state of Core Bluetooth manager.
+  /// When running < iOS 13 or Android this is always allowed.
+  static const bluetooth = Permission._(21);
+
   /// Returns a list of all possible [PermissionGroup] values.
   static const List<Permission> values = <Permission>[
     calendar,
@@ -126,6 +130,7 @@ class Permission {
     accessMediaLocation,
     activityRecognition,
     unknown,
+    bluetooth
   ];
 
   static const List<String> _names = <String>[
@@ -150,6 +155,7 @@ class Permission {
     'access_media_location',
     'activity_recognition',
     'unknown',
+    'bluetooth',
   ];
 
   @override

--- a/permission_handler_platform_interface/pubspec.yaml
+++ b/permission_handler_platform_interface/pubspec.yaml
@@ -18,5 +18,5 @@ dev_dependencies:
   effective_dart: ^1.3.0
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.22.0"

--- a/permission_handler_platform_interface/pubspec.yaml
+++ b/permission_handler_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the permission_handler plugin.
 homepage: https://github.com/baseflow/flutter-permission-handler/tree/master/permission_handler_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 3.0.0+1
+version: 3.1.0
 
 dependencies:
   flutter:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Currently it is not possible to ask for bluetooth permissions on iOS. This is introduced in iOS 13. This permission is not needed on Android and will always return 'granted'.

### :new: What is the new behavior (if this is a feature change)?
Implement Bluetooth permission.
The request for permission is a bit different as that is automatically done while doing a bluetooth action.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
I still have to verify if this really works with Bluetooth denied, but I have to use it with some bluetooth calls, which aren't available in the example.

### :memo: Links to relevant issues/docs
https://medium.com/flawless-app-stories/handling-ios-13-bluetooth-permissions-26c6a8cbb816

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop