### PR TITLE
update README.md

### DIFF
--- a/permission_handler/README.md
+++ b/permission_handler/README.md
@@ -196,6 +196,20 @@ On Android, you can show a rationale for using a permission:
 bool isShown = await Permission.contacts.shouldShowRequestRationale;
 ```
 
+Some permissions will not show a dialog asking the user to allow or deny the requested permission.  
+This is because the OS setting(s) of the app are being retrieved for the corresponding permission.  
+The status of the setting will determine whether the permission is `granted` or `denied`.  
+
+The following permissions will show no dialog:  
+
+- Notification
+- Bluetooth
+
+The following permissions will show no dialog, but will open the corrseponding setting intent for the user to change the permission status:  
+
+- manageExternalStorage
+- systemAlertWindow
+
 ## Issues
 
 Please file any issues, bugs or feature request as an issue on our [GitHub](https://github.com/Baseflow/flutter-permission-handler/issues) page. Commercial support is available if you need help with integration with your app or services. You can contact us at [hello@baseflow.com](mailto:hello@baseflow.com).


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Updated REAMDE.md, in the 'How to use' section it says now that not every permission shows a dialog.
This is because some permissions will read the OS setting(s) of the app whether the app is allowed so do things (e.g. notification, manage external storage, bluetooth)

### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

Issue #240 - Enhancement Proposal
Issue #525 - Question why there was no dialog pop-up

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
