### PR TITLE
Fix missing POST_NOTIFICATION permission in android manifest for example projects.

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.0.1
+
+* Fixes missing POST_NOTIFICATIONS permission in Android example project.
+  
 ## 10.0.0
 
 * __BREAKING CHANGE__: Updated Android `compileSdkVersion` to `33` to handle the new `POST_NOTIFICATIONS` permission.

--- a/permission_handler/example/android/app/src/main/AndroidManifest.xml
+++ b/permission_handler/example/android/app/src/main/AndroidManifest.xml
@@ -78,6 +78,9 @@
     <!-- Permissions options for the `access notification policy` group -->
     <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY"/>
 
+    <!-- Permissions options for the `notification` group -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+
     <application
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-version: 10.0.0
+version: 10.0.1
 homepage: https://github.com/baseflow/flutter-permission-handler
 
 environment:
@@ -21,7 +21,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.7.0
-  permission_handler_android: ^10.0.0
+  permission_handler_android: ^10.0.1
   permission_handler_apple: ^9.0.2
   permission_handler_windows: ^0.1.0
   permission_handler_platform_interface: ^3.7.0

--- a/permission_handler_android/CHANGELOG.md
+++ b/permission_handler_android/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 10.0.1
+
+* Fixes missing POST_NOTIFICATIONS permission in Android example project.
 ## 10.0.0
 
  * __BREAKING CHANGE__: Updated Android `compileSdkVersion` to `33` to handle the new `POST_NOTIFICATIONS` permission.

--- a/permission_handler_android/example/android/app/src/main/AndroidManifest.xml
+++ b/permission_handler_android/example/android/app/src/main/AndroidManifest.xml
@@ -78,6 +78,9 @@
     <!-- Permissions options for the `access notification policy` group -->
     <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY"/>
 
+    <!-- Permissions options for the `notification` group -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+
     <application
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"

--- a/permission_handler_android/pubspec.yaml
+++ b/permission_handler_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler_android
 description: Permission plugin for Flutter. This plugin provides the Android API to request and check permissions.
-version: 10.0.0
+version: 10.0.1
 homepage: https://github.com/baseflow/flutter-permission-handler
 
 environment:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug Fix in the example project, for the main package and android.
Closes #865 

### :arrow_heading_down: What is the current behavior?
Permission for notification are not requested on devices running Android 13 when running the example project in 
* permission_handler
* permission_handler_android

### :new: What is the new behavior (if this is a feature change)?
Permission for notification is requested as expected

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Run the example project and verify that notification permission is requested on emulator/device running SDK 33

### :memo: Links to relevant issues/docs
#865 

### :thinking: Checklist before submitting

- [ ] I made sure all projects build. - Will build when the changes in permission_handler_android are released
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [X] I updated the relevant documentation.
- [X] I rebased onto current `master`.
