### PR TITLE
Issue/601 location always permission bug

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 8.1.3
+
+* Fix bug where `locationAlways` returns `PermanentlyDenied`;
+* Updated the `README.md` for requesting the `locationAlways` permission the correct way.
+
 ## 8.1.2
 
 * Suppress deprecation warnings on iOS for code that specifically targets older iOS versions (see issue [#607](https://github.com/Baseflow/flutter-permission-handler/issues/607)). 

--- a/permission_handler/README.md
+++ b/permission_handler/README.md
@@ -225,6 +225,10 @@ The following permissions will show no dialog, but will open the corresponding s
 - requestInstallPackages
 - accessNotificationPolicy
 
+The `locationAlways` permission can not be requested directly, the user has to request the `locationWhenInUse` permission first.
+Accepting this permission by clicking on the 'Allow While Using App' gives the user the possibility to request the `locationAlways` permission.
+This will then bring up another permission popup asking you to `Keep Only While Using` or to `Change To Always Allow`.
+
 ## Issues
 
 Please file any issues, bugs or feature request as an issue on our [GitHub](https://github.com/Baseflow/flutter-permission-handler/issues) page. Commercial support is available if you need help with integration with your app or services. You can contact us at [hello@baseflow.com](mailto:hello@baseflow.com).

--- a/permission_handler/ios/Classes/strategies/LocationPermissionStrategy.m
+++ b/permission_handler/ios/Classes/strategies/LocationPermissionStrategy.m
@@ -81,7 +81,11 @@
     if (_permissionStatusHandler == nil || @(_requestedPermission) == nil) {
         return;
     }
-    
+
+    if ((_requestedPermission == PermissionGroupLocationAlways && status == kCLAuthorizationStatusAuthorizedWhenInUse)) {
+            return;
+    }
+
     PermissionStatus permissionStatus = [LocationPermissionStrategy
                                          determinePermissionStatus:_requestedPermission authorizationStatus:status];
     

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-version: 8.1.2
+version: 8.1.3
 homepage: https://github.com/baseflowit/flutter-permission-handler
 
 flutter:

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
-  permission_handler_platform_interface: ^3.6.0
+  permission_handler_platform_interface: ^3.6.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Fixed bug where `locationAlways` returns `permenantlyDenied` everytime

### :arrow_heading_down: What is the current behavior?

`locationAlways` returns permenantlyDenied

### :new: What is the new behavior (if this is a feature change)?

When requesting `locationWhenInUse` and allowing the When In Use prompt the user can now request the `locationAlways` permission.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

Mentioned in issue #601
Mentioned in issue #620 

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
