### PR TITLE
Added AppTrackingTransparency permission

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,5 +1,7 @@
-## 7.3.0
+## 8.0.0
 
+This release contains the following **breaking changes**: 
+* Starting from this version the permissions on iOS are disabled by default. To enable a permission, specify the correct `GCC_PREPROCESSOR_DEFINITIONS` in the `ios/Podfile` file. For an example check out the [Podfile](example/ios/Podfile) of the example application. 
 * Added support for the "AppTrackingTransparency" permission on iOS.
 
 ## 7.2.0

--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.3.0
+
+* Added support for the "AppTrackingTransparency" permission on iOS.
+
 ## 7.2.0
 
 * Added support for the "REQUEST_INSTALL_PACKAGES" permission on Android.

--- a/permission_handler/README.md
+++ b/permission_handler/README.md
@@ -52,9 +52,9 @@ Add permission to your `Info.plist` file.
 
 > IMPORTANT: ~~You will have to include all permission options when you want to submit your App.~~ This is because the `permission_handler` plugin touches all different SDKs and because the static code analyser (run by Apple upon App submission) detects this and will assert if it cannot find a matching permission option in the `Info.plist`. More information about this can be found [here](https://github.com/BaseflowIT/flutter-permission-handler/issues/26).
 
-The <kbd>permission_handler</kbd> plugin use [macros](https://github.com/BaseflowIT/flutter-permission-handler/blob/develop/permission_handler/ios/Classes/PermissionHandlerEnums.h) to control whether a permission is supported.
+The <kbd>permission_handler</kbd> plugin use [macros](https://github.com/BaseflowIT/flutter-permission-handler/blob/develop/permission_handler/ios/Classes/PermissionHandlerEnums.h) to control whether a permission is enabled.
 
-You can remove permissions you don't use:
+You must list permission you want to use in your application :
 
 1. Add the following to your `Podfile` file:
    ```ruby
@@ -70,67 +70,72 @@ You can remove permissions you don't use:
            '$(inherited)',
   
            ## dart: PermissionGroup.calendar
-           # 'PERMISSION_EVENTS=0',
+           # 'PERMISSION_EVENTS=1',
   
            ## dart: PermissionGroup.reminders
-           # 'PERMISSION_REMINDERS=0',
+           # 'PERMISSION_REMINDERS=1',
   
            ## dart: PermissionGroup.contacts
-           # 'PERMISSION_CONTACTS=0',
+           # 'PERMISSION_CONTACTS=1',
   
            ## dart: PermissionGroup.camera
-           # 'PERMISSION_CAMERA=0',
+           # 'PERMISSION_CAMERA=1',
   
            ## dart: PermissionGroup.microphone
-           # 'PERMISSION_MICROPHONE=0',
+           # 'PERMISSION_MICROPHONE=1',
   
            ## dart: PermissionGroup.speech
-           # 'PERMISSION_SPEECH_RECOGNIZER=0',
+           # 'PERMISSION_SPEECH_RECOGNIZER=1',
   
            ## dart: PermissionGroup.photos
-           # 'PERMISSION_PHOTOS=0',
+           # 'PERMISSION_PHOTOS=1',
   
            ## dart: [PermissionGroup.location, PermissionGroup.locationAlways, PermissionGroup.locationWhenInUse]
-           # 'PERMISSION_LOCATION=0',
+           # 'PERMISSION_LOCATION=1',
           
            ## dart: PermissionGroup.notification
-           # 'PERMISSION_NOTIFICATIONS=0',
+           # 'PERMISSION_NOTIFICATIONS=1',
   
            ## dart: PermissionGroup.mediaLibrary
-           # 'PERMISSION_MEDIA_LIBRARY=0',
+           # 'PERMISSION_MEDIA_LIBRARY=1',
   
            ## dart: PermissionGroup.sensors
-           # 'PERMISSION_SENSORS=0',   
+           # 'PERMISSION_SENSORS=1',   
            
            ## dart: PermissionGroup.bluetooth
-           # 'PERMISSION_BLUETOOTH=0'
+           # 'PERMISSION_BLUETOOTH=1',
+   
+           ## dart: PermissionGroup.appTrackingTransparency
+           # 'PERMISSION_APP_TRACKING_TRANSPARENCY=1'
          ]
   
        end
      end
    end
    ```
-2. Remove the `#` character in front of the permission you do not want to use. For example if you don't need access to the calendar make sure the code looks like this:
+2. Remove the `#` character in front of the permission you do want to use. For example if you need access to the calendar make sure the code looks like this:
    ```ruby
            ## dart: PermissionGroup.calendar
-           'PERMISSION_EVENTS=0',
+           'PERMISSION_EVENTS=1',
    ```
 3. Delete the corresponding permission description in `Info.plist`
    e.g. when you don't need camera permission, just delete 'NSCameraUsageDescription'
    The following lists the relationship between `Permission` and `The key of Info.plist`:
-   | Permission                                                                                  | Info.plist                                                                                                    | Macro                        |
-   | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ---------------------------- |
-   | PermissionGroup.calendar                                                                    | NSCalendarsUsageDescription                                                                                   | PERMISSION_EVENTS            |
-   | PermissionGroup.reminders                                                                   | NSRemindersUsageDescription                                                                                   | PERMISSION_REMINDERS         |
-   | PermissionGroup.contacts                                                                    | NSContactsUsageDescription                                                                                    | PERMISSION_CONTACTS          |
-   | PermissionGroup.camera                                                                      | NSCameraUsageDescription                                                                                      | PERMISSION_CAMERA            |
-   | PermissionGroup.microphone                                                                  | NSMicrophoneUsageDescription                                                                                  | PERMISSION_MICROPHONE        |
-   | PermissionGroup.speech                                                                      | NSSpeechRecognitionUsageDescription                                                                           | PERMISSION_SPEECH_RECOGNIZER |
-   | PermissionGroup.photos                                                                      | NSPhotoLibraryUsageDescription                                                                                | PERMISSION_PHOTOS            |
-   | PermissionGroup.location, PermissionGroup.locationAlways, PermissionGroup.locationWhenInUse | NSLocationUsageDescription, NSLocationAlwaysAndWhenInUseUsageDescription, NSLocationWhenInUseUsageDescription | PERMISSION_LOCATION          |
-   | PermissionGroup.notification                                                                | PermissionGroupNotification                                                                                   | PERMISSION_NOTIFICATIONS     |
-   | PermissionGroup.mediaLibrary                                                                | NSAppleMusicUsageDescription, kTCCServiceMediaLibrary                                                         | PERMISSION_MEDIA_LIBRARY     |
-   | PermissionGroup.sensors                                                                     | NSMotionUsageDescription                                                                                      | PERMISSION_SENSORS           |
+   | Permission                                                                                  | Info.plist                                                                                                    | Macro                                |
+   | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+   | PermissionGroup.calendar                                                                    | NSCalendarsUsageDescription                                                                                   | PERMISSION_EVENTS                    |
+   | PermissionGroup.reminders                                                                   | NSRemindersUsageDescription                                                                                   | PERMISSION_REMINDERS                 |
+   | PermissionGroup.contacts                                                                    | NSContactsUsageDescription                                                                                    | PERMISSION_CONTACTS                  |
+   | PermissionGroup.camera                                                                      | NSCameraUsageDescription                                                                                      | PERMISSION_CAMERA                    |
+   | PermissionGroup.microphone                                                                  | NSMicrophoneUsageDescription                                                                                  | PERMISSION_MICROPHONE                |
+   | PermissionGroup.speech                                                                      | NSSpeechRecognitionUsageDescription                                                                           | PERMISSION_SPEECH_RECOGNIZER         |
+   | PermissionGroup.photos                                                                      | NSPhotoLibraryUsageDescription                                                                                | PERMISSION_PHOTOS                    |
+   | PermissionGroup.location, PermissionGroup.locationAlways, PermissionGroup.locationWhenInUse | NSLocationUsageDescription, NSLocationAlwaysAndWhenInUseUsageDescription, NSLocationWhenInUseUsageDescription | PERMISSION_LOCATION                  |
+   | PermissionGroup.notification                                                                | PermissionGroupNotification                                                                                   | PERMISSION_NOTIFICATIONS             |
+   | PermissionGroup.mediaLibrary                                                                | NSAppleMusicUsageDescription, kTCCServiceMediaLibrary                                                         | PERMISSION_MEDIA_LIBRARY             |
+   | PermissionGroup.sensors                                                                     | NSMotionUsageDescription                                                                                      | PERMISSION_SENSORS                   |
+   | PermissionGroup.bluetooth                                                                   | NSBluetoothAlwaysUsageDescription, NSBluetoothPeripheralUsageDescription                                      | PERMISSION_BLUETOOTH                 |
+   | PermissionGroup.appTrackingTransparency                                                     | NSUserTrackingUsageDescription                                                                                | PERMISSION_APP_TRACKING_TRANSPARENCY |   
 4. Clean & Rebuild
 
 </details>

--- a/permission_handler/example/ios/Podfile
+++ b/permission_handler/example/ios/Podfile
@@ -46,37 +46,43 @@ post_install do |installer|
         '$(inherited)',
 
         ## dart: PermissionGroup.calendar
-        # 'PERMISSION_EVENTS=0',
+        'PERMISSION_EVENTS=1',
 
         ## dart: PermissionGroup.reminders
-        # 'PERMISSION_REMINDERS=0',
+        'PERMISSION_REMINDERS=1',
 
         ## dart: PermissionGroup.contacts
-        # 'PERMISSION_CONTACTS=0',
+        'PERMISSION_CONTACTS=1',
 
         ## dart: PermissionGroup.camera
-        # 'PERMISSION_CAMERA=0',
+        'PERMISSION_CAMERA=1',
 
         ## dart: PermissionGroup.microphone
-        # 'PERMISSION_MICROPHONE=0',
+        'PERMISSION_MICROPHONE=1',
 
         ## dart: PermissionGroup.speech
-        # 'PERMISSION_SPEECH_RECOGNIZER=0',
+        'PERMISSION_SPEECH_RECOGNIZER=1',
 
         ## dart: PermissionGroup.photos
-        #'PERMISSION_PHOTOS=0'
+        'PERMISSION_PHOTOS=1',
 
         ## dart: [PermissionGroup.location, PermissionGroup.locationAlways, PermissionGroup.locationWhenInUse]
-        # 'PERMISSION_LOCATION=0',
+        'PERMISSION_LOCATION=1',
        
         ## dart: PermissionGroup.notification
-        # 'PERMISSION_NOTIFICATIONS=0',
+        'PERMISSION_NOTIFICATIONS=1',
 
         ## dart: PermissionGroup.mediaLibrary
-        # 'PERMISSION_MEDIA_LIBRARY=0',
+        'PERMISSION_MEDIA_LIBRARY=1',
 
         ## dart: PermissionGroup.sensors
-        # 'PERMISSION_SENSORS=0'
+        'PERMISSION_SENSORS=1',
+
+        ## dart: PermissionGroup.bluetooth
+        'PERMISSION_BLUETOOTH=1',
+
+        ## dart: PermissionGroup.appTrackingTransparency
+        'PERMISSION_APP_TRACKING_TRANSPARENCY=1'
       ]
 
     end

--- a/permission_handler/example/ios/Runner/Info.plist
+++ b/permission_handler/example/ios/Runner/Info.plist
@@ -41,35 +41,63 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>Need location when in use</string>
-	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-	<string>Always and when in use!</string>
-	<key>NSLocationUsageDescription</key>
-	<string>Older devices need location.</string>
-	<key>NSLocationAlwaysUsageDescription</key>
-	<string>Can I have location always?</string>
-	<key>NSAppleMusicUsageDescription</key>
-	<string>Music!</string>
-	<key>kTCCServiceMediaLibrary</key>
-	<string>media</string>
-	<key>NSCalendarsUsageDescription</key>
-	<string>Calendars</string>
-	<key>NSCameraUsageDescription</key>
-	<string>camera</string>
-	<key>NSContactsUsageDescription</key>
-	<string>contacts</string>
-	<key>NSMicrophoneUsageDescription</key>
-	<string>microphone</string>
-	<key>NSSpeechRecognitionUsageDescription</key>
-	<string>speech</string>
-	<key>NSMotionUsageDescription</key>
-	<string>motion</string>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>photos</string>
-	<key>NSRemindersUsageDescription</key>
-	<string>reminders</string>
-	<key>NSUserTrackingUsageDescription</key>
-	<string>appTrackingTransparency</string>
+
+	<!-- Permission options for the `location` group -->
+    <key>NSLocationWhenInUseUsageDescription</key>
+    <string>Need location when in use</string>
+    <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+    <string>Always and when in use!</string>
+    <key>NSLocationUsageDescription</key>
+    <string>Older devices need location.</string>
+    <key>NSLocationAlwaysUsageDescription</key>
+    <string>Can I have location always?</string>
+
+    <!-- Permission options for the `mediaLibrary` group -->
+    <key>NSAppleMusicUsageDescription</key>
+    <string>Music!</string>
+    <key>kTCCServiceMediaLibrary</key>
+    <string>media</string>
+
+    <!-- Permission options for the `calendar` group -->
+    <key>NSCalendarsUsageDescription</key>
+    <string>Calendars</string>
+
+    <!-- Permission options for the `camera` group -->
+    <key>NSCameraUsageDescription</key>
+    <string>camera</string>
+
+    <!-- Permission options for the `contacts` group -->
+    <key>NSContactsUsageDescription</key>
+    <string>contacts</string>
+
+    <!-- Permission options for the `microphone` group -->
+    <key>NSMicrophoneUsageDescription</key>
+    <string>microphone</string>
+
+    <!-- Permission options for the `speech` group -->
+    <key>NSSpeechRecognitionUsageDescription</key>
+    <string>speech</string>
+
+    <!-- Permission options for the `sensors` group -->
+    <key>NSMotionUsageDescription</key>
+    <string>motion</string>
+
+    <!-- Permission options for the `photos` group -->
+    <key>NSPhotoLibraryUsageDescription</key>
+    <string>photos</string>
+
+    <!-- Permission options for the `reminder` group -->
+    <key>NSRemindersUsageDescription</key>
+    <string>reminders</string>
+
+    <!-- Permission options for the `bluetooth` -->
+    <key>NSBluetoothAlwaysUsageDescription</key>
+    <string>bluetooth</string>
+    <key>NSBluetoothPeripheralUsageDescription</key>
+    <string>bluetooth</string>
+
+    <!-- Permission options for the `appTrackingTransparency` -->
+    <key>NSUserTrackingUsageDescription</key>
+    <string>appTrackingTransparency</string>
 </dict>
 </plist>

--- a/permission_handler/example/ios/Runner/Info.plist
+++ b/permission_handler/example/ios/Runner/Info.plist
@@ -41,54 +41,35 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-
-	<!-- Permission options for the `location` group -->
-    <key>NSLocationWhenInUseUsageDescription</key>
-    <string>Need location when in use</string>
-    <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-    <string>Always and when in use!</string>
-    <key>NSLocationUsageDescription</key>
-    <string>Older devices need location.</string>
-    <key>NSLocationAlwaysUsageDescription</key>
-    <string>Can I have location always?</string>
-
-    <!-- Permission options for the `mediaLibrary` group -->
-    <key>NSAppleMusicUsageDescription</key>
-    <string>Music!</string>
-    <key>kTCCServiceMediaLibrary</key>
-    <string>media</string>
-
-    <!-- Permission options for the `calendar` group -->
-    <key>NSCalendarsUsageDescription</key>
-    <string>Calendars</string>
-
-    <!-- Permission options for the `camera` group -->
-    <key>NSCameraUsageDescription</key>
-    <string>camera</string>
-
-    <!-- Permission options for the `contacts` group -->
-    <key>NSContactsUsageDescription</key>
-    <string>contacts</string>
-
-    <!-- Permission options for the `microphone` group -->
-    <key>NSMicrophoneUsageDescription</key>
-    <string>microphone</string>
-
-    <!-- Permission options for the `speech` group -->
-    <key>NSSpeechRecognitionUsageDescription</key>
-    <string>speech</string>
-
-    <!-- Permission options for the `sensors` group -->
-    <key>NSMotionUsageDescription</key>
-    <string>motion</string>
-
-    <!-- Permission options for the `photos` group -->
-    <key>NSPhotoLibraryUsageDescription</key>
-    <string>photos</string>
-
-    <!-- Permission options for the `reminder` group -->
-    <key>NSRemindersUsageDescription</key>
-    <string>reminders</string>
-
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Need location when in use</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Always and when in use!</string>
+	<key>NSLocationUsageDescription</key>
+	<string>Older devices need location.</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>Can I have location always?</string>
+	<key>NSAppleMusicUsageDescription</key>
+	<string>Music!</string>
+	<key>kTCCServiceMediaLibrary</key>
+	<string>media</string>
+	<key>NSCalendarsUsageDescription</key>
+	<string>Calendars</string>
+	<key>NSCameraUsageDescription</key>
+	<string>camera</string>
+	<key>NSContactsUsageDescription</key>
+	<string>contacts</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>microphone</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>speech</string>
+	<key>NSMotionUsageDescription</key>
+	<string>motion</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>photos</string>
+	<key>NSRemindersUsageDescription</key>
+	<string>reminders</string>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>appTrackingTransparency</string>
 </dict>
 </plist>

--- a/permission_handler/example/lib/main.dart
+++ b/permission_handler/example/lib/main.dart
@@ -50,7 +50,8 @@ class _PermissionHandlerWidgetState extends State<PermissionHandlerWidget> {
                       permission != Permission.mediaLibrary &&
                       permission != Permission.photos &&
                       permission != Permission.photosAddOnly &&
-                      permission != Permission.reminders;
+                      permission != Permission.reminders &&
+                      permission != Permission.appTrackingTransparency;
                 }
               })
               .map((permission) => PermissionWidget(permission))

