### PR TITLE
Add Android 13 receive notification permission

### DIFF
--- a/permission_handler/example/android/app/src/main/AndroidManifest.xml
+++ b/permission_handler/example/android/app/src/main/AndroidManifest.xml
@@ -77,6 +77,9 @@
 
     <!-- Permissions options for the `access notification policy` group -->
     <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY"/>
+    
+    <!-- Permissions options for the `post notifications` group -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
         android:name="${applicationName}"


### PR DESCRIPTION
Since SDK 33 android requires to ask for permission to receive notifications. Adding that permission to AndroidManifest.xml is required.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
docs update

### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
https://developer.android.com/develop/ui/views/notifications/notification-permission#declare

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [ ] I updated the relevant documentation.
- [ ] I rebased onto current `master`.
