### PR TITLE
Added 'SYSTEM_ALERT_WINDOW' permission

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.1.0
+
+* Added support for the "SYSTEM_ALERT_WINDOW" permission on Android.
+
 ## 7.0.0
 
 This release contains the following **breaking changes**: 

--- a/permission_handler/android/src/main/java/com/baseflow/permissionhandler/MethodCallHandlerImpl.java
+++ b/permission_handler/android/src/main/java/com/baseflow/permissionhandler/MethodCallHandlerImpl.java
@@ -58,13 +58,7 @@ final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
                 permissionManager.checkPermissionStatus(
                         permission,
                         applicationContext,
-						activity,
-                        result::success,
-                        (String errorCode, String errorDescription) -> result.error(
-                                errorCode,
-                                errorDescription,
-                                null));
-
+                        result::success);
                 break;
             }
             case "requestPermissions":

--- a/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionConstants.java
+++ b/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionConstants.java
@@ -10,6 +10,7 @@ final class PermissionConstants {
     static final int PERMISSION_CODE = 24;
     static final int PERMISSION_CODE_IGNORE_BATTERY_OPTIMIZATIONS = 209;
     static final int PERMISSION_CODE_MANAGE_EXTERNAL_STORAGE = 210;
+    static final int PERMISSION_CODE_SYSTEM_ALERT_WINDOW = 211;
 
     //PERMISSION_GROUP
     static final int PERMISSION_GROUP_CALENDAR = 0;
@@ -35,6 +36,7 @@ final class PermissionConstants {
     static final int PERMISSION_GROUP_UNKNOWN = 20;
     static final int PERMISSION_GROUP_BLUETOOTH = 21;
     static final int PERMISSION_GROUP_MANAGE_EXTERNAL_STORAGE = 22;
+    static final int PERMISSION_GROUP_SYSTEM_ALERT_WINDOW = 23;
 
     @Retention(RetentionPolicy.SOURCE)
     @IntDef({
@@ -59,7 +61,8 @@ final class PermissionConstants {
             PERMISSION_GROUP_ACTIVITY_RECOGNITION,
             PERMISSION_GROUP_UNKNOWN,
             PERMISSION_GROUP_BLUETOOTH,
-            PERMISSION_GROUP_MANAGE_EXTERNAL_STORAGE
+            PERMISSION_GROUP_MANAGE_EXTERNAL_STORAGE,
+            PERMISSION_GROUP_SYSTEM_ALERT_WINDOW
     })
     @interface PermissionGroup {
     }

--- a/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
+++ b/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
@@ -63,6 +63,8 @@ public class PermissionUtils {
                 return PermissionConstants.PERMISSION_GROUP_ACTIVITY_RECOGNITION;
             case Manifest.permission.MANAGE_EXTERNAL_STORAGE:
                 return PermissionConstants.PERMISSION_GROUP_MANAGE_EXTERNAL_STORAGE;
+            case Manifest.permission.SYSTEM_ALERT_WINDOW:
+                return PermissionConstants.PERMISSION_GROUP_SYSTEM_ALERT_WINDOW;
             default:
                 return PermissionConstants.PERMISSION_GROUP_UNKNOWN;
         }
@@ -222,6 +224,11 @@ public class PermissionUtils {
                 // not handle permissions on pre Android R devices.
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && hasPermissionInManifest(context, permissionNames, Manifest.permission.MANAGE_EXTERNAL_STORAGE ))
                     permissionNames.add(Manifest.permission.MANAGE_EXTERNAL_STORAGE);
+                break;
+
+            case PermissionConstants.PERMISSION_GROUP_SYSTEM_ALERT_WINDOW:
+                if (hasPermissionInManifest(context, permissionNames, Manifest.permission.SYSTEM_ALERT_WINDOW ))
+                    permissionNames.add(Manifest.permission.SYSTEM_ALERT_WINDOW);
                 break;
 
             case PermissionConstants.PERMISSION_GROUP_NOTIFICATION:

--- a/permission_handler/example/android/app/src/main/AndroidManifest.xml
+++ b/permission_handler/example/android/app/src/main/AndroidManifest.xml
@@ -66,6 +66,9 @@
     <!-- Permissions options for the `manage external storage` group -->
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
 
+    <!-- Permissions options for the `system alert windows` group -->
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
+
     <application
         android:name="io.flutter.app.FlutterApplication"
         android:icon="@mipmap/ic_launcher"

--- a/permission_handler/ios/Classes/PermissionHandlerEnums.h
+++ b/permission_handler/ios/Classes/PermissionHandlerEnums.h
@@ -118,7 +118,8 @@ typedef NS_ENUM(int, PermissionGroup) {
     PermissionGroupActivityRecognition,
     PermissionGroupUnknown,
     PermissionGroupBluetooth,
-    PermissionGroupManageExternalStorage
+    PermissionGroupManageExternalStorage,
+    PermissionGroupSystemAlertWindow
 };
 
 typedef NS_ENUM(int, PermissionStatus) {

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-version: 7.0.0
+version: 7.1.0
 homepage: https://github.com/baseflowit/flutter-permission-handler
 
 flutter:
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
-  permission_handler_platform_interface: ^3.2.0
+  permission_handler_platform_interface: ^3.3.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Added the 'SYSTEM_ALERT_WINDOW' in the permission_handler

### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?

User can ask for the 'SYSTEM_ALERT_WINDOW' permission now

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs



### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
