### PR TITLE
Add support for POST_NOTIFICATIONS permissions on Android 13+

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 9.3.0
+
+> **IMPORTANT:** when updating to version 9.3.0 make sure to also set the `compileSdkVersion` in the `app/build.gradle` file to `33`.
+
+* Added support for the new Android 13 Notification permission (POST_NOTIFICATIONS) on example app.
+* Updated Android compile and target SDK to 33 (Android 13 (Tiramisu)) on example app.
+
 ## 9.2.0
 
 * Federated permission_handler_windows for the Windows version.

--- a/permission_handler/example/android/app/build.gradle
+++ b/permission_handler/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -36,7 +36,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.baseflow.permissionhandler.example"
         minSdkVersion 16
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/permission_handler/example/android/app/src/main/AndroidManifest.xml
+++ b/permission_handler/example/android/app/src/main/AndroidManifest.xml
@@ -78,6 +78,9 @@
     <!-- Permissions options for the `access notification policy` group -->
     <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY"/>
 
+    <!-- Permissions options for the `notification` group -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+
     <application
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-version: 9.2.0
+version: 9.3.0
 homepage: https://github.com/baseflow/flutter-permission-handler
 
 environment:

--- a/permission_handler_android/CHANGELOG.md
+++ b/permission_handler_android/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 9.1.0
+
+> **IMPORTANT:** when updating to version 9.1.0 make sure to also set the `compileSdkVersion` in the `app/build.gradle` file to `33`.
+
+* Added support for the new Android 13 Notification permission: POST_NOTIFICATIONS.
+* Updated Android compile and target SDK to 33 (Android 13 (Tiramisu)).
+
 ## 9.0.2+1
 
 * Undoes PR [#765](https://github.com/baseflow/flutter-permission-handler/pull/765) which by mistake requests write_external_storage permission based on the target SDK instead of the actual SDK of the Android device.

--- a/permission_handler_android/android/build.gradle
+++ b/permission_handler_android/android/build.gradle
@@ -27,7 +27,7 @@ project.getTasks().withType(JavaCompile){
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
@@ -75,6 +75,8 @@ public class PermissionUtils {
                 return PermissionConstants.PERMISSION_GROUP_BLUETOOTH_ADVERTISE;
             case Manifest.permission.BLUETOOTH_CONNECT:
                 return PermissionConstants.PERMISSION_GROUP_BLUETOOTH_CONNECT;
+            case Manifest.permission.POST_NOTIFICATIONS:
+                return PermissionConstants.PERMISSION_GROUP_NOTIFICATION;
             default:
                 return PermissionConstants.PERMISSION_GROUP_UNKNOWN;
         }
@@ -211,7 +213,7 @@ public class PermissionUtils {
                 if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q)
                     return null;
 
-                if(hasPermissionInManifest(context, permissionNames, Manifest.permission.ACCESS_MEDIA_LOCATION))
+                if (hasPermissionInManifest(context, permissionNames, Manifest.permission.ACCESS_MEDIA_LOCATION))
                     permissionNames.add(Manifest.permission.ACCESS_MEDIA_LOCATION);
                 break;
 
@@ -233,25 +235,25 @@ public class PermissionUtils {
             case PermissionConstants.PERMISSION_GROUP_MANAGE_EXTERNAL_STORAGE:
                 // The MANAGE_EXTERNAL_STORAGE permission is introduced in Android R, meaning we should
                 // not handle permissions on pre Android R devices.
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && hasPermissionInManifest(context, permissionNames, Manifest.permission.MANAGE_EXTERNAL_STORAGE ))
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && hasPermissionInManifest(context, permissionNames, Manifest.permission.MANAGE_EXTERNAL_STORAGE))
                     permissionNames.add(Manifest.permission.MANAGE_EXTERNAL_STORAGE);
                 break;
 
             case PermissionConstants.PERMISSION_GROUP_SYSTEM_ALERT_WINDOW:
-                if (hasPermissionInManifest(context, permissionNames, Manifest.permission.SYSTEM_ALERT_WINDOW ))
+                if (hasPermissionInManifest(context, permissionNames, Manifest.permission.SYSTEM_ALERT_WINDOW))
                     permissionNames.add(Manifest.permission.SYSTEM_ALERT_WINDOW);
                 break;
 
             case PermissionConstants.PERMISSION_GROUP_REQUEST_INSTALL_PACKAGES:
                 // The REQUEST_INSTALL_PACKAGES permission is introduced in Android M, meaning we should
                 // not handle permissions on pre Android M devices.
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && hasPermissionInManifest(context, permissionNames, Manifest.permission.REQUEST_INSTALL_PACKAGES ))
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && hasPermissionInManifest(context, permissionNames, Manifest.permission.REQUEST_INSTALL_PACKAGES))
                     permissionNames.add(Manifest.permission.REQUEST_INSTALL_PACKAGES);
                 break;
             case PermissionConstants.PERMISSION_GROUP_ACCESS_NOTIFICATION_POLICY:
                 // The REQUEST_NOTIFICATION_POLICY permission is introduced in Android M, meaning we should
                 // not handle permissions on pre Android M devices.
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && hasPermissionInManifest(context, permissionNames, Manifest.permission.ACCESS_NOTIFICATION_POLICY ))
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && hasPermissionInManifest(context, permissionNames, Manifest.permission.ACCESS_NOTIFICATION_POLICY))
                     permissionNames.add(Manifest.permission.ACCESS_NOTIFICATION_POLICY);
                 break;
             case PermissionConstants.PERMISSION_GROUP_BLUETOOTH_SCAN: {
@@ -288,6 +290,15 @@ public class PermissionUtils {
                 break;
             }
             case PermissionConstants.PERMISSION_GROUP_NOTIFICATION:
+                // The POST_NOTIFICATIONS permission is introduced in Android T, meaning we should
+                // not handle permissions on pre Android T devices.
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU)
+                    return null;
+
+                if (hasPermissionInManifest(context, permissionNames, Manifest.permission.POST_NOTIFICATIONS))
+                    permissionNames.add(Manifest.permission.POST_NOTIFICATIONS);
+                break;
+
             case PermissionConstants.PERMISSION_GROUP_MEDIA_LIBRARY:
             case PermissionConstants.PERMISSION_GROUP_PHOTOS:
             case PermissionConstants.PERMISSION_GROUP_REMINDERS:
