### PR TITLE
Update the MethodChannelMock due to breaking changes.

### DIFF
--- a/permission_handler_platform_interface/CHANGELOG.md
+++ b/permission_handler_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.6.2
+
+* Updated the MethodChannelMock due to breaking changes in the platform channel test interface.
+
 ## 3.6.1
 
 * Updated `meta` dependency to version `^1.3.0`.

--- a/permission_handler_platform_interface/analysis_options.yaml
+++ b/permission_handler_platform_interface/analysis_options.yaml
@@ -1,0 +1,11 @@
+
+include: package:flutter_lints/flutter.yaml
+
+analyzer:
+  exclude:
+    # Ignore generated files
+    - '**/*.g.dart'
+    - 'lib/src/generated/*.dart'
+linter:
+  rules:
+    - public_member_api_docs

--- a/permission_handler_platform_interface/lib/src/method_channel/method_channel_permission_handler.dart
+++ b/permission_handler_platform_interface/lib/src/method_channel/method_channel_permission_handler.dart
@@ -11,11 +11,12 @@ const MethodChannel _methodChannel =
 /// An implementation of [PermissionHandlerPlatform] that uses [MethodChannel]s.
 class MethodChannelPermissionHandler extends PermissionHandlerPlatform {
   /// Checks the current status of the given [Permission].
+  @override
   Future<PermissionStatus> checkPermissionStatus(Permission permission) async {
     final status = await _methodChannel.invokeMethod(
         'checkPermissionStatus', permission.value);
 
-    return Codec.decodePermissionStatus(status);
+    return decodePermissionStatus(status);
   }
 
   /// Checks the current status of the service associated with the given
@@ -39,17 +40,19 @@ class MethodChannelPermissionHandler extends PermissionHandlerPlatform {
   ///   - **PLEASE NOTE that this is still not a perfect indication** of the
   ///     device's capability to place & connect phone calls as it also depends
   ///     on the network condition.
+  @override
   Future<ServiceStatus> checkServiceStatus(Permission permission) async {
     final status = await _methodChannel.invokeMethod(
         'checkServiceStatus', permission.value);
 
-    return Codec.decodeServiceStatus(status);
+    return decodeServiceStatus(status);
   }
 
   /// Opens the app settings page.
   ///
   /// Returns [true] if the app settings page could be opened, otherwise
   /// [false].
+  @override
   Future<bool> openAppSettings() async {
     final wasOpened = await _methodChannel.invokeMethod('openAppSettings');
 
@@ -60,19 +63,21 @@ class MethodChannelPermissionHandler extends PermissionHandlerPlatform {
   /// they have not already been granted before.
   ///
   /// Returns a [Map] containing the status per requested [Permission].
+  @override
   Future<Map<Permission, PermissionStatus>> requestPermissions(
       List<Permission> permissions) async {
-    final data = Codec.encodePermissions(permissions);
+    final data = encodePermissions(permissions);
     final status =
         await _methodChannel.invokeMethod('requestPermissions', data);
 
-    return Codec.decodePermissionRequestResult(Map<int, int>.from(status));
+    return decodePermissionRequestResult(Map<int, int>.from(status));
   }
 
   /// Checks if you should show a rationale for requesting permission.
   ///
   /// This method is only implemented on Android, calling this on iOS always
   /// returns [false].
+  @override
   Future<bool> shouldShowRequestPermissionRationale(
       Permission permission) async {
     final shouldShowRationale = await _methodChannel.invokeMethod(

--- a/permission_handler_platform_interface/lib/src/method_channel/utils/codec.dart
+++ b/permission_handler_platform_interface/lib/src/method_channel/utils/codec.dart
@@ -1,29 +1,25 @@
 import '../../../permission_handler_platform_interface.dart';
 
-/// Provides utility methods for encoding messages that are sent on the Flutter
-/// message channel.
-class Codec {
-  /// Converts the given [value] into a [PermissionStatus] instance.
-  static PermissionStatus decodePermissionStatus(int value) {
-    return PermissionStatusValue.statusByValue(value);
-  }
+/// Converts the given [value] into a [PermissionStatus] instance.
+PermissionStatus decodePermissionStatus(int value) {
+  return PermissionStatusValue.statusByValue(value);
+}
 
-  /// Converts the given [value] into a [ServiceStatus] instance.
-  static ServiceStatus decodeServiceStatus(int value) {
-    return ServiceStatusValue.statusByValue(value);
-  }
+/// Converts the given [value] into a [ServiceStatus] instance.
+ServiceStatus decodeServiceStatus(int value) {
+  return ServiceStatusValue.statusByValue(value);
+}
 
-  /// Converts the given [Map] of [int]s into a [Map] with [Permission]s as
-  /// keys and their respective [PermissionStatus] as value.
-  static Map<Permission, PermissionStatus> decodePermissionRequestResult(
-      Map<int, int> value) {
-    return value.map((key, value) => MapEntry<Permission, PermissionStatus>(
-        Permission.byValue(key), PermissionStatusValue.statusByValue(value)));
-  }
+/// Converts the given [Map] of [int]s into a [Map] with [Permission]s as
+/// keys and their respective [PermissionStatus] as value.
+Map<Permission, PermissionStatus> decodePermissionRequestResult(
+    Map<int, int> value) {
+  return value.map((key, value) => MapEntry<Permission, PermissionStatus>(
+      Permission.byValue(key), PermissionStatusValue.statusByValue(value)));
+}
 
-  /// Converts the given [List] of [Permission]s into a [List] of [int]s which
-  /// can be sent on the Flutter method channel.
-  static List<int> encodePermissions(List<Permission> permissions) {
-    return permissions.map((it) => it.value).toList();
-  }
+/// Converts the given [List] of [Permission]s into a [List] of [int]s which
+/// can be sent on the Flutter method channel.
+List<int> encodePermissions(List<Permission> permissions) {
+  return permissions.map((it) => it.value).toList();
 }

--- a/permission_handler_platform_interface/lib/src/permission_status.dart
+++ b/permission_handler_platform_interface/lib/src/permission_status.dart
@@ -25,7 +25,9 @@ enum PermissionStatus {
   permanentlyDenied,
 }
 
+/// Conversion extension methods for the [PermissionStatus] type.
 extension PermissionStatusValue on PermissionStatus {
+  /// Converts the [PermissionStatus] value into an integer.
   int get value {
     switch (this) {
       case PermissionStatus.denied:
@@ -43,6 +45,7 @@ extension PermissionStatusValue on PermissionStatus {
     }
   }
 
+  /// Converts the supplied integer value into a [PermissionStatus] enum.
   static PermissionStatus statusByValue(int value) {
     return [
       PermissionStatus.denied,
@@ -54,6 +57,7 @@ extension PermissionStatusValue on PermissionStatus {
   }
 }
 
+/// Utility getter extensions for the [PermissionStatus] type.
 extension PermissionStatusGetters on PermissionStatus {
   /// If the user denied access to the requested feature.
   bool get isDenied => this == PermissionStatus.denied;
@@ -76,9 +80,11 @@ extension PermissionStatusGetters on PermissionStatus {
   /// Therefore make a `request` call first.
   bool get isPermanentlyDenied => this == PermissionStatus.permanentlyDenied;
 
+  /// Indicates that permission for limited use of the resource is granted.
   bool get isLimited => this == PermissionStatus.limited;
 }
 
+/// Utility getter extensions for the `Future<PermissionStatus>` type.
 extension FuturePermissionStatusGetters on Future<PermissionStatus> {
   /// If the user granted access to the requested feature.
   Future<bool> get isGranted async => (await this).isGranted;
@@ -99,5 +105,6 @@ extension FuturePermissionStatusGetters on Future<PermissionStatus> {
   Future<bool> get isPermanentlyDenied async =>
       (await this).isPermanentlyDenied;
 
+  /// Indicates that permission for limited use of the resource is granted.
   Future<bool> get isLimited async => (await this).isLimited;
 }

--- a/permission_handler_platform_interface/lib/src/permissions.dart
+++ b/permission_handler_platform_interface/lib/src/permissions.dart
@@ -6,6 +6,9 @@ part of permission_handler_platform_interface;
 class PermissionWithService extends Permission {
   const PermissionWithService._(int value) : super._(value);
 
+  /// Creates a [PermissionWithService] instance.
+  ///
+  /// This constructor is marked public for testing purposes only.
   @visibleForTesting
   const PermissionWithService.private(int value) : super._(value);
 }
@@ -14,6 +17,8 @@ class PermissionWithService extends Permission {
 @immutable
 class Permission {
   const Permission._(this.value);
+
+  /// Creates a [Permission] using the supplied integer value.
   factory Permission.byValue(int value) => values[value];
 
   /// Integer representation of the [Permission].

--- a/permission_handler_platform_interface/lib/src/service_status.dart
+++ b/permission_handler_platform_interface/lib/src/service_status.dart
@@ -1,5 +1,6 @@
 part of permission_handler_platform_interface;
 
+/// Defines the different states a service can be in.
 enum ServiceStatus {
   /// The service for the permission is disabled.
   disabled,
@@ -12,7 +13,9 @@ enum ServiceStatus {
   notApplicable,
 }
 
+/// Conversion extension methods for the [ServiceStatus] type.
 extension ServiceStatusValue on ServiceStatus {
+  /// Converts the [ServiceStatus] value into an integer.
   int get value {
     switch (this) {
       case ServiceStatus.disabled:
@@ -26,6 +29,7 @@ extension ServiceStatusValue on ServiceStatus {
     }
   }
 
+  /// Converts the supplied integer value into a [ServiceStatus] enum.
   static ServiceStatus statusByValue(int value) {
     return [
       ServiceStatus.disabled,
@@ -35,6 +39,7 @@ extension ServiceStatusValue on ServiceStatus {
   }
 }
 
+/// Utility getter extensions for the [ServiceStatus] type.
 extension ServiceStatusGetters on ServiceStatus {
   /// If the service for the permission is disabled.
   bool get isDisabled => this == ServiceStatus.disabled;
@@ -47,6 +52,7 @@ extension ServiceStatusGetters on ServiceStatus {
   bool get isNotApplicable => this == ServiceStatus.notApplicable;
 }
 
+/// Utility getter extensions for the `Future<ServiceStatus>` type.
 extension FutureServiceStatusGetters on Future<ServiceStatus> {
   /// If the service for the permission is disabled.
   Future<bool> get isDisabled async => (await this).isDisabled;

--- a/permission_handler_platform_interface/pubspec.yaml
+++ b/permission_handler_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the permission_handler plugin.
 homepage: https://github.com/baseflow/flutter-permission-handler/tree/master/permission_handler_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 3.6.1
+version: 3.6.2
 
 dependencies:
   flutter:
@@ -18,5 +18,5 @@ dev_dependencies:
   effective_dart: ^1.3.0
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.22.0"
+  sdk: ">=2.14.0 <3.0.0"
+  flutter: ">=2.5.0"

--- a/permission_handler_platform_interface/pubspec.yaml
+++ b/permission_handler_platform_interface/pubspec.yaml
@@ -15,7 +15,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0
-  effective_dart: ^1.3.0
+  flutter_lints: ^1.0.4
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/permission_handler_platform_interface/test/src/method_channel/method_channel_mock.dart
+++ b/permission_handler_platform_interface/test/src/method_channel/method_channel_mock.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 class MethodChannelMock {
   final MethodChannel methodChannel;
@@ -12,7 +13,8 @@ class MethodChannelMock {
     this.result,
     this.delay = Duration.zero,
   }) : methodChannel = MethodChannel(channelName) {
-    methodChannel.setMockMethodCallHandler(_handler);
+    TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger
+        .setMockMethodCallHandler(methodChannel, _handler);
   }
 
   Future _handler(MethodCall methodCall) async {

--- a/permission_handler_platform_interface/test/src/method_channel/utils/coded_test.dart
+++ b/permission_handler_platform_interface/test/src/method_channel/utils/coded_test.dart
@@ -5,11 +5,11 @@ import 'package:permission_handler_platform_interface/src/method_channel/utils/c
 void main() {
   group('Codec', () {
     test('decodePermissionStatus should return a PermissionStatus', () {
-      expect(Codec.decodePermissionStatus(0), PermissionStatus.denied);
+      expect(decodePermissionStatus(0), PermissionStatus.denied);
     });
 
     test('decodeServiceStatus should a corresponding ServiceStatus', () {
-      expect(Codec.decodeServiceStatus(0), ServiceStatus.disabled);
+      expect(decodeServiceStatus(0), ServiceStatus.disabled);
     });
 
     test(
@@ -19,7 +19,7 @@ void main() {
         1: 1,
       };
 
-      var permissionMap = Codec.decodePermissionRequestResult(value);
+      var permissionMap = decodePermissionRequestResult(value);
 
       expect(permissionMap.keys.first, isA<Permission>());
       expect(permissionMap.values.first, isA<PermissionStatus>());
@@ -28,7 +28,7 @@ void main() {
     test('encodePermissions should return a list of integers', () {
       var permissions = [Permission.accessMediaLocation];
 
-      var integers = Codec.encodePermissions(permissions);
+      var integers = encodePermissions(permissions);
 
       expect(integers.first, isA<int>());
     });

--- a/permission_handler_platform_interface/test/src/permission_handler_platform_interface_test.dart
+++ b/permission_handler_platform_interface/test/src/permission_handler_platform_interface_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
 import 'package:permission_handler_platform_interface/permission_handler_platform_interface.dart';
 import 'package:permission_handler_platform_interface/src/method_channel/method_channel_permission_handler.dart';
-import 'package:mockito/mockito.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 void main() {

--- a/permission_handler_platform_interface/test/src/permission_status_test.dart
+++ b/permission_handler_platform_interface/test/src/permission_status_test.dart
@@ -4,13 +4,13 @@ import 'package:permission_handler_platform_interface/permission_handler_platfor
 void main() {
   group('PermissionSatus', () {
     test('PermissionStatus should contain 5 options', () {
-      final values = PermissionStatus.values;
+      const values = PermissionStatus.values;
 
       expect(values.length, 5);
     });
 
     test('PermissionStatus enum should have items in correct index', () {
-      final values = PermissionStatus.values;
+      const values = PermissionStatus.values;
 
       expect(values[0], PermissionStatus.denied);
       expect(values[1], PermissionStatus.granted);

--- a/permission_handler_platform_interface/test/src/permissions_test.dart
+++ b/permission_handler_platform_interface/test/src/permissions_test.dart
@@ -4,13 +4,13 @@ import 'package:permission_handler_platform_interface/permission_handler_platfor
 void main() {
   test('Permission has the right amount of possible PermissionGroup values',
       () {
-    final values = Permission.values;
+    const values = Permission.values;
 
     expect(values.length, 28);
   });
 
   test('check if byValue returns corresponding PermissionGroup value', () {
-    final values = Permission.values;
+    const values = Permission.values;
 
     for (var i = 0; i < values.length; i++) {
       expect(values[i], Permission.byValue(i));
@@ -18,7 +18,8 @@ void main() {
   });
 
   test('check if toString method returns the corresponding name', () {
-    var permissionWithService = PermissionWithService.private(0);
+    const PermissionWithService permissionWithService =
+        PermissionWithService.private(0);
     var permissionName = permissionWithService.toString();
     expect(permissionName, 'Permission.calendar');
   });

--- a/permission_handler_platform_interface/test/src/service_status_test.dart
+++ b/permission_handler_platform_interface/test/src/service_status_test.dart
@@ -4,13 +4,13 @@ import 'package:permission_handler_platform_interface/permission_handler_platfor
 void main() {
   group('ServiceStatus', () {
     test('ServiceStatus should contain 3 options', () {
-      final values = ServiceStatus.values;
+      const values = ServiceStatus.values;
 
       expect(values.length, 3);
     });
 
     test('ServiceStatus enum should have items in correct index', () {
-      final values = ServiceStatus.values;
+      const values = ServiceStatus.values;
 
       expect(values[0], ServiceStatus.disabled);
       expect(values[1], ServiceStatus.enabled);


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

Unit tests fail when running on latest stable of Flutter because the `setMockMethodChannel` method has been moved from the `MethodChannel` class to the `TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger` class.

### :new: What is the new behavior (if this is a feature change)?

Migrate the implementation of the `MethodChannelMock` class to use the new `TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger` to register a mock handler, instead of the `MethodChannel` class.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Unit tests should succeed in tree.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
