### PR TITLE
Doc: update android min compile sdk to 30 for 7.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ android.enableJetifier=true
 2. Make sure you set the `compileSdkVersion` in your "android/app/build.gradle" file to 28:
 ```
 android {
-  compileSdkVersion 28
+  compileSdkVersion 30
   ...
 }
 ```


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

doc update for 7.x version's min compile SDK version on Android

### :arrow_heading_down: What is the current behavior?

minCompileSdk 28

### :new: What is the new behavior (if this is a feature change)?

minCompileSdk 30

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