--- a/permission_handler/ios/Classes/PermissionHandlerEnums.h
+++ b/permission_handler/ios/Classes/PermissionHandlerEnums.h
@@ -9,97 +9,97 @@
 // Info.plist: NSCalendarsUsageDescription
 // dart: PermissionGroup.calendar
 #ifndef PERMISSION_EVENTS
-    #define PERMISSION_EVENTS 1
+    #define PERMISSION_EVENTS 0
 #endif
 
 // ios: PermissionGroupReminders
 // Info.plist: NSRemindersUsageDescription
 // dart: PermissionGroup.reminders
 #ifndef PERMISSION_REMINDERS
-    #define PERMISSION_REMINDERS 1
+    #define PERMISSION_REMINDERS 0
 #endif
 
 // ios: PermissionGroupContacts
 // Info.plist: NSContactsUsageDescription
 // dart: PermissionGroup.contacts
 #ifndef PERMISSION_CONTACTS
-    #define PERMISSION_CONTACTS 1
+    #define PERMISSION_CONTACTS 0
 #endif
 
 // ios: PermissionGroupCamera
 // Info.plist: NSCameraUsageDescription
 // dart: PermissionGroup.camera
 #ifndef PERMISSION_CAMERA
-    #define PERMISSION_CAMERA 1
+    #define PERMISSION_CAMERA 0
 #endif
 
 // ios: PermissionGroupMicrophone
 // Info.plist: NSMicrophoneUsageDescription
 // dart: PermissionGroup.microphone
 #ifndef PERMISSION_MICROPHONE
