### PR TITLE
docs: compileSdkVersion 28 to 30

### DIFF
--- a/permission_handler/README.md
+++ b/permission_handler/README.md
@@ -28,10 +28,10 @@ The TL;DR version is:
 android.useAndroidX=true
 android.enableJetifier=true
 ```
-2. Make sure you set the `compileSdkVersion` in your "android/app/build.gradle" file to 28:
+2. Make sure you set the `compileSdkVersion` in your "android/app/build.gradle" file to 30:
 ```
 android {
-  compileSdkVersion 28
+  compileSdkVersion 30
   ...
 }
 ```


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

docs (README.md)

### :memo: Links to relevant issues/docs

[Issue](https://github.com/Baseflow/flutter-permission-handler/issues/541#issuecomment-830564097)

Permission Handler for android requires compileSdkVersion 30
