### PR TITLE
Prepare for issue flutter/flutter#109339

### DIFF
--- a/permission_handler_platform_interface/test/src/permission_handler_platform_interface_test.dart
+++ b/permission_handler_platform_interface/test/src/permission_handler_platform_interface_test.dart
@@ -17,7 +17,7 @@ void main() {
       expect(() {
         PermissionHandlerPlatform.instance =
             ImplementsPermissionHandlerPlatform();
-      }, throwsNoSuchMethodError);
+      }, throwsA(anything));
     });
 
     test('Can be extended with `extend`', () {


### PR DESCRIPTION
Currently, in some circumstances where a subclasses of
`PlatformInterface` erroneously uses `implements` rather than
`extends`, a `NoSuchMethodError` will be thrown (in spite of the
documentation at
https://pub.dev/documentation/plugin_platform_interface/latest/plugin_platform_interface/PlatformInterface/verify.html
claiming that `AssertionError` will be thrown).

After https://github.com/flutter/flutter/issues/109339 is fixed, the
correct type of exception will be thrown.  To avoid a test breakage in
`geolocator_platform_interface_test.dart` when the fix happens, we
need to modify the test so that it doesn't care what kind of exception
is thrown.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

The test expects `NoSuchMethodError` to be thrown; this will break after https://github.com/flutter/flutter/issues/109339 is fixed.

### :new: What is the new behavior (if this is a feature change)?

The test doesn't care what kind of exception is thrown, so fixing https://github.com/flutter/flutter/issues/109339 will not cause a breakage.

### :boom: Does this PR introduce a breaking change?

No.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
