### PR TITLE
Implement the equality operator for Permission class

### DIFF
--- a/permission_handler_platform_interface/lib/permission_handler_platform_interface.dart
+++ b/permission_handler_platform_interface/lib/permission_handler_platform_interface.dart
@@ -1,6 +1,7 @@
 library permission_handler_platform_interface;
 
 import 'dart:async';
+import 'package:meta/meta.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'src/method_channel/method_channel_permission_handler.dart';
 

--- a/permission_handler_platform_interface/lib/src/permissions.dart
+++ b/permission_handler_platform_interface/lib/src/permissions.dart
@@ -8,6 +8,7 @@ class PermissionWithService extends Permission {
 }
 
 /// Defines the permissions which can be checked and requested.
+@immutable
 class Permission {
   const Permission._(this.value);
   factory Permission.byValue(int value) => values[value];
@@ -146,4 +147,18 @@ class Permission {
 
   @override
   String toString() => 'Permission.${_names[value]}';
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+    return other is Permission && other.value == value;
+  }
+
+  @override
+  int get hashCode => value.hashCode;
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

This change implements the equality operator for `Permisson` class.

I added `@immutable` annotation to `Permission` according to enabled lint rule [avoid_equals_and_hash_code_on_mutable_classes](https://dart-lang.github.io/linter/lints/avoid_equals_and_hash_code_on_mutable_classes.html).<br>The class is already not mutable, this annotation was added to satisfy linter.

### :arrow_heading_down: What is the current behavior?
`Permission` equals another `Permission` only if they are the same instance.

### :new: What is the new behavior (if this is a feature change)?
`Permission` equals another `Permission` when they have equal `Permission.value`.

### :boom: Does this PR introduce a breaking change?
Yes. If someone extends `Permission` class and the child class is not immutable, they'll get a warning message.

### :bug: Recommendations for testing
I'd like to write tests for equality, but tests directory is missing from `develop` branch.

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
