### PR TITLE
Upgrade to permission_handler_platform_interface 3.1.3

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 6.1.3
+
+* Implement equality operator on the `Permission` class;
+* Updated the README.md with instructions on enabling/ disabling the bluetooth permissions on iOS;
+* Corrected some spelling mistakes in the `CHANGELOG.md`.
+
 ## 6.1.2
 
 * Correctly handle the ACCESS_MEDIA_LOCATION and ACCESS_ACTIVITY_RECOGNITION permissions on pre Android Q devices (permissions should be implicitly granted on pre Android Q). 

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-version: 6.1.2
+version: 6.1.3
 homepage: https://github.com/baseflowit/flutter-permission-handler
 
 flutter:
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
-  permission_handler_platform_interface: ^3.1.1
+  permission_handler_platform_interface: ^3.1.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

Two instances of the permission class can not be compared.

### :new: What is the new behavior (if this is a feature change)?

Implemented the equality operator.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
