### PR TITLE
Added support for new Android media and alarm permissions

### DIFF
--- a/permission_handler_platform_interface/CHANGELOG.md
+++ b/permission_handler_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.9.0
+
+* Added support for the new Android 13 permissions: SCHEDULE_EXACT_ALARM, READ_MEDIA_IMAGES, READ_MEDIA_VIDEO and READ_MEDIA_AUDIO
+
 ## 3.8.0
 
 * Added support for the new Android 13 permission: NEARBY_WIFI_DEVICES.

--- a/permission_handler_platform_interface/lib/src/permissions.dart
+++ b/permission_handler_platform_interface/lib/src/permissions.dart
@@ -67,7 +67,8 @@ class Permission {
   /// iOS: Nothing
   static const phone = PermissionWithService._(8);
 
-  /// Android: Nothing
+  /// When running on Android T and above: Read image files from external storage
+  /// When running on Android < T: Nothing
   /// iOS: Photos
   /// iOS 14+ read & write access level
   static const photos = Permission._(9);
@@ -180,6 +181,21 @@ class Permission {
   ///iOS: Nothing
   static const nearbyWifiDevices = Permission._(31);
 
+  /// When running on Android T and above: Read video files from external storage
+  /// When running on Android < T: Nothing
+  /// iOS: Nothing
+  static const videos = Permission._(32);
+
+  /// When running on Android T and above: Read audio files from external storage
+  /// When running on Android < T: Nothing
+  /// iOS: Nothing
+  static const audio = Permission._(33);
+
+  /// When running on Android S and above: Allows exact alarm functionality
+  /// When running on Android < S: Nothing
+  ///iOS: Nothing
+  static const scheduleExactAlarm = Permission._(34);
+
   /// Returns a list of all possible [PermissionGroup] values.
   static const List<Permission> values = <Permission>[
     calendar,
@@ -213,7 +229,10 @@ class Permission {
     bluetoothScan,
     bluetoothAdvertise,
     bluetoothConnect,
-    nearbyWifiDevices
+    nearbyWifiDevices,
+    videos,
+    audio,
+    scheduleExactAlarm
   ];
 
   static const List<String> _names = <String>[
@@ -248,7 +267,10 @@ class Permission {
     'bluetoothScan',
     'bluetoothAdvertise',
     'bluetoothConnect',
-    'nearbyWifiDevices'
+    'nearbyWifiDevices',
+    'videos',
+    'audio',
+    'scheduleExactAlarm'
   ];
 
   @override

--- a/permission_handler_platform_interface/pubspec.yaml
+++ b/permission_handler_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the permission_handler plugin.
 homepage: https://github.com/baseflow/flutter-permission-handler/tree/master/permission_handler_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 3.8.0
+version: 3.9.0
 
 dependencies:
   flutter:

--- a/permission_handler_platform_interface/test/src/permissions_test.dart
+++ b/permission_handler_platform_interface/test/src/permissions_test.dart
@@ -6,7 +6,7 @@ void main() {
       () {
     const values = Permission.values;
 
-    expect(values.length, 32);
+    expect(values.length, 35);
   });
 
   test('check if byValue returns corresponding PermissionGroup value', () {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Added support for the new Android 13 permissions: SCHEDULE_EXACT_ALARM, READ_MEDIA_IMAGES, READ_MEDIA_VIDEO and READ_MEDIA_AUDIO

### :arrow_heading_down: What is the current behavior?
No support

### :new: What is the new behavior (if this is a feature change)?
Permissions supported

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
-

### :memo: Links to relevant issues/docs
[859](https://github.com/Baseflow/flutter-permission-handler/issues/859)

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
