### PR TITLE
Fixed the WRITE_EXTERNAL_STORAGE permission may not request on AndroidQ

### DIFF
--- a/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
+++ b/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
@@ -192,7 +192,7 @@ public class PermissionUtils {
                 if (hasPermissionInManifest(context, permissionNames, Manifest.permission.READ_EXTERNAL_STORAGE))
                     permissionNames.add(Manifest.permission.READ_EXTERNAL_STORAGE);
 
-                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q || (Build.VERSION.SDK_INT == Build.VERSION_CODES.Q && Environment.isExternalStorageLegacy())) {
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q || (context.getApplicationInfo().targetSdkVersion <= Build.VERSION_CODES.Q && Environment.isExternalStorageLegacy())) {
                     if (hasPermissionInManifest(context, permissionNames, Manifest.permission.WRITE_EXTERNAL_STORAGE))
                         permissionNames.add(Manifest.permission.WRITE_EXTERNAL_STORAGE);
                     break;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
the WRITE_EXTERNAL_STORAGE permission may not request on Android Q or higher which configuring targetSDK <=29 and externalStorageLegacy = true

### :new: What is the new behavior (if this is a feature change)?
fixed the problem

### :boom: Does this PR introduce a breaking change?
no

### :bug: Recommendations for testing
run on Android Q or higher which configuring targetSDK <=29 and externalStorageLegacy = true, request WRITE_EXTERNAL_STORAGE permission

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x ] I made sure all projects build.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [ ] I updated the relevant documentation.
- [x ] I rebased onto current `master`.