-    #define PERMISSION_MICROPHONE 1
+    #define PERMISSION_MICROPHONE 0
 #endif
 
 // ios: PermissionGroupSpeech
 // Info.plist: NSSpeechRecognitionUsageDescription
 // dart: PermissionGroup.speech
 #ifndef PERMISSION_SPEECH_RECOGNIZER
-    #define PERMISSION_SPEECH_RECOGNIZER 1
+    #define PERMISSION_SPEECH_RECOGNIZER 0
 #endif
 
 // ios: PermissionGroupPhotos
 // Info.plist: NSPhotoLibraryUsageDescription
 // dart: PermissionGroup.photos
 #ifndef PERMISSION_PHOTOS
-    #define PERMISSION_PHOTOS 1
+    #define PERMISSION_PHOTOS 0
 #endif
 
 // ios: PermissionGroupPhotosAddOnly
 // Info.plist: NSPhotoLibraryUsageDescription
 // dart: PermissionGroup.photosAddOnly
 #ifndef PERMISSION_PHOTOS_ADD_ONLY
-    #define PERMISSION_PHOTOS_ADD_ONLY 1
+    #define PERMISSION_PHOTOS_ADD_ONLY 0
 #endif
 
 // ios: [PermissionGroupLocation, PermissionGroupLocationAlways, PermissionGroupLocationWhenInUse]
 // Info.plist: [NSLocationUsageDescription, NSLocationAlwaysAndWhenInUseUsageDescription, NSLocationWhenInUseUsageDescription]
 // dart: [PermissionGroup.location, PermissionGroup.locationAlways, PermissionGroup.locationWhenInUse]
 #ifndef PERMISSION_LOCATION
