### PR TITLE
Enhanced bluetooth permission for iOS 13 and up (and fixed typo)

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.1.5
+
+* iOS: Enhanced the `bluetooth` permission for iOS 13 and up, so the user gets prompted with the `bluetooth` permission dialog (see issue [#591](https://github.com/Baseflow/flutter-permission-handler/issues/591))
+
 ## 8.1.4+2
 
 * iOS: fixed memory error that occurred on iOS 12.2 and below (see issue [#638](https://github.com/Baseflow/flutter-permission-handler/issues/638)).
@@ -26,7 +30,7 @@
 ## 8.1.0
 
 * Added support for iOS 12+ Critical Alerts permission requesting.
-    * NOTE: This requires applying to Apple and recieving a special entitlement from them inorder to work. See [this article](https://medium.com/@shashidharyamsani/implementing-ios-critical-alerts-7d82b4bb5026) for an explination on how to use Critical Alerts.
+    * NOTE: This requires applying to Apple and receiving a special entitlement from them inorder to work. See [this article](https://medium.com/@shashidharyamsani/implementing-ios-critical-alerts-7d82b4bb5026) for an explination on how to use Critical Alerts.
 * Added support for Android M+ Access Notification Policy permission requesting (ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS).
     * Note: This opens a general page in settings, not specific to the package. 
 

--- a/permission_handler/ios/Classes/PermissionManager.m
+++ b/permission_handler/ios/Classes/PermissionManager.m
@@ -132,7 +132,11 @@
         case PermissionGroupStorage:
             return [StoragePermissionStrategy new];
         case PermissionGroupBluetooth:
+            #if PERMISSION_BLUETOOTH
+            return [[BluetoothPermissionStrategy alloc] initWithBluetoothManager];
+            #else
             return [BluetoothPermissionStrategy new];
+            #endif
         case PermissionGroupAppTrackingTransparency:
             return [AppTrackingTransparencyPermissionStrategy new];
         case PermissionGroupCriticalAlerts:

--- a/permission_handler/ios/Classes/strategies/BluetoothPermissionStrategy.h
+++ b/permission_handler/ios/Classes/strategies/BluetoothPermissionStrategy.h
@@ -12,7 +12,8 @@
 
 #import <CoreBluetooth/CoreBluetooth.h>
 
-@interface BluetoothPermissionStrategy : NSObject <PermissionStrategy>
+@interface BluetoothPermissionStrategy : NSObject <PermissionStrategy, CBCentralManagerDelegate>
+-(instancetype)initWithBluetoothManager;
 @end
 
 #else

--- a/permission_handler/ios/Classes/strategies/BluetoothPermissionStrategy.m
+++ b/permission_handler/ios/Classes/strategies/BluetoothPermissionStrategy.m
@@ -9,31 +9,50 @@
 
 #if PERMISSION_BLUETOOTH
 
-@implementation BluetoothPermissionStrategy
+@implementation BluetoothPermissionStrategy {
+    CBCentralManager *_centralManager;
+    PermissionStatusHandler _permissionStatusHandler;
+    PermissionGroup _requestedPermission;
+}
+
+- (instancetype)initWithBluetoothManager {
+    self = [super init];
+    if (self) {
+        _centralManager = [[CBCentralManager alloc] init];
+        _centralManager.delegate = self;
+    }
+    
+    return self;
+}
 
 - (PermissionStatus)checkPermissionStatus:(PermissionGroup)permission {
     if (@available(iOS 13.1, *)) {
-        CBManagerAuthorization blePermission = [CBCentralManager authorization];
+        CBManagerAuthorization blePermission = [_centralManager authorization];
         return [BluetoothPermissionStrategy parsePermission:blePermission];
     } else if (@available(iOS 13.0, *)){
-        CBCentralManager* manager = [[CBCentralManager alloc] init];
-        CBManagerAuthorization blePermission =  [manager authorization];
+        CBManagerAuthorization blePermission =  [_centralManager authorization];
         return [BluetoothPermissionStrategy parsePermission:blePermission];
     }
     return PermissionStatusGranted;
 }
 
 - (ServiceStatus)checkServiceStatus:(PermissionGroup)permission {
-    CBCentralManager* manager = [[CBCentralManager alloc] init];
     if (@available(iOS 10, *)) {
-        return [manager state] == CBManagerStatePoweredOn ? ServiceStatusEnabled : ServiceStatusDisabled;
+        return [_centralManager state] == CBManagerStatePoweredOn ? ServiceStatusEnabled : ServiceStatusDisabled;
     }
-    return [manager state] == CBCentralManagerStatePoweredOn ? ServiceStatusEnabled : ServiceStatusDisabled;
-    
+    return [_centralManager state] == CBCentralManagerStatePoweredOn ? ServiceStatusEnabled : ServiceStatusDisabled;
 }
 
 - (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {
-    completionHandler([self checkPermissionStatus:permission]);
+    PermissionStatus status = [self checkPermissionStatus:permission];
+    
+    if (status != PermissionStatusDenied) {
+        completionHandler(status);
+        return;
+    }
+    
+    _permissionStatusHandler = completionHandler;
+    _requestedPermission = permission;
 }
 
 + (PermissionStatus)parsePermission:(CBManagerAuthorization)bluetoothPermission API_AVAILABLE(ios(13)){
@@ -48,6 +67,12 @@
             return PermissionStatusGranted;
     }
 }
+
+- (void)centralManagerDidUpdateState:(nonnull CBCentralManager *)centralManager {
+    PermissionStatus permissionStatus = [self checkPermissionStatus:_requestedPermission];
+    _permissionStatusHandler(permissionStatus);
+}
+
 @end
 
 #else

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-version: 8.1.4+2
+version: 8.1.5
 homepage: https://github.com/baseflowit/flutter-permission-handler
 
 flutter:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

iOS 13 and up users will now be prompted when requesting the `bluetooth` permission.

### :arrow_heading_down: What is the current behavior?

Now the user does not get prompted with a dialog to accept the `bluetooth` permission.

### :new: What is the new behavior (if this is a feature change)?

Users on iOS 13 and up will now get prompted with the `bluetooth` request dialog when the app uses bluetooth.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

- issue #591
- issue #585 
-  
### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
