### PR TITLE
Fix ERROR_ALREADY_REQUESTING_PERMISSIONS on iOS after requesting locationAlways

### DIFF
--- a/permission_handler_apple/AUTHORS
+++ b/permission_handler_apple/AUTHORS
@@ -6,3 +6,4 @@
 
 Baseflow <hello@baseflow.com>
 Maurits van Beusekom <maurits@baseflow.com>
+Lukas Kurz <me@lukaskurz.com>

--- a/permission_handler_apple/CHANGELOG.md
+++ b/permission_handler_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 9.0.3
+
+* Ensures a request for `locationAlways` permission returns a result unblocking the permission request and preventing the `ERROR_ALREADY_REQUESTING_PERMISSIONS` error for subsequent permission request.
+
 ## 9.0.2
 
 * Moves Apple implementation into its own package.

--- a/permission_handler_apple/ios/Classes/strategies/LocationPermissionStrategy.h
+++ b/permission_handler_apple/ios/Classes/strategies/LocationPermissionStrategy.h
@@ -12,7 +12,6 @@
 
 @interface LocationPermissionStrategy : NSObject <PermissionStrategy, CLLocationManagerDelegate>
 - (instancetype)initWithLocationManager;
-- (void) receiveActivityNotification:(NSNotification *)notification;
 @end
 
 #else

--- a/permission_handler_apple/ios/Classes/strategies/LocationPermissionStrategy.h
+++ b/permission_handler_apple/ios/Classes/strategies/LocationPermissionStrategy.h
@@ -12,6 +12,7 @@
 
 @interface LocationPermissionStrategy : NSObject <PermissionStrategy, CLLocationManagerDelegate>
 - (instancetype)initWithLocationManager;
+- (void) receiveActivityNotification:(NSNotification *)notification;
 @end
 
 #else

--- a/permission_handler_apple/ios/Classes/strategies/LocationPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/LocationPermissionStrategy.m
@@ -7,6 +7,10 @@
 
 #if PERMISSION_LOCATION
 
+@interface LocationPermissionStrategy ()
+- (void) receiveActivityNotification:(NSNotification *)notification;
+@end
+
 @implementation LocationPermissionStrategy {
     CLLocationManager *_locationManager;
     PermissionStatusHandler _permissionStatusHandler;

--- a/permission_handler_apple/ios/Classes/strategies/LocationPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/LocationPermissionStrategy.m
@@ -53,6 +53,7 @@
         }
     } else if (permission == PermissionGroupLocationAlways) {
         if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"] != nil) {
+            [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(receiveActivityNotification:) name:UIApplicationDidBecomeActiveNotification object:nil];
             [_locationManager requestAlwaysAuthorization];
         } else {
             [[NSException exceptionWithName:NSInternalInconsistencyException reason:@"To use location in iOS8 you need to define NSLocationAlwaysUsageDescription in the app bundle's Info.plist file" userInfo:nil] raise];
@@ -64,6 +65,22 @@
             [[NSException exceptionWithName:NSInternalInconsistencyException reason:@"To use location in iOS8 you need to define NSLocationWhenInUseUsageDescription in the app bundle's Info.plist file" userInfo:nil] raise];
         }
     }
+}
+
+- (void) receiveActivityNotification:(NSNotification *) notification {
+    CLAuthorizationStatus status;
+    if(@available(iOS 14.0, *)){
+        status = _locationManager.authorizationStatus;
+    } else {
+        status = [CLLocationManager authorizationStatus];
+    }
+
+    if ((_requestedPermission == PermissionGroupLocationAlways && status != kCLAuthorizationStatusAuthorizedAlways)) {
+        PermissionStatus permissionStatus = [LocationPermissionStrategy determinePermissionStatus:_requestedPermission authorizationStatus:status];
+
+        _permissionStatusHandler(permissionStatus);
+    }
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidBecomeActiveNotification object:nil];    
 }
 
 // {WARNING}

--- a/permission_handler_apple/pubspec.yaml
+++ b/permission_handler_apple/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler_apple
 description: Permission plugin for Flutter. This plugin provides the iOS API to request and check permissions.
-version: 9.0.2
+version: 9.0.3
 homepage: https://github.com/baseflow/flutter-permission-handler
 
 environment:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

I will apologise right now for the long explanation, but I think it is warranted to understand the complicated nature of the issue and how it was fixed.

