### PR TITLE
Added support for new Android 13 NEARBY_WIFI_DEVICES permission

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.1.0
+
+* Added support for the new Android 13 permission: NEARBY_WIFI_DEVICES.
+
 ## 10.0.2
 
 * Adds a link to the issue tracker which shows up as "View/report issues" on pub.dev.

--- a/permission_handler/example/android/app/src/main/AndroidManifest.xml
+++ b/permission_handler/example/android/app/src/main/AndroidManifest.xml
@@ -60,11 +60,12 @@
     <!-- Permissions options for the `ignoreBatteryOptimizations` group -->
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
-    <!-- Permissions options for the `bluetooth` group -->
+    <!-- Permissions options for the `nearby devices` group -->
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.NEARBY_WIFI_DEVICES" />
 
     <!-- Permissions options for the `manage external storage` group -->
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -22,10 +22,10 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.7.0
-  permission_handler_android: ^10.0.0
-  permission_handler_apple: ^9.0.2
-  permission_handler_windows: ^0.1.0
-  permission_handler_platform_interface: ^3.7.0
+  permission_handler_android: ^10.1.0
+  permission_handler_apple: ^9.0.5
+  permission_handler_windows: ^0.1.1
+  permission_handler_platform_interface: ^3.8.0
 
 dev_dependencies:
   flutter_lints: ^1.0.4

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-version: 10.0.2
+version: 10.1.0
 repository: https://github.com/baseflow/flutter-permission-handler
 issue_tracker: https://github.com/Baseflow/flutter-permission-handler/issues
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature: added support for new Android 13 NEARBY_WIFI_DEVICES permission

### :arrow_heading_down: What is the current behavior?
No support

### :new: What is the new behavior (if this is a feature change)?
Support added

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
-

### :memo: Links to relevant issues/docs
[PR: 927](https://github.com/Baseflow/flutter-permission-handler/pull/927)
[ISSUE: 859](https://github.com/Baseflow/flutter-permission-handler/issues/859)

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
