### PR TITLE
Issue 793

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 9.0.2
+
+* Fixes regression when requesting 'locationAlways' permission on Andriod 9 (Pie) and earlier.
+
 ## 9.0.1
 
 * Fixes bug when requesting `locationAlways` permissions on Android.

--- a/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
+++ b/permission_handler/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
@@ -115,8 +115,8 @@ public class PermissionUtils {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                     if (hasPermissionInManifest(context, permissionNames, Manifest.permission.ACCESS_BACKGROUND_LOCATION))
                         permissionNames.add(Manifest.permission.ACCESS_BACKGROUND_LOCATION);
+                    break;
                 }
-                break;
             case PermissionConstants.PERMISSION_GROUP_LOCATION_WHEN_IN_USE:
             case PermissionConstants.PERMISSION_GROUP_LOCATION:
                 if (hasPermissionInManifest(context, permissionNames, Manifest.permission.ACCESS_COARSE_LOCATION))

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-version: 9.0.1
+version: 9.0.2
 homepage: https://github.com/baseflowit/flutter-permission-handler
 
 flutter:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This change fixes the regression described in Issue #793

### :arrow_heading_down: What is the current behavior?
Current behavior prevents Android 9 (Pie) or earlier from having locationAlways permission granted due to a misplaced 'break' statement.

### :new: What is the new behavior (if this is a feature change)?
Behavior is restored to how it worked in v8.3.0 for Android 9 (Pie) and earlier.

### :boom: Does this PR introduce a breaking change?
No.  Compared location permission behavior on Android 12 for both 9.0.1 and the current PR.  Behavior is the same.

### :bug: Recommendations for testing
Follow steps described in Issue #793 to confirm the behavior is now the same as it was in version 8.3.0 for location permissions.

### :memo: Links to relevant issues/docs
Issue #793: https://github.com/Baseflow/flutter-permission-handler/issues/793

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
