### PR TITLE
Added support for new Android 13 permission: NEARBY_WIFI_DEVICES

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.1.0
+
+* Added support for the new Android 13 permission: NEARBY_WIFI_DEVICES.
+
 ## 10.0.1
 
 - Fix PermissionHandlerEnums link in the README.md

--- a/permission_handler/example/android/app/src/main/AndroidManifest.xml
+++ b/permission_handler/example/android/app/src/main/AndroidManifest.xml
@@ -60,11 +60,12 @@
     <!-- Permissions options for the `ignoreBatteryOptimizations` group -->
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
-    <!-- Permissions options for the `bluetooth` group -->
+    <!-- Permissions options for the `nearby devices` group -->
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.NEARBY_WIFI_DEVICES" />
 
     <!-- Permissions options for the `manage external storage` group -->
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
@@ -77,6 +78,8 @@
 
     <!-- Permissions options for the `access notification policy` group -->
     <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY"/>
+
+
 
     <application
         android:name="${applicationName}"

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-version: 10.0.1
+version: 10.1.0
 homepage: https://github.com/baseflow/flutter-permission-handler
 
 environment:

--- a/permission_handler_android/CHANGELOG.md
+++ b/permission_handler_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.1.0
+
+* Added support for the new Android 13 permission: NEARBY_WIFI_DEVICES.
+
 ## 10.0.0
 
  * __BREAKING CHANGE__: Updated Android `compileSdkVersion` to `33` to handle the new `POST_NOTIFICATIONS` permission.

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionConstants.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionConstants.java
@@ -46,6 +46,7 @@ final class PermissionConstants {
     static final int PERMISSION_GROUP_BLUETOOTH_SCAN = 28;
     static final int PERMISSION_GROUP_BLUETOOTH_ADVERTISE = 29;
     static final int PERMISSION_GROUP_BLUETOOTH_CONNECT = 30;
+    static final int PERMISSION_GROUP_NEARBY_WIFI_DEVICES = 31;
 
 
     @Retention(RetentionPolicy.SOURCE)
@@ -77,7 +78,8 @@ final class PermissionConstants {
             PERMISSION_GROUP_ACCESS_NOTIFICATION_POLICY,
             PERMISSION_GROUP_BLUETOOTH_SCAN,
             PERMISSION_GROUP_BLUETOOTH_ADVERTISE,
-            PERMISSION_GROUP_BLUETOOTH_CONNECT
+            PERMISSION_GROUP_BLUETOOTH_CONNECT,
+            PERMISSION_GROUP_NEARBY_WIFI_DEVICES
     })
     @interface PermissionGroup {
     }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
@@ -298,7 +298,7 @@ public class PermissionUtils {
                     permissionNames.add(Manifest.permission.POST_NOTIFICATIONS);
                 break;
             case PermissionConstants.PERMISSION_GROUP_NEARBY_WIFI_DEVICES:
-                if(Build.VERSION.SDK.INT >= Build.VERSION_CODES.TIRAMISU && hasPermissionInManifest(context, permissionNames, Manifest.permission.NEARBY_WIFI_DEVICES )) 
+                if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && hasPermissionInManifest(context, permissionNames, Manifest.permission.NEARBY_WIFI_DEVICES )) 
                     permissionNames.add(Manifest.permission.NEARBY_WIFI_DEVICES);
                 break;
             case PermissionConstants.PERMISSION_GROUP_MEDIA_LIBRARY:

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
@@ -77,6 +77,8 @@ public class PermissionUtils {
                 return PermissionConstants.PERMISSION_GROUP_BLUETOOTH_CONNECT;
             case Manifest.permission.POST_NOTIFICATIONS:
                 return PermissionConstants.PERMISSION_GROUP_NOTIFICATION;
+            case Manifest.permission.NEARBY_WIFI_DEVICES:
+                return PermissionConstants.PERMISSION_GROUP_NEARBY_WIFI_DEVICES;
             default:
                 return PermissionConstants.PERMISSION_GROUP_UNKNOWN;
         }
