### PR TITLE
Permission Manager / Location Settings intent nullpointer fix

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.1.5
+
+* Android: Fixed a NullPointerException in release mode, which caused applications to crash when changing settings in the Location Settings intent.
+
 ## 8.1.4+2
 
 * iOS: fixed memory error that occurred on iOS 12.2 and below (see issue [#638](https://github.com/Baseflow/flutter-permission-handler/issues/638)).

--- a/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
+++ b/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
@@ -104,6 +104,10 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
             return false;
         }
 
+        if (requestResults == null) {
+           return false;
+        }
+
         for (int i = 0; i < permissions.length; i++) {
             final String permissionName = permissions[i];
 

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-version: 8.1.4+2
+version: 8.1.5
 homepage: https://github.com/baseflowit/flutter-permission-handler
 
 flutter:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Currently, when opening the Location Settings and changing location settings and thus permissions, the app will crash when returning to the application. This only occurs in release mode. When running the application in development mode, the application will 'freeze' instead of crash.

### :new: What is the new behavior (if this is a feature change)?
In release mode the nullpointerexception will no longer occur. In development mode, the app will still freeze when returning from the Location Settings intent. 

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Use the example application

### :memo: Links to relevant issues/docs
Does not apply

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [ ] I updated the relevant documentation.
- [ ] I rebased onto current `master`.
