### PR TITLE
Added granular permissions for android 13.

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.0.3 
+
+* Added support for the new Android 13 granular permissions: READ_MEDIA_IMAGES, READ_MEDIA_VIDEO & READ_MEDIA_AUDIO.
+
 ## 10.0.2
 
 * Adds a link to the issue tracker which shows up as "View/report issues" on pub.dev.

--- a/permission_handler/example/android/app/src/main/AndroidManifest.xml
+++ b/permission_handler/example/android/app/src/main/AndroidManifest.xml
@@ -17,6 +17,15 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
+    <!-- Permissions options for the `photos` group -->
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>>
+
+    <!-- Permissions options for the `videos` group -->
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+
+    <!-- Permissions options for the `audio` group -->
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+
     <!-- Permissions options for the `camera` group -->
     <uses-permission android:name="android.permission.CAMERA"/>
 

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-version: 10.0.2
+version: 10.0.3
 repository: https://github.com/baseflow/flutter-permission-handler
 issue_tracker: https://github.com/Baseflow/flutter-permission-handler/issues
 
@@ -22,10 +22,10 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.7.0
-  permission_handler_android: ^10.0.0
+  permission_handler_android: ^10.0.2
   permission_handler_apple: ^9.0.2
   permission_handler_windows: ^0.1.0
-  permission_handler_platform_interface: ^3.7.0
+  permission_handler_platform_interface: ^3.9.0
 
 dev_dependencies:
   flutter_lints: ^1.0.4

--- a/permission_handler_android/CHANGELOG.md
+++ b/permission_handler_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.2.0
+
+* Added support for the new Android 13 granular permissions: READ_MEDIA_IMAGES, READ_MEDIA_VIDEO & READ_MEDIA_AUDIO.
+
 ## 10.1.0
 
 * Added support for the new Android 13 permission: NEARBY_WIFI_DEVICES.

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionConstants.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionConstants.java
@@ -47,6 +47,8 @@ final class PermissionConstants {
     static final int PERMISSION_GROUP_BLUETOOTH_ADVERTISE = 29;
     static final int PERMISSION_GROUP_BLUETOOTH_CONNECT = 30;
     static final int PERMISSION_GROUP_NEARBY_WIFI_DEVICES = 31;
+    static final int PERMISSION_GROUP_VIDEO = 32;
+    static final int PERMISSION_GROUP_AUDIO = 33;
 
 
     @Retention(RetentionPolicy.SOURCE)
@@ -79,7 +81,9 @@ final class PermissionConstants {
             PERMISSION_GROUP_BLUETOOTH_SCAN,
             PERMISSION_GROUP_BLUETOOTH_ADVERTISE,
             PERMISSION_GROUP_BLUETOOTH_CONNECT,
-            PERMISSION_GROUP_NEARBY_WIFI_DEVICES
+            PERMISSION_GROUP_NEARBY_WIFI_DEVICES,
+            PERMISSION_GROUP_VIDEO,
+            PERMISSION_GROUP_AUDIO
     })
     @interface PermissionGroup {
     }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
@@ -79,6 +79,12 @@ public class PermissionUtils {
                 return PermissionConstants.PERMISSION_GROUP_NOTIFICATION;
             case Manifest.permission.NEARBY_WIFI_DEVICES:
                 return PermissionConstants.PERMISSION_GROUP_NEARBY_WIFI_DEVICES;
+            case Manifest.permission.READ_MEDIA_IMAGES:
+                return PermissionConstants.PERMISSION_GROUP_PHOTOS;
+            case Manifest.permission.READ_MEDIA_VIDEO:
+                return PermissionConstants.PERMISSION_GROUP_VIDEO;
+            case Manifest.permission.READ_MEDIA_AUDIO:
+                return PermissionConstants.PERMISSION_GROUP_AUDIO;
             default:
                 return PermissionConstants.PERMISSION_GROUP_UNKNOWN;
         }
@@ -305,6 +311,21 @@ public class PermissionUtils {
                 break;
             case PermissionConstants.PERMISSION_GROUP_MEDIA_LIBRARY:
             case PermissionConstants.PERMISSION_GROUP_PHOTOS:
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && hasPermissionInManifest(context, permissionNames, Manifest.permission.READ_MEDIA_IMAGES ))
+                    permissionNames.add(Manifest.permission.READ_MEDIA_IMAGES);
+                break;
+            case PermissionConstants.PERMISSION_GROUP_VIDEO:
+                // The READ_MEDIA_IMAGES permission is introduced in Android 13, meaning we should
+                // not handle permissions on pre Android 13 devices.
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && hasPermissionInManifest(context, permissionNames, Manifest.permission.READ_MEDIA_VIDEO ))
+                    permissionNames.add(Manifest.permission.READ_MEDIA_VIDEO);
+                break;
+            case PermissionConstants.PERMISSION_GROUP_AUDIO:
+                // The READ_MEDIA_IMAGES permission is introduced in Android 13, meaning we should
+                // not handle permissions on pre Android 13 devices.
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && hasPermissionInManifest(context, permissionNames, Manifest.permission.READ_MEDIA_AUDIO ))
+                    permissionNames.add(Manifest.permission.READ_MEDIA_AUDIO);
+                break;
             case PermissionConstants.PERMISSION_GROUP_REMINDERS:
             case PermissionConstants.PERMISSION_GROUP_UNKNOWN:
                 return null;

