### PR TITLE
Hotfix - requesting location after being granted results in memory error

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.1.4+1
+
+*Fix a bug where after allowing the `location` permission and requesting it again would lead to a memory error.
+
 ## 8.1.4
 
 * Fix bug where requesting `locationAlways` permission sometimes returns `PermissionStatus.Denied` instead of `PermissionStatus.Granted`.

--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 8.1.4+1
 
-*Fix a bug where after allowing the `location` permission and requesting it again would lead to a memory error.
+* Fix a bug where after allowing the `location` permission and requesting it again would lead to a memory error.
 
 ## 8.1.4
 

--- a/permission_handler/ios/Classes/strategies/ContactPermissionStrategy.m
+++ b/permission_handler/ios/Classes/strategies/ContactPermissionStrategy.m
@@ -22,6 +22,7 @@
 
     if (status != PermissionStatusDenied) {
         completionHandler(status);
+        return;
     }
 
     if (@available(iOS 9.0, *)) {

--- a/permission_handler/ios/Classes/strategies/LocationPermissionStrategy.m
+++ b/permission_handler/ios/Classes/strategies/LocationPermissionStrategy.m
@@ -37,6 +37,7 @@
         // don't do anything and continue requesting permissions
     } else if (status != PermissionStatusDenied) {
         completionHandler(status);
+        return;
     }
     
     _permissionStatusHandler = completionHandler;

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-version: 8.1.4
+version: 8.1.4+1
 homepage: https://github.com/baseflowit/flutter-permission-handler
 
 flutter:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Hotfix bug where requesting location after being granted would result into a memory error.

### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

Issue #633 

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
