### PR TITLE
Update API doc on permanentlyDenied status

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,3 @@ The Flutter permission_handler plugin is build following the federated plugin ar
 [2]: ./permission_handler/README.md
 [3]: ./permission_handler_platform_interface
 [4]: ./permission_handler_platform_interface/README.md
-

--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.0.1
+
+* Updated API documentation for the `PermissionStatus.permanentlyDenied` status.
+
 ## 8.0.0+2
 
 * Fix broken Podfile link noted at `8.0.0`.

--- a/permission_handler/lib/permission_handler.dart
+++ b/permission_handler/lib/permission_handler.dart
@@ -22,10 +22,6 @@ Future<bool> openAppSettings() => _handler.openAppSettings();
 /// Actions that can be executed on a permission.
 extension PermissionActions on Permission {
   /// The current status of this permission.
-  ///
-  /// The Android-only [PermissionStatus.permanentlyDenied] status will only be
-  /// calculated if the active context is an Activity. If it isn't,
-  /// [PermissionStatus.denied] will be returned.
   Future<PermissionStatus> get status => _handler.checkPermissionStatus(this);
 
   /// If you should show a rationale for requesting permission.
@@ -64,14 +60,15 @@ extension PermissionCheckShortcuts on Permission {
   /// *Only supported on iOS.*
   Future<bool> get isRestricted => status.isRestricted;
 
-  ///User has authorized this application for limited photo library access.
+  /// User has authorized this application for limited photo library access.
   /// *Only supported on iOS.(iOS14+)*
   Future<bool> get isLimited => status.isLimited;
 
-  /// If the user denied this permission and selected to never again show a
-  /// request for it. The user may still change the permission's status in the
-  /// device settings.
-  /// *Only supported on Android.*
+  /// Returns `true` when permissions are denied permanently.
+  ///
+  /// When permissions are denied permanently, no new permission dialog will
+  /// be showed to the user. Consuming Apps should redirect the user to the
+  /// App settings to change permissions.
   Future<bool> get isPermanentlyDenied => status.isPermanentlyDenied;
 }
 

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-version: 8.0.0+2
+version: 8.0.1
 homepage: https://github.com/baseflowit/flutter-permission-handler
 
 flutter:
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
-  permission_handler_platform_interface: ^3.5.0
+  permission_handler_platform_interface: ^3.5.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Documentation update

### :arrow_heading_down: What is the current behavior?

Current documentation suggests the `PermissionStatus.permanentlyDenied` status is only used on Android.

### :new: What is the new behavior (if this is a feature change)?

Since version 6.0.0 the `PermissionStatus.permanentlyDenied` status is used on all platforms and the documentation should reflect this.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

n/a

### :memo: Links to relevant issues/docs

- #574

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
