### PR TITLE
Explain isPermanentlyDenied

### DIFF
--- a/permission_handler_platform_interface/lib/src/permission_status.dart
+++ b/permission_handler_platform_interface/lib/src/permission_status.dart
@@ -21,6 +21,7 @@ enum PermissionStatus {
   /// Permission to the requested feature is permanently denied, the permission
   /// dialog will not be shown when requesting this permission. The user may
   /// still change the permission status in the settings.
+  /// *Only supported on Android.*
   permanentlyDenied,
 }
 
@@ -70,6 +71,9 @@ extension PermissionStatusGetters on PermissionStatus {
   /// again show a request for this permission. The user may still change the
   /// permission status in the settings.
   /// *Only supported on Android.*
+  ///
+  /// WARNING: This can only be determined AFTER requesting this permission.
+  /// Therefore make a `request` call first.
   bool get isPermanentlyDenied => this == PermissionStatus.permanentlyDenied;
 
   bool get isLimited => this == PermissionStatus.limited;


### PR DESCRIPTION
Some users (me included) were puzzled when `isPermanentlyDenied` returned `false` even when permission was permanently denied.

