### PR TITLE
Release version 10.0.0

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 10.0.0
+
+* __BREAKING CHANGE__: Updated Android `compileSdkVersion` to `33` to handle the new `POST_NOTIFICATIONS` permission.
+> When updating to version 10.0.0 make sure to update the `android/app/build.gradle` file and set the `compileSdkVersion` to `33`.
+
 ## 9.2.0
 
 * Federated permission_handler_windows for the Windows version.

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-version: 9.2.0
+version: 10.0.0
 homepage: https://github.com/baseflow/flutter-permission-handler
 
 environment:
@@ -21,7 +21,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.7.0
-  permission_handler_android: ^9.0.2
+  permission_handler_android: ^10.0.0
   permission_handler_apple: ^9.0.2
   permission_handler_windows: ^0.1.0
   permission_handler_platform_interface: ^3.7.0

--- a/permission_handler_android/CHANGELOG.md
+++ b/permission_handler_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 10.0.0
+
+* __BREAKING CHANGE__: Updated Android `compileSdkVersion` to `33` to handle the new `POST_NOTIFICATIONS` permission.
+> When updating to version 10.0.0 make sure to update the `android/app/build.gradle` file and set the `compileSdkVersion` to `33`.
+
 ## 9.0.2+1
 
 * Undoes PR [#765](https://github.com/baseflow/flutter-permission-handler/pull/765) which by mistake requests write_external_storage permission based on the target SDK instead of the actual SDK of the Android device.

--- a/permission_handler_android/pubspec.yaml
+++ b/permission_handler_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler_android
 description: Permission plugin for Flutter. This plugin provides the Android API to request and check permissions.
-version: 9.0.2+1
+version: 10.0.0
 homepage: https://github.com/baseflow/flutter-permission-handler
 
 environment:


### PR DESCRIPTION
Bump `permission_handler` and `permission_handler_android` to 10.0.0 (Android 13 related breaking changes).

Part of #845.