### PR TITLE
fix: init CBCentralManager lazely

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 9.0.0
+
+* iOS: Bluetooth permission dialog now appears when requested instead of when the app is initialized.
+Note: Requesting Bluetooth status will also prompt the permission dialog (see issue [#591](https://github.com/Baseflow/flutter-permission-handler/issues/591)).
+
 ## 8.3.0
 
 * Updated Android Gradle Plugin to 4.1.0 and Gradle Wrapper to 6.7 which is inline with the current Flutter stable version (Flutter 2.5.3).

--- a/permission_handler/ios/Classes/PermissionManager.m
+++ b/permission_handler/ios/Classes/PermissionManager.m
@@ -132,11 +132,7 @@
         case PermissionGroupStorage:
             return [StoragePermissionStrategy new];
         case PermissionGroupBluetooth:
-            #if PERMISSION_BLUETOOTH
-            return [[BluetoothPermissionStrategy alloc] initWithBluetoothManager];
-            #else
             return [BluetoothPermissionStrategy new];
-            #endif
         case PermissionGroupAppTrackingTransparency:
             return [AppTrackingTransparencyPermissionStrategy new];
         case PermissionGroupCriticalAlerts:

--- a/permission_handler/ios/Classes/strategies/BluetoothPermissionStrategy.h
+++ b/permission_handler/ios/Classes/strategies/BluetoothPermissionStrategy.h
@@ -13,7 +13,7 @@
 #import <CoreBluetooth/CoreBluetooth.h>
 
 @interface BluetoothPermissionStrategy : NSObject <PermissionStrategy, CBCentralManagerDelegate>
--(instancetype)initWithBluetoothManager;
+- (void)initManagerIfNeeded;
 @end
 
 #else

--- a/permission_handler/ios/Classes/strategies/BluetoothPermissionStrategy.m
+++ b/permission_handler/ios/Classes/strategies/BluetoothPermissionStrategy.m
@@ -15,16 +15,14 @@
     PermissionGroup _requestedPermission;
 }
 
-- (instancetype)initWithBluetoothManager {
-    self = [super init];
-    if (self) {
+- (void)initManagerIfNeeded {
+    if (_centralManager == nil) {
         _centralManager = [[CBCentralManager alloc] initWithDelegate:self queue:nil];
     }
-    
-    return self;
 }
 
 - (PermissionStatus)checkPermissionStatus:(PermissionGroup)permission {
+    [self initManagerIfNeeded];
     if (@available(iOS 13.1, *)) {
         CBManagerAuthorization blePermission = [_centralManager authorization];
         return [BluetoothPermissionStrategy parsePermission:blePermission];
@@ -36,6 +34,7 @@
 }
 
 - (ServiceStatus)checkServiceStatus:(PermissionGroup)permission {
+    [self initManagerIfNeeded];
     if (@available(iOS 10, *)) {
         return [_centralManager state] == CBManagerStatePoweredOn ? ServiceStatusEnabled : ServiceStatusDisabled;
     }
@@ -43,6 +42,7 @@
 }
 
 - (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {
+    [self initManagerIfNeeded];
     PermissionStatus status = [self checkPermissionStatus:permission];
     
     if (status != PermissionStatusDenied) {

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-version: 8.3.0
+version: 9.0.0
 homepage: https://github.com/baseflowit/flutter-permission-handler
 
 flutter:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fixes problem that request Ble as soon as the app started  https://github.com/Baseflow/flutter-permission-handler/issues/591

### :arrow_heading_down: What is the current behavior?
As soon as you open the app the Bluetooth permission is requested if 'PERMISSION_BLUETOOTH=1',

### :new: What is the new behavior (if this is a feature change)?
Request bluetooth connection only when serviceStatus or requestPermission is called

### :boom: Does this PR introduce a breaking change?
Yes! Devs could have consider this while implementing the permission flow throw their app

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
 https://github.com/Baseflow/flutter-permission-handler/issues/591

### :thinking: Checklist before submitting

- [X] I made sure all projects build.
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [ ] I updated the relevant documentation.
- [X] I rebased onto current `master`

https://user-images.githubusercontent.com/19904063/143449302-8d34f925-340e-42b5-80cc-437bff8f17ff.MP4

