### PR TITLE
Ignore deprecation warnings for code that targets older iOS versions

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.1.2
+
+* Suppress deprecation warnings on iOS for code that specifically targets older iOS versions (see issue [#607](https://github.com/Baseflow/flutter-permission-handler/issues/607)). 
+
 ## 8.1.1
 
 * Fixed deprecation issue when checking phone capabilities on iOS (see issue [#597](https://github.com/Baseflow/flutter-permission-handler/issues/597)).

--- a/permission_handler/ios/Classes/PermissionManager.m
+++ b/permission_handler/ios/Classes/PermissionManager.m
@@ -72,8 +72,11 @@
                                      result([[NSNumber alloc] initWithBool:success]);
                                  }];
     } else if (@available(iOS 8.0, *)) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         BOOL success = [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]];
         result([[NSNumber alloc] initWithBool:success]);
+#pragma clang diagnostic pop
     } else {
         result(@false);    
     }

--- a/permission_handler/ios/Classes/strategies/ContactPermissionStrategy.m
+++ b/permission_handler/ios/Classes/strategies/ContactPermissionStrategy.m
@@ -47,6 +47,8 @@
         }
 
     } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         ABAuthorizationStatus status = ABAddressBookGetAuthorizationStatus();
 
         switch (status) {
@@ -58,6 +60,7 @@
                 return PermissionStatusPermanentlyDenied;
             case kABAuthorizationStatusAuthorized:
                 return PermissionStatusGranted;
+#pragma clang diagnostic pop
         }
     }
 
@@ -77,6 +80,8 @@
 }
 
 + (void)requestPermissionsFromAddressBook:(PermissionStatusHandler)completionHandler {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     ABAddressBookRequestAccessWithCompletion(ABAddressBookCreate(), ^(bool granted, CFErrorRef error) {
         if (granted) {
             completionHandler(PermissionStatusGranted);
@@ -84,6 +89,7 @@
             completionHandler(PermissionStatusPermanentlyDenied);
         }
     });
+#pragma clang diagnostic pop
 }
 @end
 

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-version: 8.1.1
+version: 8.1.2
 homepage: https://github.com/baseflowit/flutter-permission-handler
 
 flutter:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

In some situations users of the plugin run into issues where they cannot compile their App when using the permission_handler plugin due to deprecation warnings. Even though the permission_handler plugin correctly uses the `@available` attribute to run the correct code on the right iOS version/ 

### :new: What is the new behavior (if this is a feature change)?

Added additional lines to ignore deprecation warnings when for code that is specifically available to support older iOS versions.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

-

### :memo: Links to relevant issues/docs

- Fixes #607

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
