### PR TITLE
Updated permission_status.dart comments

### DIFF
--- a/permission_handler_platform_interface/lib/src/permission_status.dart
+++ b/permission_handler_platform_interface/lib/src/permission_status.dart
@@ -106,7 +106,7 @@ extension FuturePermissionStatusGetters on Future<PermissionStatus> {
 
   /// *On Android:*
   /// If the user denied access to the requested feature and selected to never
-  /// again show a request for this permission,(pre API 30) or the user denied
+  /// again show a request for this permission (pre API 30) or the user denied
   /// permissions for a second time (API 30 and higher).
   /// The user may still change the permission status in the settings.
   ///

--- a/permission_handler_platform_interface/lib/src/permission_status.dart
+++ b/permission_handler_platform_interface/lib/src/permission_status.dart
@@ -2,7 +2,7 @@ part of permission_handler_platform_interface;
 
 /// Defines the state of a [Permission].
 enum PermissionStatus {
-  /// The user denied access to the requested feature or
+  /// The user denied access to the requested feature,
   /// permission needs to be asked first.
   denied,
 
@@ -19,14 +19,9 @@ enum PermissionStatus {
   /// *Only supported on iOS (iOS14+).*
   limited,
 
-  /// *On Android:*
   /// Permission to the requested feature is permanently denied, the permission
   /// dialog will not be shown when requesting this permission. The user may
   /// still change the permission status in the settings.
-  ///
-  /// *On iOs:*
-  /// Permission to the requested feature has been denied. The user may still
-  /// change the permission status in the settings.
   permanentlyDenied,
 }
 
@@ -64,7 +59,7 @@ extension PermissionStatusValue on PermissionStatus {
 
 /// Utility getter extensions for the [PermissionStatus] type.
 extension PermissionStatusGetters on PermissionStatus {
-  /// If the user denied access to the requested feature or
+  /// If the user denied access to the requested feature,
   /// permission needs to be asked first.
   bool get isDenied => this == PermissionStatus.denied;
 
@@ -79,7 +74,7 @@ extension PermissionStatusGetters on PermissionStatus {
 
   /// *On Android:*
   /// If the user denied access to the requested feature and selected to never
-  /// again show a request for this permission,(pre API 30) or the user denied
+  /// again show a request for this permission (pre API 30) or the user denied
   /// permissions for a second time (API 30 and higher).
   /// The user may still change the permission status in the settings.
   ///

--- a/permission_handler_platform_interface/lib/src/permission_status.dart
+++ b/permission_handler_platform_interface/lib/src/permission_status.dart
@@ -2,7 +2,8 @@ part of permission_handler_platform_interface;
 
 /// Defines the state of a [Permission].
 enum PermissionStatus {
-  /// The user denied access to the requested feature.
+  /// The user denied access to the requested feature or
+  /// permission needs to be asked first.
   denied,
 
   /// The user granted access to the requested feature.
@@ -18,10 +19,14 @@ enum PermissionStatus {
   /// *Only supported on iOS (iOS14+).*
   limited,
 
+  /// *On Android:*
   /// Permission to the requested feature is permanently denied, the permission
   /// dialog will not be shown when requesting this permission. The user may
   /// still change the permission status in the settings.
-  /// *Only supported on Android.*
+  ///
+  /// *On iOs:*
+  /// Permission to the requested feature has been denied. The user may still
+  /// change the permission status in the settings.
   permanentlyDenied,
 }
 
@@ -59,7 +64,8 @@ extension PermissionStatusValue on PermissionStatus {
 
 /// Utility getter extensions for the [PermissionStatus] type.
 extension PermissionStatusGetters on PermissionStatus {
-  /// If the user denied access to the requested feature.
+  /// If the user denied access to the requested feature or
+  /// permission needs to be asked first.
   bool get isDenied => this == PermissionStatus.denied;
 
   /// If the user granted access to the requested feature.
@@ -71,10 +77,15 @@ extension PermissionStatusGetters on PermissionStatus {
   /// *Only supported on iOS.*
   bool get isRestricted => this == PermissionStatus.restricted;
 
+  /// *On Android:*
   /// If the user denied access to the requested feature and selected to never
-  /// again show a request for this permission. The user may still change the
-  /// permission status in the settings.
-  /// *Only supported on Android.*
+  /// again show a request for this permission,(pre API 30) or the user denied
+  /// permissions for a second time (API 30 and higher).
+  /// The user may still change the permission status in the settings.
+  ///
+  /// *On iOS:*
+  /// If the user has denied acces to the requested feature.
+  /// The user may still change the permission status in the settings
   ///
   /// WARNING: This can only be determined AFTER requesting this permission.
   /// Therefore make a `request` call first.
@@ -98,10 +109,15 @@ extension FuturePermissionStatusGetters on Future<PermissionStatus> {
   /// *Only supported on iOS.*
   Future<bool> get isRestricted async => (await this).isRestricted;
 
+  /// *On Android:*
   /// If the user denied access to the requested feature and selected to never
-  /// again show a request for this permission. The user may still change the
-  /// permission status in the settings.
-  /// *Only supported on Android.*
+  /// again show a request for this permission,(pre API 30) or the user denied
+  /// permissions for a second time (API 30 and higher).
+  /// The user may still change the permission status in the settings.
+  ///
+  /// *On iOS:*
+  /// If the user has denied acces to the requested feature.
+  /// The user may still change the permission status in the settings
   Future<bool> get isPermanentlyDenied async =>
       (await this).isPermanentlyDenied;
 


### PR DESCRIPTION
Updated `permission_handler_platform_interface\lib\src\permission_status.dart` comments to better reflect current funtionality

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Docs update

### :arrow_heading_down: What is the current behavior?
-

### :new: What is the new behavior (if this is a feature change)?
-

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
-

### :memo: Links to relevant issues/docs
[Issue 826](https://github.com/Baseflow/flutter-permission-handler/issues/826)

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [-] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [-] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
