### PR TITLE
Issue/319 permission handler platform interface

### DIFF
--- a/permission_handler_platform_interface/CHANGELOG.md
+++ b/permission_handler_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.4.0
+
+*Added support request install packages permission.
+
 ## 3.3.0
 
 * Added support for system alert window permission.

--- a/permission_handler_platform_interface/lib/src/permissions.dart
+++ b/permission_handler_platform_interface/lib/src/permissions.dart
@@ -133,6 +133,11 @@ class Permission {
   ///iOS: Nothing
   static const systemAlertWindow = Permission._(23);
 
+  ///Android: Allows an app to request installing packages.
+  ///iOS: Nothing
+  static const requestInstallPackages = Permission._(24);
+
+
   /// Returns a list of all possible [PermissionGroup] values.
   static const List<Permission> values = <Permission>[
     calendar,
@@ -158,7 +163,8 @@ class Permission {
     unknown,
     bluetooth,
     manageExternalStorage,
-    systemAlertWindow
+    systemAlertWindow,
+    requestInstallPackages
   ];
 
   static const List<String> _names = <String>[
@@ -185,7 +191,8 @@ class Permission {
     'unknown',
     'bluetooth',
     'manageExternalStorage',
-    'systemAlertWindow'
+    'systemAlertWindow',
+    'requestInstallPackages'
   ];
 
   @override

--- a/permission_handler_platform_interface/lib/src/permissions.dart
+++ b/permission_handler_platform_interface/lib/src/permissions.dart
@@ -137,7 +137,6 @@ class Permission {
   ///iOS: Nothing
   static const requestInstallPackages = Permission._(24);
 
-
   /// Returns a list of all possible [PermissionGroup] values.
   static const List<Permission> values = <Permission>[
     calendar,

--- a/permission_handler_platform_interface/pubspec.yaml
+++ b/permission_handler_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the permission_handler plugin.
 homepage: https://github.com/baseflow/flutter-permission-handler/tree/master/permission_handler_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 3.3.0
+version: 3.4.0
 
 dependencies:
   flutter:

--- a/permission_handler_platform_interface/test/src/permissions_test.dart
+++ b/permission_handler_platform_interface/test/src/permissions_test.dart
@@ -6,7 +6,7 @@ void main() {
       () {
     final values = Permission.values;
 
-    expect(values.length, 24);
+    expect(values.length, 25);
   });
 
   test('check if byValue returns corresponding PermissionGroup value', () {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Added the "REQUEST_INSTALL_PACKAGES" permission.

### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?

Allows an application to request installing packages (permission will open an intent where the user can grant the permission)

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

- Issue #508 - Requesting the permission
- Issue #319  - Requesting the permission
- Android documentation - [REQUEST_INSTALL_PACKAGES](https://developer.android.com/reference/android/Manifest.permission#REQUEST_INSTALL_PACKAGES)
- StackOverflow - [Extra information](https://stackoverflow.com/a/49828751/14542829) 

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
