### PR TITLE
Added platform interface support for Android 13: NEARBY_WIFI_DEVICES

### DIFF
--- a/permission_handler_platform_interface/CHANGELOG.md
+++ b/permission_handler_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.8.0
+
+* Added support for the new Android 13 permission: NEARBY_WIFI_DEVICES.
+
 ## 3.7.1
 
 * Updated the documentation on permissions in `permission_status.dart`

--- a/permission_handler_platform_interface/lib/src/permissions.dart
+++ b/permission_handler_platform_interface/lib/src/permissions.dart
@@ -176,6 +176,10 @@ class Permission {
   ///iOS: Nothing
   static const bluetoothConnect = Permission._(30);
 
+  ///Android: Allows the user to connect to nearby devices via Wi-Fi
+  ///iOS: Nothing
+  static const nearbyWifiDevices = Permission._(31);
+
   /// Returns a list of all possible [PermissionGroup] values.
   static const List<Permission> values = <Permission>[
     calendar,
@@ -209,6 +213,7 @@ class Permission {
     bluetoothScan,
     bluetoothAdvertise,
     bluetoothConnect,
+    nearbyWifiDevices
   ];
 
   static const List<String> _names = <String>[
@@ -243,6 +248,7 @@ class Permission {
     'bluetoothScan',
     'bluetoothAdvertise',
     'bluetoothConnect',
+    'nearbyWifiDevices'
   ];
 
   @override

--- a/permission_handler_platform_interface/pubspec.yaml
+++ b/permission_handler_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the permission_handler plugin.
 homepage: https://github.com/baseflow/flutter-permission-handler/tree/master/permission_handler_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 3.7.1
+version: 3.8.0
 
 dependencies:
   flutter:

--- a/permission_handler_platform_interface/test/src/permissions_test.dart
+++ b/permission_handler_platform_interface/test/src/permissions_test.dart
@@ -6,7 +6,7 @@ void main() {
       () {
     const values = Permission.values;
 
-    expect(values.length, 31);
+    expect(values.length, 32);
   });
 
   test('check if byValue returns corresponding PermissionGroup value', () {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Added support for new Android 13 permission: NEARBY_WIFI_DEVICES in the platform interface package

### :arrow_heading_down: What is the current behavior?
No support for this permission

### :new: What is the new behavior (if this is a feature change)?
Support for this permission

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
-

### :memo: Links to relevant issues/docs
[859](https://github.com/Baseflow/flutter-permission-handler/issues/859)

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
