### PR TITLE
Implement equality for Permission

### DIFF
--- a/permission_handler_platform_interface/CHANGELOG.md
+++ b/permission_handler_platform_interface/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.1.3 
+
+* Implemented equality operator for `Permission` class;
+* Reverted services status check for notification permission. Turns out implementation does not fit with idea's of permission_handler plugin.
+
 ## 3.1.2
 
 * Allow checking serviceStatus for notification permission.

--- a/permission_handler_platform_interface/lib/src/permissions.dart
+++ b/permission_handler_platform_interface/lib/src/permissions.dart
@@ -93,7 +93,7 @@ class Permission {
 
   /// Android: Notification
   /// iOS: Notification
-  static const notification = PermissionWithService._(17);
+  static const notification = Permission._(17);
 
   /// Android: Allows an application to access any geographic locations
   /// persisted in the user's shared collection.

--- a/permission_handler_platform_interface/pubspec.yaml
+++ b/permission_handler_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the permission_handler plugin.
 homepage: https://github.com/baseflow/flutter-permission-handler/tree/master/permission_handler_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 3.1.2
+version: 3.1.3
 
 dependencies:
   flutter:

--- a/permission_handler_platform_interface/test/src/permissions_test.dart
+++ b/permission_handler_platform_interface/test/src/permissions_test.dart
@@ -73,8 +73,8 @@ void main() {
 
     // Act & Assert
     expect(
-      firstPermission.hashCode != secondPermission.hashCode,
-      true,
+      firstPermission.hashCode == secondPermission.hashCode,
+      false,
     );
   });
 }

--- a/permission_handler_platform_interface/test/src/permissions_test.dart
+++ b/permission_handler_platform_interface/test/src/permissions_test.dart
@@ -22,4 +22,59 @@ void main() {
     var permissionName = permissionWithService.toString();
     expect(permissionName, 'Permission.calendar');
   });
+
+  test(
+      // ignore: lines_longer_than_80_chars
+      'equality operator should return true for two instances with the same values',
+      () {
+    // Arrange
+    final firstPermission = Permission.byValue(1);
+    final secondPermission = Permission.byValue(1);
+
+    // Act & Assert
+    expect(
+      firstPermission == secondPermission,
+      true,
+    );
+  });
+
+  test(
+      // ignore: lines_longer_than_80_chars
+      'equality operator should return false for two instances with different values',
+      () {
+    // Arrange
+    final firstPermission = Permission.byValue(1);
+    final secondPermission = Permission.byValue(2);
+
+    // Act & Assert
+    expect(
+      firstPermission == secondPermission,
+      false,
+    );
+  });
+
+  test('hashCode should be the same for two instances with the same values',
+      () {
+    // Arrange
+    final firstPermission = Permission.byValue(1);
+    final secondPermission = Permission.byValue(1);
+
+    // Act & Assert
+    expect(
+      firstPermission.hashCode,
+      secondPermission.hashCode,
+    );
+  });
+
+  test('hashCode should not match for two instances with different values', () {
+    // Arrange
+    final firstPermission = Permission.byValue(1);
+    final secondPermission = Permission.byValue(2);
+
+    // Act & Assert
+    expect(
+      firstPermission.hashCode != secondPermission.hashCode,
+      true,
+    );
+  });
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

This change implements the equality operator for `Permisson` class.

I added `@immutable` annotation to `Permission` according to enabled lint rule [avoid_equals_and_hash_code_on_mutable_classes](https://dart-lang.github.io/linter/lints/avoid_equals_and_hash_code_on_mutable_classes.html).<br>The class is already not mutable, this annotation was added to satisfy linter.

### :arrow_heading_down: What is the current behavior?
`Permission` equals another `Permission` only if they are the same instance.

### :new: What is the new behavior (if this is a feature change)?
`Permission` equals another `Permission` when they have equal `Permission.value`.

### :boom: Does this PR introduce a breaking change?
Yes. If someone extends `Permission` class and the child class is not immutable, they'll get a warning message.

### :bug: Recommendations for testing

Added additional unit tests to proof that the equality operator is working.

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
