### PR TITLE
Issue/319 permission handler

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.2.0
+
+* Added support for the "REQUEST_INSTALL_PACKAGES" permission on Android.
+
 ## 7.1.1
 
 * Improved the example app by using the Baseflow Plugin Template and move all the functionality to the `main.dart` file.

--- a/permission_handler/README.md
+++ b/permission_handler/README.md
@@ -209,6 +209,7 @@ The following permissions will show no dialog, but will open the corrseponding s
 
 - manageExternalStorage
 - systemAlertWindow
+- requestInstallPackages
 
 ## Issues
 

--- a/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionConstants.java
+++ b/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionConstants.java
@@ -11,6 +11,7 @@ final class PermissionConstants {
     static final int PERMISSION_CODE_IGNORE_BATTERY_OPTIMIZATIONS = 209;
     static final int PERMISSION_CODE_MANAGE_EXTERNAL_STORAGE = 210;
     static final int PERMISSION_CODE_SYSTEM_ALERT_WINDOW = 211;
+    static final int PERMISSION_CODE_REQUEST_INSTALL_PACKAGES = 212;
 
     //PERMISSION_GROUP
     static final int PERMISSION_GROUP_CALENDAR = 0;
@@ -37,6 +38,7 @@ final class PermissionConstants {
     static final int PERMISSION_GROUP_BLUETOOTH = 21;
     static final int PERMISSION_GROUP_MANAGE_EXTERNAL_STORAGE = 22;
     static final int PERMISSION_GROUP_SYSTEM_ALERT_WINDOW = 23;
+    static final int PERMISSION_GROUP_REQUEST_INSTALL_PACKAGES = 24;
 
     @Retention(RetentionPolicy.SOURCE)
     @IntDef({
@@ -62,7 +64,8 @@ final class PermissionConstants {
             PERMISSION_GROUP_UNKNOWN,
             PERMISSION_GROUP_BLUETOOTH,
             PERMISSION_GROUP_MANAGE_EXTERNAL_STORAGE,
-            PERMISSION_GROUP_SYSTEM_ALERT_WINDOW
+            PERMISSION_GROUP_SYSTEM_ALERT_WINDOW,
+            PERMISSION_GROUP_REQUEST_INSTALL_PACKAGES
     })
     @interface PermissionGroup {
     }

--- a/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
+++ b/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
@@ -37,7 +37,8 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
     public boolean onActivityResult(int requestCode, int resultCode, Intent data) {
         if (requestCode != PermissionConstants.PERMISSION_CODE_IGNORE_BATTERY_OPTIMIZATIONS &&
                 requestCode != PermissionConstants.PERMISSION_CODE_MANAGE_EXTERNAL_STORAGE &&
-                requestCode != PermissionConstants.PERMISSION_CODE_SYSTEM_ALERT_WINDOW) {
+                requestCode != PermissionConstants.PERMISSION_CODE_SYSTEM_ALERT_WINDOW &&
+                requestCode != PermissionConstants.PERMISSION_CODE_REQUEST_INSTALL_PACKAGES) {
             return false;
         }
 
@@ -60,6 +61,15 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
                         ? PermissionConstants.PERMISSION_STATUS_GRANTED
                         : PermissionConstants.PERMISSION_STATUS_DENIED;
                 permission = PermissionConstants.PERMISSION_GROUP_SYSTEM_ALERT_WINDOW;
+            } else {
+                return false;
+            }
+        } else if (requestCode == PermissionConstants.PERMISSION_CODE_REQUEST_INSTALL_PACKAGES) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                status = activity.getPackageManager().canRequestPackageInstalls()
+                        ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                        : PermissionConstants.PERMISSION_STATUS_DENIED;
+                permission = PermissionConstants.PERMISSION_GROUP_REQUEST_INSTALL_PACKAGES;
             } else {
                 return false;
             }
@@ -241,6 +251,10 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
                 executeIntent(
                         Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
                         PermissionConstants.PERMISSION_CODE_SYSTEM_ALERT_WINDOW);
+            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && permission == PermissionConstants.PERMISSION_GROUP_REQUEST_INSTALL_PACKAGES) {
+                executeIntent(
+                        Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
+                        PermissionConstants.PERMISSION_CODE_REQUEST_INSTALL_PACKAGES);
             } else {
                 permissionsToRequest.addAll(names);
             }
@@ -338,6 +352,14 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
                 if (permission == PermissionConstants.PERMISSION_GROUP_SYSTEM_ALERT_WINDOW) {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                         return Settings.canDrawOverlays(context)
+                                ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                                : PermissionConstants.PERMISSION_STATUS_DENIED;
+                    }
+                }
+
+                if (permission == PermissionConstants.PERMISSION_GROUP_REQUEST_INSTALL_PACKAGES) {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        return context.getPackageManager().canRequestPackageInstalls()
                                 ? PermissionConstants.PERMISSION_STATUS_GRANTED
                                 : PermissionConstants.PERMISSION_STATUS_DENIED;
                     }

