### PR TITLE
Ensure checking permissions on pre Android M works correctly.

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 8.2.1
+
+* Resolved an issue where checking permissions on pre Android M devices always resolved to `PermissionStatus.denied` (see issue [#60](https://github.com/Baseflow/flutter-permission-plugins/issues/60));
+* Updated the url_launcher dependency in the example App to `^6.0.12`.
+
 ## 8.2.0
 
 * Added support for the new Android 12 Bluetooth permissions: BLUETOOTH_SCAN, BLUETOOTH_ADVERTISE and BLUETOOTH_CONNECT.

--- a/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
+++ b/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
@@ -338,7 +338,9 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
                 }
             }
 
-            return PermissionConstants.PERMISSION_STATUS_DENIED;
+            return Build.VERSION.SDK_INT < Build.VERSION_CODES.M
+                ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                : PermissionConstants.PERMISSION_STATUS_DENIED;
         }
 
         final boolean targetsMOrHigher = context.getApplicationInfo().targetSdkVersion >= Build.VERSION_CODES.M;

--- a/permission_handler/example/pubspec.yaml
+++ b/permission_handler/example/pubspec.yaml
@@ -19,7 +19,7 @@ dev_dependencies:
   permission_handler:
     path: ../
 
-  url_launcher: ^6.0.0
+  url_launcher: ^6.0.12
 
 flutter:
   uses-material-design: true

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-version: 8.2.0
+version: 8.2.1
 homepage: https://github.com/baseflowit/flutter-permission-handler
 
 flutter:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

When checking permissions on pre Android M (without support for runtime permissions) the result is always `PermissionStatus.denied` while `PermissionStatus.granted` is the expected value.

### :new: What is the new behavior (if this is a feature change)?

Return `PermissionStatus.granted` on pre Android M devices when permissions are not specified in the `AndroidManifest.xml` file.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
