### PR TITLE
Add criticalAlerts for iOS and accessNotificationPolicy for Android

### DIFF
--- a/permission_handler_platform_interface/CHANGELOG.md
+++ b/permission_handler_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.6.0
+
+* Add support for iOS Critical alerts and Android Access Notification Policy.
+
 ## 3.5.1
 
 * Updated API documentation for the `PermissionStatus.permanentlyDenied` status.

--- a/permission_handler_platform_interface/lib/src/permissions.dart
+++ b/permission_handler_platform_interface/lib/src/permissions.dart
@@ -143,6 +143,15 @@ class Permission {
   ///websites.
   static const appTrackingTransparency = Permission._(25);
 
+  ///Android: Nothing
+  ///iOS: Notifications that override your ringer
+  static const criticalAlerts = Permission._(26);
+
+  ///Android: Allows the user to access the notification policy of the phone.
+  /// EX: Allows app to turn on and off do-not-disturb.
+  ///iOS: Nothing
+  static const accessNotificationPolicy = Permission._(27);
+
   /// Returns a list of all possible [PermissionGroup] values.
   static const List<Permission> values = <Permission>[
     calendar,
@@ -170,7 +179,9 @@ class Permission {
     manageExternalStorage,
     systemAlertWindow,
     requestInstallPackages,
-    appTrackingTransparency
+    appTrackingTransparency,
+    criticalAlerts,
+    accessNotificationPolicy,
   ];
 
   static const List<String> _names = <String>[
@@ -199,7 +210,9 @@ class Permission {
     'manageExternalStorage',
     'systemAlertWindow',
     'requestInstallPackages',
-    'appTrackingTransparency'
+    'appTrackingTransparency',
+    'criticalAlerts',
+    'accessNotificationPolicy',
   ];
 
   @override

--- a/permission_handler_platform_interface/pubspec.yaml
+++ b/permission_handler_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the permission_handler plugin.
 homepage: https://github.com/baseflow/flutter-permission-handler/tree/master/permission_handler_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 3.5.1
+version: 3.6.0
 
 dependencies:
   flutter:

--- a/permission_handler_platform_interface/test/src/permissions_test.dart
+++ b/permission_handler_platform_interface/test/src/permissions_test.dart
@@ -6,7 +6,7 @@ void main() {
       () {
     final values = Permission.values;
 
-    expect(values.length, 26);
+    expect(values.length, 28);
   });
 
   test('check if byValue returns corresponding PermissionGroup value', () {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
- Add critical alerts for iOS 
- Add AccessNotificationPolicy on Android


### :boom: Does this PR introduce a breaking change?
Nope

### :bug: Recommendations for testing
Run on Android and test notification policy — iOS see video in other PR

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
