### PR TITLE
Updated GitHub workflow actions

### DIFF
--- a/.github/workflows/permission_handler.yaml
+++ b/.github/workflows/permission_handler.yaml
@@ -29,10 +29,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       
       # Make sure the stable version of Flutter is available
-      - uses: subosito/flutter-action@v1
+      - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
 

--- a/.github/workflows/permission_handler_android.yaml
+++ b/.github/workflows/permission_handler_android.yaml
@@ -29,10 +29,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       
       # Make sure the stable version of Flutter is available
-      - uses: subosito/flutter-action@v1
+      - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
 

--- a/.github/workflows/permission_handler_apple.yaml
+++ b/.github/workflows/permission_handler_apple.yaml
@@ -29,10 +29,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       
       # Make sure the stable version of Flutter is available
-      - uses: subosito/flutter-action@v1
+      - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
 

--- a/.github/workflows/permission_handler_platform_interface.yaml
+++ b/.github/workflows/permission_handler_platform_interface.yaml
@@ -28,10 +28,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       
       # Make sure the stable version of Flutter is available
-      - uses: subosito/flutter-action@v1
+      - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Maintenance

### :arrow_heading_down: What is the current behavior?

The GitHub Actions steps "checkout" and "flutter-action" are outdated and cause failures downloading flutter dependencies.

### :new: What is the new behavior (if this is a feature change)?

Updated the GitHub Actions steps to the latest versions (checkout to v3 and flutter-action to v2 respectively).

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