TLDR; When you request `locationAlways` and deny the request, then the next permission request results in a `ERROR_ALREADY_REQUESTING_PERMISSIONS` error. This is due odd behaviour in the iOS API and a callback that never gets called.

Longer explanation:
The error occurs when we try to obtain `locationAlways` permission. For this, we first have to obtain `locationWhenInUse` permission, and then upgrade our permission by requesting `locationAlways`. The way this is done natively is by calling the asynchronous `requestWhenInUseAuthorization` and `requestAlwaysAuthorization` respectively.

[LocationPermissionStrategy.m:34](https://github.com/Baseflow/flutter-permission-handler/blob/4c5ae3f977a56c30da591afe5a43823c14bf5b0c/permission_handler_apple/ios/Classes/strategies/LocationPermissionStrategy.m#L34)
```objc
- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {
    PermissionStatus status = [self checkPermissionStatus:permission];
    if ([CLLocationManager authorizationStatus] == kCLAuthorizationStatusAuthorizedWhenInUse && permission == PermissionGroupLocationAlways) {
        // don't do anything and continue requesting permissions
    } else if (status != PermissionStatusDenied) {
        completionHandler(status);
        return;
    }
    
    _permissionStatusHandler = completionHandler;
    _requestedPermission = permission;
    
    if (permission == PermissionGroupLocation) {
        if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"] != nil) {
            [_locationManager requestAlwaysAuthorization];
        } else if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"] != nil) {
            [_locationManager requestWhenInUseAuthorization];
        } else {
            [[NSException exceptionWithName:NSInternalInconsistencyException reason:@"To use location in iOS8 you need to define either NSLocationWhenInUseUsageDescription or NSLocationAlwaysUsageDescription in the app bundle's Info.plist file" userInfo:nil] raise];
        }
    } else if (permission == PermissionGroupLocationAlways) {
        if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"] != nil) {
            [_locationManager requestAlwaysAuthorization];
        } else {
            [[NSException exceptionWithName:NSInternalInconsistencyException reason:@"To use location in iOS8 you need to define NSLocationAlwaysUsageDescription in the app bundle's Info.plist file" userInfo:nil] raise];
        }
    } else if (permission == PermissionGroupLocationWhenInUse) {
        if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"] != nil) {
            [_locationManager requestWhenInUseAuthorization];
        } else {
            [[NSException exceptionWithName:NSInternalInconsistencyException reason:@"To use location in iOS8 you need to define NSLocationWhenInUseUsageDescription in the app bundle's Info.plist file" userInfo:nil] raise];
        }
    }
}
```

Due to the nature of the [CLLocationManager API](https://developer.apple.com/documentation/corelocation/cllocationmanager?language=objc), we don't get a direct response/return when requesting authorization, but rather through [`locationManager:didChangeAuthorizationStatus:`](https://developer.apple.com/documentation/corelocation/cllocationmanagerdelegate/1423701-locationmanager?language=objc)(which is deprecated as of iOS 14 btw). As explained in the documentation of the new [`locationManagerDidChangeAuthorization:`](https://developer.apple.com/documentation/corelocation/cllocationmanagerdelegate/3563956-locationmanagerdidchangeauthoriz?language=objc), this method only gets called once when the current authorization is undetermined ~ not yet requested, and whenever the authorization changes, atleast according to the documentation. So to get our response we register a callback before the request, and call it from inside the `didChangeAuthorization` method. And this is were our error stems from.

In the case of `requestWhenInUseAuthorization`, the current authorization is undetermined, which is not interesting and gets handled here.

[LocationPermissionStrategy.m:78](https://github.com/Baseflow/flutter-permission-handler/blob/4c5ae3f977a56c30da591afe5a43823c14bf5b0c/permission_handler_apple/ios/Classes/strategies/LocationPermissionStrategy.m#L78)
```objc
- (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {
    if (status == kCLAuthorizationStatusNotDetermined) {
        return;
    }
```

The dialog shown to the user offers 3 authorization levels

![image](https://user-images.githubusercontent.com/22956519/155895176-19651a45-4095-4fcd-9dfd-2c4347b95c63.png)

In each case, the authorization changes and `didChangeAuthorization` gets called, thus our callback gets called too and everything is (still) fine.

Given that we have now obtained `locationWhenInUse` permission, we now request to upgrade it to `locationAlways`, which promts a dialog with only 2 options

![image](https://user-images.githubusercontent.com/22956519/155895338-707f61bb-7aaa-4e3f-b859-8af44bbaeac9.png)

If we were to `Always Allow`, then the authorization would change again and everything would work as expected.
However if we `Keep only while using`, then our upgrade request was sort of "denied", resulting in no change to the authorization, which means `didChangeAuthorization` never gets called and in turn our callback is never called. This results in our chain of callbacks from [`LocationStrategy.m:43`](https://github.com/Baseflow/flutter-permission-handler/blob/4c5ae3f977a56c30da591afe5a43823c14bf5b0c/permission_handler_apple/ios/Classes/strategies/LocationPermissionStrategy.m#L43), to [PermissionManager.m:60](https://github.com/Baseflow/flutter-permission-handler/blob/4c5ae3f977a56c30da591afe5a43823c14bf5b0c/permission_handler_apple/ios/Classes/PermissionManager.m#L60), to [PermissionHandlerPlugin.m:45](https://github.com/Baseflow/flutter-permission-handler/blob/4c5ae3f977a56c30da591afe5a43823c14bf5b0c/permission_handler_apple/ios/Classes/PermissionHandlerPlugin.m#L45) never being called, resulting in `_methodResult` never being set to `nil`.

[PermissionHandlerPlugin.m:48](https://github.com/Baseflow/flutter-permission-handler/blob/4c5ae3f977a56c30da591afe5a43823c14bf5b0c/permission_handler_apple/ios/Classes/PermissionHandlerPlugin.m#L48)
```objc
[_permissionManager requestPermissions:permissions completion:^(NSDictionary *permissionRequestResults) {
   if (self->_methodResult != nil) {
       self->_methodResult(permissionRequestResults);
   }
   
   self->_methodResult = nil;
}];
```

So the next time we request a permission this check fails and triggers our error

```objc
- (void)handleMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result {
    if ([@"checkPermissionStatus" isEqualToString:call.method]) {
        PermissionGroup permission = [Codec decodePermissionGroupFrom:call.arguments];
        [PermissionManager checkPermissionStatus:permission result:result];
    } else if ([@"checkServiceStatus" isEqualToString:call.method]) {
        PermissionGroup permission = [Codec decodePermissionGroupFrom:call.arguments];
        [PermissionManager checkServiceStatus:permission result:result];
    } else if ([@"requestPermissions" isEqualToString:call.method]) {
        if (_methodResult != nil) {
            result([FlutterError errorWithCode:@"ERROR_ALREADY_REQUESTING_PERMISSIONS" message:@"A request for permissions is already running, please wait for it to finish before doing another request (note that you can request multiple permissions at the same time)." details:nil]);
        }
```

### :new: What is the new behavior (if this is a feature change)?

According to response from an apple staffer in the apple developer forum, where i created a post about this, the correct way is to "respect" the users choice and not pester them ~ only respond to the dialog, if given permission, but not if permission is denied. This however would mean a different behaviour for requesting permission than on android, which would mean we have to code platform specific behavior in flutter, which is not nice.

I came up a possible solution, that allows us to stay in line with the current behaviour. All we really need is to have a callback that gets called, when the upgrade dialog is denied ~ the permission does not change. So my idea was to subscribe to the `NSNotificationCenter` and listen for `UIApplicationDidBecomeActiveNotification`, similar to how we listen to `didChangeAppLifecycleState`in Flutter. The notification should be sent/received once the permission dialog closes and the app is returning back to foreground, but not before the internal `didChangeAuthorization` gets called.

This also fixes a problem, where the request is stuck/unresponsive, due to the callback never being called.

I tested these changes in my companies app and all combinations of denied/allowed worked, as they should.

### :boom: Does this PR introduce a breaking change?

Not really, it fixes a bug.

### :bug: Recommendations for testing

:shrug: 

### :memo: Links to relevant issues/docs

#721 #733 #780 i think these are affected, but maybe a couple others too, which is hard to say, due to lack of information in some of the issues.

### :thinking: Checklist before submitting

- [X] I made sure all projects build.
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [X] I updated the relevant documentation.
- [X] I rebased onto current `master`.

### Note

I am in no way a experienced iOS developer, I had to spend a whole day learning the basics of objective c to even understand the native code :sweat_smile: And I also don't have any iOS/OSX capable devices, so I had to do some good old fashioned pair-programming with a colleague who has a mac-mini + iphone to debug this. I still hope the code is up to standard, since I have no way to tell without xcode :shrug: 