### PR TITLE
Update to latest version of platform_interface

### DIFF
--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -16,8 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
-  permission_handler_platform_interface:
-    path: ../permission_handler_platform_interface  # FIXME: Publish new version and use it here
+  permission_handler_platform_interface: ^3.7.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Updates the permission_handler (app facing package) to use the latest version of the permission_handler_platform_interface package. 


### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