@@ -294,6 +296,10 @@ public class PermissionUtils {
                 // not handle permissions on pre Android 13 devices.
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && hasPermissionInManifest(context, permissionNames, Manifest.permission.POST_NOTIFICATIONS ))
                     permissionNames.add(Manifest.permission.POST_NOTIFICATIONS);
+                break;
+            case PermissionConstants.PERMISSION_GROUP_NEARBY_WIFI_DEVICES:
+                if(Build.VERSION.SDK.INT >= Build.VERSION_CODES.TIRAMISU && hasPermissionInManifest(context, permissionNames, Manifest.permission.NEARBY_WIFI_DEVICES )) 
+                    permissionNames.add(Manifest.permission.NEARBY_WIFI_DEVICES);
                 break;
             case PermissionConstants.PERMISSION_GROUP_MEDIA_LIBRARY:
             case PermissionConstants.PERMISSION_GROUP_PHOTOS:

--- a/permission_handler_android/example/android/app/src/main/AndroidManifest.xml
+++ b/permission_handler_android/example/android/app/src/main/AndroidManifest.xml
@@ -60,11 +60,12 @@
     <!-- Permissions options for the `ignoreBatteryOptimizations` group -->
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
-    <!-- Permissions options for the `bluetooth` group -->
+    <!-- Permissions options for the `nearby devices` group -->
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.NEARBY_WIFI_DEVICES"/>
 
     <!-- Permissions options for the `manage external storage` group -->
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />

--- a/permission_handler_android/pubspec.yaml
+++ b/permission_handler_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler_android
 description: Permission plugin for Flutter. This plugin provides the Android API to request and check permissions.
-version: 10.0.0
+version: 10.1.0
 homepage: https://github.com/baseflow/flutter-permission-handler
 
 environment:

--- a/permission_handler_platform_interface/CHANGELOG.md
+++ b/permission_handler_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.8.0
+
+* Added support for the new Android 13 permission: NEARBY_WIFI_DEVICES.
+
 ## 3.7.1
 
 * Updated the documentation on permissions in `permission_status.dart`

--- a/permission_handler_platform_interface/lib/src/permissions.dart
+++ b/permission_handler_platform_interface/lib/src/permissions.dart
@@ -176,6 +176,10 @@ class Permission {
   ///iOS: Nothing
   static const bluetoothConnect = Permission._(30);
 
+  ///Android: Allows the user to connect to nearby devices via Wi-Fi
+  ///iOS: Nothing
+  static const nearbyWifiDevices = Permission._(31);
+
   /// Returns a list of all possible [PermissionGroup] values.
   static const List<Permission> values = <Permission>[
     calendar,
@@ -209,6 +213,7 @@ class Permission {
     bluetoothScan,
     bluetoothAdvertise,
     bluetoothConnect,
+    nearbyWifiDevices
   ];
 
   static const List<String> _names = <String>[
@@ -243,6 +248,7 @@ class Permission {
     'bluetoothScan',
     'bluetoothAdvertise',
     'bluetoothConnect',
+    'nearbyWifiDevices'
   ];
 
   @override

--- a/permission_handler_platform_interface/pubspec.yaml
+++ b/permission_handler_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the permission_handler plugin.
 homepage: https://github.com/baseflow/flutter-permission-handler/tree/master/permission_handler_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 3.7.1
+version: 3.8.0
 
 dependencies:
   flutter:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature update, support for the new Android 13 permission: NEARBY_WIFI_DEVICES

### :arrow_heading_down: What is the current behavior?
No support

### :new: What is the new behavior (if this is a feature change)?
Permission supported by relevant packages

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Use the new NEARBY_WIFI_DEVICES permission

### :memo: Links to relevant issues/docs
[859](https://github.com/Baseflow/flutter-permission-handler/issues/859)

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
