### PR TITLE
Fix broken Podfile link

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## 8.0.0
 
 This release contains the following **breaking changes**: 
-* Starting from this version the permissions on iOS are disabled by default. To enable a permission, specify the correct `GCC_PREPROCESSOR_DEFINITIONS` in the `ios/Podfile` file. For an example check out the [Podfile](example/ios/Podfile) of the example application. 
+* Starting from this version the permissions on iOS are disabled by default. To enable a permission, specify the correct `GCC_PREPROCESSOR_DEFINITIONS` in the `ios/Podfile` file. For an example check out the [Podfile](permission_handler/example/ios/Podfile) of the example application. 
 * Added support for the "AppTrackingTransparency" permission on iOS.
 
 ## 7.2.0

--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 8.0.0+2
+
+* Fix broken Podfile link noted at `8.0.0`.
+* Fix the information link noted at [Podfile](permission_handler/example/ios/Podfile).
+
 ## 8.0.0+1
 
 * Updated the README.md setup section about the Podfile and changed a minor spelling mistake.

--- a/permission_handler/README.md
+++ b/permission_handler/README.md
@@ -69,7 +69,7 @@ You must list permission you want to use in your application :
          # ## dart: PermissionGroup.camera
          # 'PERMISSION_CAMERA=1'
          #
-         #  Preprocessor definitions can be found in: https://github.com/Baseflow/flutter-permission-handler/blob/develop/permission_handler/ios/Classes/PermissionHandlerEnums.h
+         #  Preprocessor definitions can be found in: https://github.com/Baseflow/flutter-permission-handler/blob/master/permission_handler/ios/Classes/PermissionHandlerEnums.h
          config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [
            '$(inherited)',
   

--- a/permission_handler/example/ios/Podfile
+++ b/permission_handler/example/ios/Podfile
@@ -40,7 +40,7 @@ post_install do |installer|
 
     target.build_configurations.each do |config|
       # You can remove unused permissions here
-      # for more infomation: https://github.com/BaseflowIT/flutter-permission-handler/blob/develop/permission_handler/ios/Classes/PermissionHandlerEnums.h
+      # for more infomation: https://github.com/BaseflowIT/flutter-permission-handler/blob/master/permission_handler/ios/Classes/PermissionHandlerEnums.h
       # e.g. when you don't need camera permission, just add 'PERMISSION_CAMERA=0'
       config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [
         '$(inherited)',

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-version: 8.0.0+1
+version: 8.0.0+2
 homepage: https://github.com/baseflowit/flutter-permission-handler
 
 flutter:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

docs update.

### :arrow_heading_down: What is the current behavior?

`Podfile` link at https://pub.dev/packages/permission_handler/changelog#800 is broken.

### :new: What is the new behavior (if this is a feature change)?

Fix the link.

### :boom: Does this PR introduce a breaking change?

No.

### :bug: Recommendations for testing

No.

### :memo: Links to relevant issues/docs

- https://pub.dev/packages/permission_handler/changelog#800

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