-    #define PERMISSION_LOCATION 1
+    #define PERMISSION_LOCATION 0
 #endif
 
 // ios: PermissionGroupNotification
 // dart: PermissionGroup.notification
 #ifndef PERMISSION_NOTIFICATIONS
-    #define PERMISSION_NOTIFICATIONS 1
+    #define PERMISSION_NOTIFICATIONS 0
 #endif
 
 // ios: PermissionGroupMediaLibrary
 // Info.plist: [NSAppleMusicUsageDescription, kTCCServiceMediaLibrary]
 // dart: PermissionGroup.mediaLibrary
 #ifndef PERMISSION_MEDIA_LIBRARY
-    #define PERMISSION_MEDIA_LIBRARY 1
+    #define PERMISSION_MEDIA_LIBRARY 0
 #endif
 
 // ios: PermissionGroupSensors
 // Info.plist: NSMotionUsageDescription
 // dart: PermissionGroup.sensors
 #ifndef PERMISSION_SENSORS
-    #define PERMISSION_SENSORS 1
+    #define PERMISSION_SENSORS 0
 #endif
 
 // ios: PermissionGroupBluetooth
 // Info.plist: [NSBluetoothAlwaysUsageDescription, NSBluetoothPeripheralUsageDescription]
 // dart: PermissionGroup.bluetooth
 #ifndef PERMISSION_BLUETOOTH
