### PR TITLE
Bug fix - 'No permissions found in manifest for:...' on Android 11 and lower

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.2.4
+
+* Solved bug where output would log that there is no permission in manifest for BLUETOOTH_SCAN, BLUETOOTH_ADVERTISE and BLUETOOTH_CONNECT on Android 11 devices and lower(see issue [#691](https://github.com/Baseflow/flutter-permission-handler/issues/691)).
+
 ## 8.2.3
 
 * iOS: Enhanced the `bluetooth` permission for iOS 13 and up, so the user gets prompted with the "bluetooth" permission dialog (see issue [#591](https://github.com/Baseflow/flutter-permission-handler/issues/591)).

--- a/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
+++ b/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
@@ -55,9 +55,13 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
         if (requestCode == PermissionConstants.PERMISSION_CODE_IGNORE_BATTERY_OPTIMIZATIONS) {
             permission = PermissionConstants.PERMISSION_GROUP_IGNORE_BATTERY_OPTIMIZATIONS;
         } else if (requestCode == PermissionConstants.PERMISSION_CODE_MANAGE_EXTERNAL_STORAGE) {
-            status = Environment.isExternalStorageManager()
-                    ? PermissionConstants.PERMISSION_STATUS_GRANTED
-                    : PermissionConstants.PERMISSION_STATUS_DENIED;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                status = Environment.isExternalStorageManager()
+                        ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                        : PermissionConstants.PERMISSION_STATUS_DENIED;
+            } else {
+                return false;
+            }
             permission = PermissionConstants.PERMISSION_GROUP_MANAGE_EXTERNAL_STORAGE;
         } else if (requestCode == PermissionConstants.PERMISSION_CODE_SYSTEM_ALERT_WINDOW) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
@@ -306,8 +310,17 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
         if (permission == PermissionConstants.PERMISSION_GROUP_NOTIFICATION) {
             return checkNotificationPermissionStatus(context);
         }
+
         if (permission == PermissionConstants.PERMISSION_GROUP_BLUETOOTH) {
             return checkBluetoothPermissionStatus(context);
+        }
+
+        if (permission == PermissionConstants.PERMISSION_GROUP_BLUETOOTH_CONNECT
+                || permission == PermissionConstants.PERMISSION_GROUP_BLUETOOTH_SCAN
+                || permission == PermissionConstants.PERMISSION_GROUP_BLUETOOTH_ADVERTISE){
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+                return checkBluetoothPermissionStatus(context);
+            }
         }
 
         final List<String> names = PermissionUtils.getManifestNames(context, permission);

--- a/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
+++ b/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
@@ -253,24 +253,39 @@ public class PermissionUtils {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && hasPermissionInManifest(context, permissionNames, Manifest.permission.ACCESS_NOTIFICATION_POLICY ))
                     permissionNames.add(Manifest.permission.ACCESS_NOTIFICATION_POLICY);
                 break;
-            case PermissionConstants.PERMISSION_GROUP_BLUETOOTH_SCAN:
+            case PermissionConstants.PERMISSION_GROUP_BLUETOOTH_SCAN: {
                 // The BLUETOOTH_SCAN permission is introduced in Android S, meaning we should
                 // not handle permissions on pre Android S devices.
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && hasPermissionInManifest(context, permissionNames, Manifest.permission.BLUETOOTH_SCAN ))
-                    permissionNames.add(Manifest.permission.BLUETOOTH_SCAN);
+                String result = determineBluetoothPermission(context, Manifest.permission.BLUETOOTH_SCAN);
+
+                if (result != null) {
+                    permissionNames.add(result);
+                }
+
                 break;
-            case PermissionConstants.PERMISSION_GROUP_BLUETOOTH_ADVERTISE:
+            }
+            case PermissionConstants.PERMISSION_GROUP_BLUETOOTH_ADVERTISE: {
                 // The BLUETOOTH_ADVERTISE permission is introduced in Android S, meaning we should
                 // not handle permissions on pre Android S devices.
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && hasPermissionInManifest(context, permissionNames, Manifest.permission.BLUETOOTH_ADVERTISE ))
-                    permissionNames.add(Manifest.permission.BLUETOOTH_ADVERTISE);
+                String result = determineBluetoothPermission(context, Manifest.permission.BLUETOOTH_ADVERTISE);
+
+                if (result != null) {
+                    permissionNames.add(result);
+                }
+
                 break;
-            case PermissionConstants.PERMISSION_GROUP_BLUETOOTH_CONNECT:
+            }
+            case PermissionConstants.PERMISSION_GROUP_BLUETOOTH_CONNECT: {
                 // The BLUETOOTH_CONNECT permission is introduced in Android S, meaning we should
                 // not handle permissions on pre Android S devices.
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && hasPermissionInManifest(context, permissionNames, Manifest.permission.BLUETOOTH_CONNECT ))
-                    permissionNames.add(Manifest.permission.BLUETOOTH_CONNECT);
+                String result = determineBluetoothPermission(context, Manifest.permission.BLUETOOTH_CONNECT);
+
+                if (result != null) {
+                    permissionNames.add(result);
+                }
+
                 break;
+            }
             case PermissionConstants.PERMISSION_GROUP_NOTIFICATION:
             case PermissionConstants.PERMISSION_GROUP_MEDIA_LIBRARY:
             case PermissionConstants.PERMISSION_GROUP_PHOTOS:
@@ -349,5 +364,23 @@ public class PermissionUtils {
 
         final boolean shouldShowRequestPermissionRationale = ActivityCompat.shouldShowRequestPermissionRationale(activity, name);
         return !shouldShowRequestPermissionRationale;
+    }
+
+    private static String determineBluetoothPermission(Context context, String permission) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && hasPermissionInManifest(context, null, permission )) {
+            return permission;
+        } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            if(hasPermissionInManifest(context, null, Manifest.permission.ACCESS_FINE_LOCATION)){
+                return Manifest.permission.ACCESS_FINE_LOCATION;
+            } else if (hasPermissionInManifest(context, null, Manifest.permission.ACCESS_COARSE_LOCATION)){
+                return Manifest.permission.ACCESS_COARSE_LOCATION;
+            }
+
+            return  null;
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && hasPermissionInManifest(context, null, Manifest.permission.ACCESS_FINE_LOCATION)) {
+            return Manifest.permission.ACCESS_FINE_LOCATION;
+        }
+
+        return null;
     }
 }

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-version: 8.2.3
+version: 8.2.4
 homepage: https://github.com/baseflowit/flutter-permission-handler
 
 flutter:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix - output would log that there are no permissions in the manifest for the new bluetooth permissions (BLUETOOTH_SCAN, BLUETOOTH_CONNECT and BLUETOOTH_ADVERTISE) on Android 11 and lower devices. This PR solves that problem

### :arrow_heading_down: What is the current behavior?

Output would log that there are no permissions in the manifest for the bluetooth advertise, connect and scan permissions on Android 11 and lower. 

### :new: What is the new behavior (if this is a feature change)?

The permissions will be automatically granted on Android 11 and lower. As stated in the Android [documentation](https://developer.android.com/guide/topics/connectivity/bluetooth/permissions#declare-android11-or-lower) user should ask for `location` permission if the user wants to use bluetooth permission.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

N.A.

### :memo: Links to relevant issues/docs

Issue #691 

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
