### PR TITLE
Issue/604 update meta dependency platform interface

### DIFF
--- a/permission_handler_platform_interface/CHANGELOG.md
+++ b/permission_handler_platform_interface/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.6.1
 
 * Updated `meta` dependency to version `^1.3.0`.
+* Updated documentation for the `locationAlways` permission
 
 ## 3.6.0
 

--- a/permission_handler_platform_interface/CHANGELOG.md
+++ b/permission_handler_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.6.1
+
+* Updated `meta` dependency to version `^1.3.0`.
+
 ## 3.6.0
 
 * Add support for iOS Critical alerts and Android Access Notification Policy.

--- a/permission_handler_platform_interface/lib/src/permissions.dart
+++ b/permission_handler_platform_interface/lib/src/permissions.dart
@@ -39,6 +39,11 @@ class Permission {
   ///   When running on Android < Q: Fine and Coarse Location
   ///   When running on Android Q and above: Background Location Permission
   /// iOS: CoreLocation - Always
+  ///   When requesting this permission the user needs to grant permission
+  ///   for the `locationWhenInUse` permission first, clicking on
+  ///   the `Àllow While Using App` option on the popup.
+  ///   After allowing the permission the user can request the `locationAlways`
+  ///   permission and can click on the `Change To Always Allow` option.
   static const locationAlways = PermissionWithService._(4);
 
   /// Android: Fine and Coarse Location

--- a/permission_handler_platform_interface/pubspec.yaml
+++ b/permission_handler_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the permission_handler plugin.
 homepage: https://github.com/baseflow/flutter-permission-handler/tree/master/permission_handler_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 3.6.0
+version: 3.6.1
 
 dependencies:
   flutter:

--- a/permission_handler_platform_interface/pubspec.yaml
+++ b/permission_handler_platform_interface/pubspec.yaml
@@ -8,7 +8,7 @@ version: 3.6.0
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.0.5
+  meta: ^1.3.0
   plugin_platform_interface: ^2.0.0
 
 dev_dependencies:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Updated the `meta` dependency in the permission_handler_platform_interface to version ^1.3.0.

### :arrow_heading_down: What is the current behavior?

Same as before

### :new: What is the new behavior (if this is a feature change)?

Same as before

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Does not apply

### :memo: Links to relevant issues/docs

Requested in issue #604 

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
