### PR TITLE
Fix locationAlways does not work on Android 10

### DIFF
--- a/permission_handler_android/CHANGELOG.md
+++ b/permission_handler_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.0.1
+
+* Fix locationAlways does not work on Android 10.
+
 ## 10.0.0
 
  * __BREAKING CHANGE__: Updated Android `compileSdkVersion` to `33` to handle the new `POST_NOTIFICATIONS` permission.

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
@@ -117,7 +117,9 @@ public class PermissionUtils {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                     if (hasPermissionInManifest(context, permissionNames, Manifest.permission.ACCESS_BACKGROUND_LOCATION))
                         permissionNames.add(Manifest.permission.ACCESS_BACKGROUND_LOCATION);
-                    break;
+
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
+                        break;
                 }
             case PermissionConstants.PERMISSION_GROUP_LOCATION_WHEN_IN_USE:
             case PermissionConstants.PERMISSION_GROUP_LOCATION:

--- a/permission_handler_android/pubspec.yaml
+++ b/permission_handler_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler_android
 description: Permission plugin for Flutter. This plugin provides the Android API to request and check permissions.
-version: 10.0.0
+version: 10.0.1
 homepage: https://github.com/baseflow/flutter-permission-handler
 
 environment:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This change fixes the regression described in Issue #917.

### :arrow_heading_down: What is the current behavior?
The current behavior is that Runtime Permission is not shown when requesting locationAlways on Android 10 (Q).

### :new: What is the new behavior (if this is a feature change)?
In Android Q (10), it is possible to request background and foreground permissions at the same time. LocationAlways satisfies this.
Android 11 (R) or higher cannot request background and foreground permissions at the same time, so v10.0.1 behavior is not affected.
These are Android specifications.
https://developer.android.com/training/location/permissions#request-background-location

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
When I request locationAlways on Android 10 (Q), the Runtime Permission appears and I can select "Allow all the time".

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X] I made sure all projects build.
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [X] I updated the relevant documentation.
- [X] I rebased onto current `master`.
