### PR TITLE
Updated README.md

### DIFF
--- a/permission_handler/README.md
+++ b/permission_handler/README.md
@@ -144,7 +144,7 @@ You can get a `Permission`'s `status`, which is either `granted`, `denied`, `res
 
 ```dart
 var status = await Permission.camera.status;
-if (status.denied) {
+if (status.isDenied) {
   // We didn't ask for permission yet or the permission has been denied before but not permanently.
 }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Small mistake in the README.md 'How to use section'.
The first part says:

```
var status = await Permission.camera.status;
if (status.denied) {
  // We didn't ask for permission yet or the permission has been denied before but not permanently.
}
```

while it should be `status.isDenied`

### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

#506 - Mentioning there is a small mistake in the 'How to use' section.

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
