### PR TITLE
Fixed memory reference error on iOS 12 and below.

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.1.4+2
+
+* iOS: fixed memory error that occurred on iOS 12.2 and below (see issue [#638](https://github.com/Baseflow/flutter-permission-handler/issues/638)).
+
 ## 8.1.4+1
 
 * Fix a bug where after allowing the `location` permission and requesting it again would lead to a memory error.

--- a/permission_handler/ios/Classes/PermissionManager.m
+++ b/permission_handler/ios/Classes/PermissionManager.m
@@ -55,12 +55,16 @@
             [requestQueue removeObject:@(permission)];
             
             [self->_strategyInstances removeObject:permissionStrategy];
-            permissionStrategy = nil;
             
             if (requestQueue.count == 0) {
                 completion(permissionStatusResult);
-                return;
             }
+          
+            // Make sure `completion` is called before cleaning up the reference
+            // otherwise the `completion` block is also dereferenced on iOS 12 and
+            // below (this is most likely a bug in Objective-C which is solved in
+            // later versions of the runtime).
+            permissionStrategy = nil;
         }];
     }
 }

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-version: 8.1.4+1
+version: 8.1.4+2
 homepage: https://github.com/baseflowit/flutter-permission-handler
 
 flutter:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

When requesting permissions on iOS 12 or below the permission_handler will crash and reports an EXC_BAD_ACCESS exception. Caused by a block callback function that is removed once a related class was set to `nil`.

### :new: What is the new behavior (if this is a feature change)?

In this case we can call the block before we nullify the related class. I included a comment to describe the importance of the calling order. Note that this bug was also resolved in the Objective-C runtime that ships with iOS 13 and higher.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

- Fixes #638

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