@@ -313,9 +324,12 @@ public class PermissionUtils {
                 return false;
             }
 
-            PackageInfo info = context
-                    .getPackageManager()
-                    .getPackageInfo(context.getPackageName(), PackageManager.GET_PERMISSIONS);
+            PackageManager pm = context.getPackageManager();
+
+            @SuppressWarnings("deprecation")
+            PackageInfo info = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+                    ? pm.getPackageInfo(context.getPackageName(), PackageManager.PackageInfoFlags.of(PackageManager.GET_PERMISSIONS))
+                    : pm.getPackageInfo(context.getPackageName(), PackageManager.GET_PERMISSIONS);
 
             if (info == null) {
                 Log.d(PermissionConstants.LOG_TAG, "Unable to get Package info, will not be able to determine permissions to request.");
@@ -368,16 +382,16 @@ public class PermissionUtils {
     }
 
     private static String determineBluetoothPermission(Context context, String permission) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && hasPermissionInManifest(context, null, permission )) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && hasPermissionInManifest(context, null, permission)) {
             return permission;
         } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-            if(hasPermissionInManifest(context, null, Manifest.permission.ACCESS_FINE_LOCATION)){
+            if (hasPermissionInManifest(context, null, Manifest.permission.ACCESS_FINE_LOCATION)) {
                 return Manifest.permission.ACCESS_FINE_LOCATION;
-            } else if (hasPermissionInManifest(context, null, Manifest.permission.ACCESS_COARSE_LOCATION)){
+            } else if (hasPermissionInManifest(context, null, Manifest.permission.ACCESS_COARSE_LOCATION)) {
                 return Manifest.permission.ACCESS_COARSE_LOCATION;
             }
 
-            return  null;
+            return null;
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && hasPermissionInManifest(context, null, Manifest.permission.ACCESS_FINE_LOCATION)) {
             return Manifest.permission.ACCESS_FINE_LOCATION;
         }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ServiceManager.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ServiceManager.java
@@ -72,7 +72,11 @@ final class ServiceManager {
 
             Intent callIntent = new Intent(Intent.ACTION_CALL);
             callIntent.setData(Uri.parse("tel:123123"));
-            List<ResolveInfo> callAppsList = pm.queryIntentActivities(callIntent, 0);
+
+            @SuppressWarnings("deprecation")
+            List<ResolveInfo> callAppsList = Build.VERSION.SDK_INT >= VERSION_CODES.TIRAMISU
+                    ? pm.queryIntentActivities(callIntent, PackageManager.ResolveInfoFlags.of(0))
+                    : pm.queryIntentActivities(callIntent, 0);
 
             if (callAppsList.isEmpty()) {
                 successCallback.onSuccess(PermissionConstants.SERVICE_STATUS_NOT_APPLICABLE);

--- a/permission_handler_android/pubspec.yaml
+++ b/permission_handler_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler_android
 description: Permission plugin for Flutter. This plugin provides the Android API to request and check permissions.
-version: 9.0.2+1
+version: 9.1.0
 homepage: https://github.com/baseflow/flutter-permission-handler
 
 environment:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature: add support for POST_NOTIFICATIONS permissions on Android 13+ 

### :arrow_heading_down: What is the current behavior?

Notifications are enabled by default on Android versions prior to 13, so this package just ignores it.

### :new: What is the new behavior (if this is a feature change)?

On devices running Android 13 or newer, asks for POST_NOTIFICATIONS permission. 
[![POST_NOTIFICATIONS example](https://i.imgur.com/bAooOLq.png "POST_NOTIFICATIONS example")](https://i.imgur.com/bAooOLq.png)

### :boom: Does this PR introduce a breaking change?

Yes, `compileSdkVersion` in the `app/build.gradle` file must be set to `33`.

### :bug: Recommendations for testing

* Install **Android SDK Build-Tools 33** from the **SDK Manager**
* Run the example app on an emulator.

### :memo: Links to relevant issues/docs
* Closes Baseflow/flutter-permission-handler#815
* [Android documentation](https://developer.android.com/about/versions/13/changes/notification-permission)
* [Android 13 Beta 3 and Platform Stability](https://android-developers.googleblog.com/2022/06/android-13-beta-3-platform-stability.html)

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
