### PR TITLE
Added support for SYSTEM_ALERT_WINDOW permission

### DIFF
--- a/permission_handler_platform_interface/CHANGELOG.md
+++ b/permission_handler_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.0
+
+* Added support for system alert window permission.
+
 ## 3.2.0
 
 * Added support for manage external storage permission available on Android 10 and up.

--- a/permission_handler_platform_interface/lib/src/permissions.dart
+++ b/permission_handler_platform_interface/lib/src/permissions.dart
@@ -129,6 +129,10 @@ class Permission {
   /// https://support.google.com/googleplay/android-developer/answer/9214102#zippy=
   static const manageExternalStorage = Permission._(22);
 
+  ///Android: Allows an app to create windows shown on top of all other apps
+  ///iOS: Nothing
+  static const systemAlertWindow = Permission._(23);
+
   /// Returns a list of all possible [PermissionGroup] values.
   static const List<Permission> values = <Permission>[
     calendar,
@@ -153,7 +157,8 @@ class Permission {
     activityRecognition,
     unknown,
     bluetooth,
-    manageExternalStorage
+    manageExternalStorage,
+    systemAlertWindow
   ];
 
   static const List<String> _names = <String>[
@@ -179,7 +184,8 @@ class Permission {
     'activity_recognition',
     'unknown',
     'bluetooth',
-    'manageExternalStorage'
+    'manageExternalStorage',
+    'systemAlertWindow'
   ];
 
   @override

--- a/permission_handler_platform_interface/pubspec.yaml
+++ b/permission_handler_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the permission_handler plugin.
 homepage: https://github.com/baseflow/flutter-permission-handler/tree/master/permission_handler_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 3.2.0
+version: 3.3.0
 
 dependencies:
   flutter:

--- a/permission_handler_platform_interface/test/src/permissions_test.dart
+++ b/permission_handler_platform_interface/test/src/permissions_test.dart
@@ -6,7 +6,7 @@ void main() {
       () {
     final values = Permission.values;
 
-    expect(values.length, 23);
+    expect(values.length, 24);
   });
 
   test('check if byValue returns corresponding PermissionGroup value', () {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Added SYSTEM_ALERT_WINDOW permission

### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

Android's documentation about the [SYSTEM_ALERT_WINDOW](https://developer.android.com/reference/android/Manifest.permission#SYSTEM_ALERT_WINDOW)

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
