### PR TITLE
Update API doc on permanentlyDenied status

### DIFF
--- a/permission_handler_platform_interface/CHANGELOG.md
+++ b/permission_handler_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.1
+
+* Updated API documentation for the `PermissionStatus.permanentlyDenied` status.
+
 ## 3.5.0
 
 * Added support for app tracking transparency permission.

--- a/permission_handler_platform_interface/lib/src/permission_status.dart
+++ b/permission_handler_platform_interface/lib/src/permission_status.dart
@@ -18,10 +18,9 @@ enum PermissionStatus {
   /// *Only supported on iOS (iOS14+).*
   limited,
 
-  /// The user denied access to the requested feature and selected to never
-  /// again show a request for this permission. The user may still change the
-  /// permission status in the settings.
-  /// *Only supported on Android.*
+  /// Permission to the requested feature is permanently denied, the permission
+  /// dialog will not be shown when requesting this permission. The user may
+  /// still change the permission status in the settings.
   permanentlyDenied,
 }
 

--- a/permission_handler_platform_interface/pubspec.yaml
+++ b/permission_handler_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the permission_handler plugin.
 homepage: https://github.com/baseflow/flutter-permission-handler/tree/master/permission_handler_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 3.5.0
+version: 3.5.1
 
 dependencies:
   flutter:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Documentation update

### :arrow_heading_down: What is the current behavior?

Current documentation suggests the `PermissionStatus.permanentlyDenied` status is only used on Android.

### :new: What is the new behavior (if this is a feature change)?

Since version 6.0.0 the `PermissionStatus.permanentlyDenied` status is used on all platforms and the documentation should reflect this.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

n/a

### :memo: Links to relevant issues/docs

- #574

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
