### PR TITLE
Issue/fix 601 location always permission bug

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 8.1.4
 
-* Fix bug where `locationAlways` returned sometimes `PermissionStatus.Denied` instead of `PermissionStatus.Granted`.
+* Fix bug where requesting `locationAlways` permission sometimes returns `PermissionStatus.Denied` instead of `PermissionStatus.Granted`.
 
 ## 8.1.3
 

--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.1.4
+
+* Fix bug where `locationAlways` returned sometimes `PermissionStatus.Denied` instead of `PermissionStatus.Granted`.
+
 ## 8.1.3
 
 * Fix bug where `locationAlways` returns `PermanentlyDenied`;

--- a/permission_handler/ios/Classes/PermissionManager.m
+++ b/permission_handler/ios/Classes/PermissionManager.m
@@ -46,7 +46,7 @@
         int rawValue = rawNumberValue.intValue;
         PermissionGroup permission = (PermissionGroup) rawValue;
         
-        id <PermissionStrategy> permissionStrategy = [PermissionManager createPermissionStrategy:permission];
+        __block id <PermissionStrategy> permissionStrategy = [PermissionManager createPermissionStrategy:permission];
         [_strategyInstances addObject:permissionStrategy];
         
         
@@ -55,6 +55,7 @@
             [requestQueue removeObject:@(permission)];
             
             [self->_strategyInstances removeObject:permissionStrategy];
+            permissionStrategy = nil;
             
             if (requestQueue.count == 0) {
                 completion(permissionStatusResult);

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-version: 8.1.3
+version: 8.1.4
 homepage: https://github.com/baseflowit/flutter-permission-handler
 
 flutter:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Fixed a bug where `locationAlways` returned sometimes `PermissionStatus.Denied` instead of `PermissionStatus.Granted`.

### :arrow_heading_down: What is the current behavior?

`locationAlways` now returns somtimes the wrong `PermissionStatus`.

### :new: What is the new behavior (if this is a feature change)?

`locationAlways` now returns the correct `PermissionStatus`.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

Issue number #620 

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