--- a/permission_handler_android/pubspec.yaml
+++ b/permission_handler_android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: permission_handler_android
 description: Permission plugin for Flutter. This plugin provides the Android API to request and check permissions.
-version: 10.1.0
-homepage: https://github.com/baseflow/flutter-permission-handler
+version: 10.2.0
+homepage: https://github.com/Mattel/flutter-permission-handler/tree/master/permission_handler_android
 
 environment:
   sdk: ">=2.15.0 <3.0.0"

--- a/permission_handler_android/pubspec.yaml
+++ b/permission_handler_android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: permission_handler_android
 description: Permission plugin for Flutter. This plugin provides the Android API to request and check permissions.
 version: 10.2.0
-homepage: https://github.com/Mattel/flutter-permission-handler/tree/master/permission_handler_android
+homepage: https://github.com/baseflow/flutter-permission-handler/tree/master/permission_handler_android
 
 environment:
   sdk: ">=2.15.0 <3.0.0"
@@ -18,7 +18,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  permission_handler_platform_interface: ^3.7.0
+  permission_handler_platform_interface: ^3.9.0
 
 dev_dependencies:
   flutter_lints: ^1.0.4

--- a/permission_handler_android/pubspec.yaml
+++ b/permission_handler_android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: permission_handler_android
 description: Permission plugin for Flutter. This plugin provides the Android API to request and check permissions.
 version: 10.2.0
-homepage: https://github.com/baseflow/flutter-permission-handler/tree/master/permission_handler_android
+homepage: https://github.com/baseflow/flutter-permission-handler
 
 environment:
   sdk: ">=2.15.0 <3.0.0"

--- a/permission_handler_platform_interface/CHANGELOG.md
+++ b/permission_handler_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.9.0
+
+* Added support for the new Android 13 granular permissions: READ_MEDIA_IMAGES, READ_MEDIA_VIDEO & READ_MEDIA_AUDIO.
+
 ## 3.8.0
 
 * Added support for the new Android 13 permission: NEARBY_WIFI_DEVICES.

--- a/permission_handler_platform_interface/lib/src/permissions.dart
+++ b/permission_handler_platform_interface/lib/src/permissions.dart
@@ -67,7 +67,8 @@ class Permission {
   /// iOS: Nothing
   static const phone = PermissionWithService._(8);
 
-  /// Android: Nothing
+  /// When running on Android T and above: Images files
+  /// When running on Android < T: Nothing
   /// iOS: Photos
   /// iOS 14+ read & write access level
   static const photos = Permission._(9);
@@ -180,6 +181,16 @@ class Permission {
   ///iOS: Nothing
   static const nearbyWifiDevices = Permission._(31);
 
+  /// When running on Android T and above: Videos
+  /// When running on Android < T: Nothing
+  /// iOS: Nothing
+  static const video = Permission._(32);
+
+  /// When running on Android T and above: Audio files
+  /// When running on Android < T: Nothing
+  /// iOS: Nothing
+  static const audio = Permission._(33);
+
   /// Returns a list of all possible [PermissionGroup] values.
   static const List<Permission> values = <Permission>[
     calendar,
@@ -213,7 +224,9 @@ class Permission {
     bluetoothScan,
     bluetoothAdvertise,
     bluetoothConnect,
-    nearbyWifiDevices
+    nearbyWifiDevices,
+    video,
+    audio
   ];
 
   static const List<String> _names = <String>[
@@ -248,7 +261,9 @@ class Permission {
     'bluetoothScan',
     'bluetoothAdvertise',
     'bluetoothConnect',
-    'nearbyWifiDevices'
+    'nearbyWifiDevices',
+    'video',
+    'audio'
   ];
 
   @override

--- a/permission_handler_platform_interface/pubspec.yaml
+++ b/permission_handler_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler_platform_interface
 description: A common platform interface for the permission_handler plugin.
-homepage: https://github.com/Mattel/flutter-permission-handler/tree/master/permission_handler_platform_interface
+homepage: https://github.com/baseflow/flutter-permission-handler/tree/master/permission_handler_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
 version: 3.9.0

--- a/permission_handler_platform_interface/pubspec.yaml
+++ b/permission_handler_platform_interface/pubspec.yaml
@@ -1,9 +1,9 @@
 name: permission_handler_platform_interface
 description: A common platform interface for the permission_handler plugin.
-homepage: https://github.com/baseflow/flutter-permission-handler/tree/master/permission_handler_platform_interface
+homepage: https://github.com/Mattel/flutter-permission-handler/tree/master/permission_handler_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 3.8.0
+version: 3.9.0
 
 dependencies:
   flutter:


### PR DESCRIPTION
✨ What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature: added support for new Android 13 granular permissions (READ_MEDIA_IMAGES, READ_MEDIA_VIDEO & READ_MEDIA_AUDIO).
⤵️ What is the current behavior?

No support
🆕 What is the new behavior (if this is a feature change)?

Support added
💥 Does this PR introduce a breaking change?
No
🐛 Reco
mmendations for testing

📝 Links to relevant issues/docs

🤔 Checklist before submitting

I made sure all projects build.
I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
I updated CHANGELOG.md to add a description of the change.
I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
I updated the relevant documentation.
I rebased onto current master.