-    #define PERMISSION_BLUETOOTH 1
+    #define PERMISSION_BLUETOOTH 0
 #endif
 
 // ios: PermissionGroupAppTrackingTransparency
 // Info.plist: [NSUserTrackingUsageDescription]
 // dart: PermissionGroup.appTrackingTransparency
 #ifndef PERMISSION_APP_TRACKING_TRANSPARENCY
-    #define PERMISSION_APP_TRACKING_TRANSPARENCY 1
+    #define PERMISSION_APP_TRACKING_TRANSPARENCY 0
 #endif
 
 typedef NS_ENUM(int, PermissionGroup) {

--- a/permission_handler/ios/Classes/PermissionHandlerEnums.h
+++ b/permission_handler/ios/Classes/PermissionHandlerEnums.h
@@ -95,6 +95,13 @@
     #define PERMISSION_BLUETOOTH 1
 #endif
 
+// ios: PermissionGroupAppTrackingTransparency
+// Info.plist: [NSUserTrackingUsageDescription]
+// dart: PermissionGroup.appTrackingTransparency
+#ifndef PERMISSION_APP_TRACKING_TRANSPARENCY
+    #define PERMISSION_APP_TRACKING_TRANSPARENCY 1
+#endif
+
 typedef NS_ENUM(int, PermissionGroup) {
     PermissionGroupCalendar = 0,
     PermissionGroupCamera,
@@ -119,7 +126,9 @@ typedef NS_ENUM(int, PermissionGroup) {
     PermissionGroupUnknown,
     PermissionGroupBluetooth,
     PermissionGroupManageExternalStorage,
-    PermissionGroupSystemAlertWindow
+    PermissionGroupSystemAlertWindow,
+    PermissionGroupRequestInstallPackages,
+    PermissionGroupAppTrackingTransparency
 };
 
 typedef NS_ENUM(int, PermissionStatus) {

--- a/permission_handler/ios/Classes/PermissionManager.h
+++ b/permission_handler/ios/Classes/PermissionManager.h
@@ -10,6 +10,7 @@
 #import <UIKit/UIKit.h>
 
 #import "AudioVideoPermissionStrategy.h"
+#import "AppTrackingTransparencyPermissionStrategy.h"
 #import "BluetoothPermissionStrategy.h"
 #import "ContactPermissionStrategy.h"
 #import "EventPermissionStrategy.h"

--- a/permission_handler/ios/Classes/PermissionManager.m
+++ b/permission_handler/ios/Classes/PermissionManager.m
@@ -125,6 +125,8 @@
             return [StoragePermissionStrategy new];
         case PermissionGroupBluetooth:
             return [BluetoothPermissionStrategy new];
+        case PermissionGroupAppTrackingTransparency:
+            return [AppTrackingTransparencyPermissionStrategy new];
         default:
             return [UnknownPermissionStrategy new];
     }

--- a/permission_handler/ios/Classes/strategies/AppTrackingTransparencyPermissionStrategy.h
+++ b/permission_handler/ios/Classes/strategies/AppTrackingTransparencyPermissionStrategy.h
@@ -1,0 +1,25 @@
+//
+//  AppTrackingTransparency.h
+//  permission_handler
+//
+//  Created by Jan-Derk on 21/05/2021.
+//
+
+#import <Foundation/Foundation.h>
+#import "PermissionStrategy.h"
+
+#if PERMISSION_APP_TRACKING_TRANSPARENCY
+
+#import <AppTrackingTransparency/AppTrackingTransparency.h>
+
+@interface AppTrackingTransparencyPermissionStrategy : NSObject <PermissionStrategy>
+@end
+
+#else
+
+#import "UnknownPermissionStrategy.h"
+
+@interface AppTrackingTransparencyPermissionStrategy : UnknownPermissionStrategy
+@end
+
+#endif

--- a/permission_handler/ios/Classes/strategies/AppTrackingTransparencyPermissionStrategy.m
+++ b/permission_handler/ios/Classes/strategies/AppTrackingTransparencyPermissionStrategy.m
@@ -1,0 +1,64 @@
+//
+//  AppTrackingTransparency.m
+//  permission_handler
+//
+//  Created by Jan-Derk on 21/05/2021.
+//
+
+#import "AppTrackingTransparencyPermissionStrategy.h"
+
+#if PERMISSION_APP_TRACKING_TRANSPARENCY
+
+@implementation AppTrackingTransparencyPermissionStrategy
+
+- (PermissionStatus)checkPermissionStatus:(PermissionGroup)permission {
+    if (@available(iOS 14, *)) {
+        ATTrackingManagerAuthorizationStatus attPermission = [ATTrackingManager trackingAuthorizationStatus];
+        return [AppTrackingTransparencyPermissionStrategy parsePermission:attPermission];
+    }
+    
+    return PermissionStatusGranted;
+}
+
+- (ServiceStatus)checkServiceStatus:(PermissionGroup)permission {
+    return ServiceStatusNotApplicable;
+}
+
+- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {
+    PermissionStatus status = [self checkPermissionStatus:permission];
+    if (status != PermissionStatusDenied) {
+        completionHandler(status);
+        return;
+    }
+    
+    if (@available(iOS 14, *)){
+        [ATTrackingManager requestTrackingAuthorizationWithCompletionHandler:^(ATTrackingManagerAuthorizationStatus status) {
+            PermissionStatus permissionStatus = [AppTrackingTransparencyPermissionStrategy parsePermission:status];
+            completionHandler(permissionStatus);
+        }];
+    } else {
+        completionHandler(PermissionStatusGranted);
+    }
+}
+
++ (PermissionStatus)parsePermission:(ATTrackingManagerAuthorizationStatus)attPermission API_AVAILABLE(ios(14)){
+    switch(attPermission){
+        case ATTrackingManagerAuthorizationStatusAuthorized:
+            return PermissionStatusGranted;
+        case ATTrackingManagerAuthorizationStatusRestricted:
+            return PermissionStatusRestricted;
+        case ATTrackingManagerAuthorizationStatusDenied:
+            return PermissionStatusPermanentlyDenied;
+        case ATTrackingManagerAuthorizationStatusNotDetermined:
+            return PermissionStatusDenied;
+    }
+}
+@end
+
+#else
+
+@implementation AppTrackingTransparencyPermissionStrategy
+@end
+
+#endif
+

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-version: 7.2.0
+version: 7.3.0
 homepage: https://github.com/baseflowit/flutter-permission-handler
 
 flutter:
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
-  permission_handler_platform_interface: ^3.4.0
+  permission_handler_platform_interface: ^3.5.0
 
 dev_dependencies:
   flutter_test:

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-version: 7.3.0
+version: 8.0.0
 homepage: https://github.com/baseflowit/flutter-permission-handler
 
 flutter:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Added AppTrackingTransparency permission for iOS.

### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?

User can ask for the AppTrackingTransparency

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

issue #375 

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
