### PR TITLE
Correctly handle some permissions on pre Android Q

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.1.2
+
+* Correctly handle the ACCESS_MEDIA_LOCATION and ACCESS_ACTIVITY_RECOGNITION permissions on pre Android Q devices (permissions should be implicitly granted on pre Android Q). 
+
 ## 6.1.1
 
 * Added unit-tests to guard API against breaking changes.

--- a/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
+++ b/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
@@ -93,11 +93,14 @@ public class PermissionUtils {
                 break;
 
             case PermissionConstants.PERMISSION_GROUP_LOCATION_ALWAYS:
+                // Note that the LOCATION_ALWAYS will deliberately fallthrough to the LOCATION
+                // case on pre Android Q devices. The ACCESS_BACKGROUND_LOCATION permission was only
+                // introduced in Android Q, before it should be treated as the ACCESS_COARSE_LOCATION or
+                // ACCESS_FINE_LOCATION.
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                     if (hasPermissionInManifest(context, permissionNames, Manifest.permission.ACCESS_BACKGROUND_LOCATION))
                         permissionNames.add(Manifest.permission.ACCESS_BACKGROUND_LOCATION);
                 }
-
             case PermissionConstants.PERMISSION_GROUP_LOCATION_WHEN_IN_USE:
             case PermissionConstants.PERMISSION_GROUP_LOCATION:
                 if (hasPermissionInManifest(context, permissionNames, Manifest.permission.ACCESS_COARSE_LOCATION))
@@ -184,12 +187,22 @@ public class PermissionUtils {
                 break;
 
             case PermissionConstants.PERMISSION_GROUP_ACCESS_MEDIA_LOCATION:
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && hasPermissionInManifest(context, permissionNames, Manifest.permission.ACCESS_MEDIA_LOCATION))
+                // The ACCESS_MEDIA_LOCATION permission is introduced in Android Q, meaning we should
+                // not handle permissions on pre Android Q devices.
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q)
+                    return null;
+
+                if(hasPermissionInManifest(context, permissionNames, Manifest.permission.ACCESS_MEDIA_LOCATION))
                     permissionNames.add(Manifest.permission.ACCESS_MEDIA_LOCATION);
                 break;
 
             case PermissionConstants.PERMISSION_GROUP_ACTIVITY_RECOGNITION:
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && hasPermissionInManifest(context, permissionNames, Manifest.permission.ACTIVITY_RECOGNITION))
+                // The ACCESS_MEDIA_LOCATION permission is introduced in Android Q, meaning we should
+                // not handle permissions on pre Android Q devices.
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q)
+                    return null;
+
+                if (hasPermissionInManifest(context, permissionNames, Manifest.permission.ACTIVITY_RECOGNITION))
                     permissionNames.add(Manifest.permission.ACTIVITY_RECOGNITION);
                 break;
 

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-version: 6.1.1
+version: 6.1.2
 homepage: https://github.com/baseflowit/flutter-permission-handler
 
 flutter:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

On pre Android Q devices, permission for `ACCESS_ACTIVITY_RECOGNITION` and `ACCESS_MEDIA_LOCATION` are always return as denied. This is incorrect as permissions are implicitly granted on earlier devices.

### :new: What is the new behavior (if this is a feature change)?

Permissions will now be returned as granted as expected.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Simply run the example App on pre Android Q device or emulator and check permissions for the "ActivityRecognition" and "MediaLocation" permissions.

### :memo: Links to relevant issues/docs

N/A (added some additional comments in code to explain certain cases).

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
