### PR TITLE
Update compileSdkVersion documentation.

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,9 +1,16 @@
+## 8.2.2
+
+* Updated the README.md to mention setting the `compileSdkVersion` to `31`;
+* Added an additional note to version 8.2.0 release notes to inform people to update the `compileSdkVersion`.
+
 ## 8.2.1
 
 * Resolved an issue where checking permissions on pre Android M devices always resolved to `PermissionStatus.denied` (see issue [#60](https://github.com/Baseflow/flutter-permission-plugins/issues/60));
 * Updated the url_launcher dependency in the example App to `^6.0.12`.
 
 ## 8.2.0
+
+> **IMPORTANT:** when updating to version 8.2.0 make sure to also set the `compileSdkVersion` in the `app/build.gradle` file to `31`.
 
 * Added support for the new Android 12 Bluetooth permissions: BLUETOOTH_SCAN, BLUETOOTH_ADVERTISE and BLUETOOTH_CONNECT.
 * Updated Android compile and target SDK to 31 (Android 12 (S)).

--- a/permission_handler/README.md
+++ b/permission_handler/README.md
@@ -28,10 +28,10 @@ The TL;DR version is:
 android.useAndroidX=true
 android.enableJetifier=true
 ```
-2. Make sure you set the `compileSdkVersion` in your "android/app/build.gradle" file to 30:
+2. Make sure you set the `compileSdkVersion` in your "android/app/build.gradle" file to 31:
 ```
 android {
-  compileSdkVersion 30
+  compileSdkVersion 31
   ...
 }
 ```

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-version: 8.2.1
+version: 8.2.2
 homepage: https://github.com/baseflowit/flutter-permission-handler
 
 flutter:


### PR DESCRIPTION
Update instructions on configuring the Android `compileSdkVersion` to value `31` as required by version 8.2.0 of the permission_handler.

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