--- a/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
+++ b/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
@@ -251,7 +251,7 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
                 executeIntent(
                         Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
                         PermissionConstants.PERMISSION_CODE_SYSTEM_ALERT_WINDOW);
-            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && permission == PermissionConstants.PERMISSION_GROUP_REQUEST_INSTALL_PACKAGES) {
+            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && permission == PermissionConstants.PERMISSION_GROUP_REQUEST_INSTALL_PACKAGES) {
                 executeIntent(
                         Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
                         PermissionConstants.PERMISSION_CODE_REQUEST_INSTALL_PACKAGES);

--- a/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
+++ b/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
@@ -65,6 +65,8 @@ public class PermissionUtils {
                 return PermissionConstants.PERMISSION_GROUP_MANAGE_EXTERNAL_STORAGE;
             case Manifest.permission.SYSTEM_ALERT_WINDOW:
                 return PermissionConstants.PERMISSION_GROUP_SYSTEM_ALERT_WINDOW;
+            case Manifest.permission.REQUEST_INSTALL_PACKAGES:
+                return PermissionConstants.PERMISSION_GROUP_REQUEST_INSTALL_PACKAGES;
             default:
                 return PermissionConstants.PERMISSION_GROUP_UNKNOWN;
         }
@@ -229,6 +231,13 @@ public class PermissionUtils {
             case PermissionConstants.PERMISSION_GROUP_SYSTEM_ALERT_WINDOW:
                 if (hasPermissionInManifest(context, permissionNames, Manifest.permission.SYSTEM_ALERT_WINDOW ))
                     permissionNames.add(Manifest.permission.SYSTEM_ALERT_WINDOW);
+                break;
+
+            case PermissionConstants.PERMISSION_GROUP_REQUEST_INSTALL_PACKAGES:
+                // The REQUEST_INSTALL_PACKAGES permission is introduced in Android M, meaning we should
+                // not handle permissions on pre Android M devices.
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && hasPermissionInManifest(context, permissionNames, Manifest.permission.REQUEST_INSTALL_PACKAGES ))
+                    permissionNames.add(Manifest.permission.REQUEST_INSTALL_PACKAGES);
                 break;
 
             case PermissionConstants.PERMISSION_GROUP_NOTIFICATION:

--- a/permission_handler/example/android/app/src/main/AndroidManifest.xml
+++ b/permission_handler/example/android/app/src/main/AndroidManifest.xml
@@ -69,6 +69,9 @@
     <!-- Permissions options for the `system alert windows` group -->
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
 
+    <!-- Permissions options for the `request install packages` group -->
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+
     <application
         android:name="io.flutter.app.FlutterApplication"
         android:icon="@mipmap/ic_launcher"

--- a/permission_handler/example/lib/main.dart
+++ b/permission_handler/example/lib/main.dart
@@ -43,11 +43,13 @@ class _PermissionHandlerWidgetState extends State<PermissionHandlerWidget> {
                       permission != Permission.accessMediaLocation &&
                       permission != Permission.activityRecognition &&
                       permission != Permission.manageExternalStorage &&
-                      permission != Permission.systemAlertWindow;
+                      permission != Permission.systemAlertWindow &&
+                      permission != Permission.requestInstallPackages;
                 } else {
                   return permission != Permission.unknown &&
                       permission != Permission.mediaLibrary &&
                       permission != Permission.photos &&
+                      permission != Permission.photosAddOnly &&
                       permission != Permission.reminders;
                 }
               })

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-version: 7.1.1
+version: 7.2.0
 homepage: https://github.com/baseflowit/flutter-permission-handler
 
 flutter:
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
-  permission_handler_platform_interface: ^3.3.0
+  permission_handler_platform_interface: ^3.4.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Added the "REQUEST_INSTALL_PACKAGES" permission.

### :arrow_heading_down: What is the current behavior?

Allows an application to request installing packages (permission will open an intent where the user can grant the permission)

### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

Issue [#508](https://github.com/Baseflow/flutter-permission-handler/issues/508)  - Requesting the permission
Issue [#319](https://github.com/Baseflow/flutter-permission-handler/issues/319) - Requesting the permission
Android documentation - [REQUEST_INSTALL_PACKAGES](https://developer.android.com/reference/android/Manifest.permission#REQUEST_INSTALL_PACKAGES) 
StackOverflow - [Extra information](https://stackoverflow.com/a/49828751/14542829) 

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
