### PR TITLE
Added platform support for new android granular media and alarm permissions

### DIFF
--- a/permission_handler_android/CHANGELOG.md
+++ b/permission_handler_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.2.0
+
+* Added support for the new Android 13 permissions: SCHEDULE_EXACT_ALARM, READ_MEDIA_IMAGES, READ_MEDIA_VIDEO and READ_MEDIA_AUDIO
+
 ## 10.1.0
 
 * Added support for the new Android 13 permission: NEARBY_WIFI_DEVICES.

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionConstants.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionConstants.java
@@ -49,7 +49,7 @@ final class PermissionConstants {
     static final int PERMISSION_GROUP_NEARBY_WIFI_DEVICES = 31;
     static final int PERMISSION_GROUP_VIDEOS = 32;
     static final int PERMISSION_GROUP_AUDIO = 33;
-    static final int PERMISSINO_GROUP_SCHEDULE_EXACT_ALARM = 34;
+    static final int PERMISSION_GROUP_SCHEDULE_EXACT_ALARM = 34;
 
     @Retention(RetentionPolicy.SOURCE)
     @IntDef({

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionConstants.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionConstants.java
@@ -47,7 +47,9 @@ final class PermissionConstants {
     static final int PERMISSION_GROUP_BLUETOOTH_ADVERTISE = 29;
     static final int PERMISSION_GROUP_BLUETOOTH_CONNECT = 30;
     static final int PERMISSION_GROUP_NEARBY_WIFI_DEVICES = 31;
-
+    static final int PERMISSION_GROUP_VIDEOS = 32;
+    static final int PERMISSION_GROUP_AUDIO = 33;
+    static final int PERMISSINO_GROUP_SCHEDULE_EXACT_ALARM = 34;
 
     @Retention(RetentionPolicy.SOURCE)
     @IntDef({
@@ -79,7 +81,10 @@ final class PermissionConstants {
             PERMISSION_GROUP_BLUETOOTH_SCAN,
             PERMISSION_GROUP_BLUETOOTH_ADVERTISE,
             PERMISSION_GROUP_BLUETOOTH_CONNECT,
-            PERMISSION_GROUP_NEARBY_WIFI_DEVICES
+            PERMISSION_GROUP_NEARBY_WIFI_DEVICES,
+            PERMISSION_GROUP_VIDEOS,
+            PERMISSION_GROUP_AUDIO,
+            PERMISSION_GROUP_SCHEDULE_EXACT_ALARM
     })
     @interface PermissionGroup {
     }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
@@ -333,7 +333,7 @@ public class PermissionUtils {
                 // The SCHEDULE_EXACT_ALARM permission is introduced in Android S, meaning we should
                 // not handle permissions on pre Android S devices.
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && hasPermissionInManifest(context, permissionNames, Manifest.permission.SCHEDULE_EXACT_ALARM ))
-                    permissionNames.add(Manifest.permission.SCHEDULE_EXACT_ALARM)
+                    permissionNames.add(Manifest.permission.SCHEDULE_EXACT_ALARM);
                 break;
             case PermissionConstants.PERMISSION_GROUP_MEDIA_LIBRARY:
             case PermissionConstants.PERMISSION_GROUP_REMINDERS:

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
@@ -306,8 +306,8 @@ public class PermissionUtils {
                     permissionNames.add(Manifest.permission.POST_NOTIFICATIONS);
                 break;
             case PermissionConstants.PERMISSION_GROUP_NEARBY_WIFI_DEVICES:
-            // The NEARBY_WIFI_DEVICES permission is introduced in Android T, meaning we should
-            // not handle permissions on pre Android T devices.
+                // The NEARBY_WIFI_DEVICES permission is introduced in Android T, meaning we should
+                // not handle permissions on pre Android T devices.
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && hasPermissionInManifest(context, permissionNames, Manifest.permission.NEARBY_WIFI_DEVICES ))
                     permissionNames.add(Manifest.permission.NEARBY_WIFI_DEVICES);
                 break;
@@ -317,7 +317,7 @@ public class PermissionUtils {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && hasPermissionInManifest(context, permissionNames, Manifest.permission.READ_MEDIA_IMAGES ))
                     permissionNames.add(Manifest.permission.READ_MEDIA_IMAGES);
                 break;
-                case PermissionConstants.PERMISSION_GROUP_VIDEOS:
+            case PermissionConstants.PERMISSION_GROUP_VIDEOS:
                 // The READ_MEDIA_VIDEOS permission is introduced in Android T, meaning we should
                 // not handle permissions on pre Android T devices.
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && hasPermissionInManifest(context, permissionNames, Manifest.permission.READ_MEDIA_VIDEO ))

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
@@ -79,6 +79,14 @@ public class PermissionUtils {
                 return PermissionConstants.PERMISSION_GROUP_NOTIFICATION;
             case Manifest.permission.NEARBY_WIFI_DEVICES:
                 return PermissionConstants.PERMISSION_GROUP_NEARBY_WIFI_DEVICES;
+            case Manifest.permission.READ_MEDIA_IMAGES:
+                return PermissionConstants.PERMISSION_GROUP_PHOTOS;
+            case Manifest.permission.READ_MEDIA_VIDEO:
+                return PermissionConstants.PERMISSION_GROUP_VIDEOS;
+            case Manifest.permission.READ_MEDIA_AUDIO:
+                return PermissionConstants.PERMISSION_GROUP_AUDIO;
+            case Manifest.permission.SCHEDULE_EXACT_ALARM:
+                return PermissionConstants.PERMISSION_GROUP_SCHEDULE_EXACT_ALARM;
             default:
                 return PermissionConstants.PERMISSION_GROUP_UNKNOWN;
         }
@@ -292,19 +300,42 @@ public class PermissionUtils {
                 break;
             }
             case PermissionConstants.PERMISSION_GROUP_NOTIFICATION:
-                // The POST_NOTIFICATIONS permission is introduced in Android 13, meaning we should
-                // not handle permissions on pre Android 13 devices.
+                // The POST_NOTIFICATIONS permission is introduced in Android T, meaning we should
+                // not handle permissions on pre Android T devices.
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && hasPermissionInManifest(context, permissionNames, Manifest.permission.POST_NOTIFICATIONS ))
                     permissionNames.add(Manifest.permission.POST_NOTIFICATIONS);
                 break;
             case PermissionConstants.PERMISSION_GROUP_NEARBY_WIFI_DEVICES:
-            // The NEARBY_WIFI_DEVICES permission is introduced in Android 13, meaning we should
-            // not handle permissions on pre Android 13 devices.
+            // The NEARBY_WIFI_DEVICES permission is introduced in Android T, meaning we should
+            // not handle permissions on pre Android T devices.
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && hasPermissionInManifest(context, permissionNames, Manifest.permission.NEARBY_WIFI_DEVICES ))
                     permissionNames.add(Manifest.permission.NEARBY_WIFI_DEVICES);
                 break;
-            case PermissionConstants.PERMISSION_GROUP_MEDIA_LIBRARY:
             case PermissionConstants.PERMISSION_GROUP_PHOTOS:
+                // The READ_MEDIA_IMAGES permission is introduced in Android T, meaning we should
+                // not handle permissions on pre Android T devices.   
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && hasPermissionInManifest(context, permissionNames, Manifest.permission.READ_MEDIA_IMAGES ))
+                    permissionNames.add(Manifest.permission.READ_MEDIA_IMAGES);
+                break;
+                case PermissionConstants.PERMISSION_GROUP_VIDEOS:
+                // The READ_MEDIA_VIDEOS permission is introduced in Android T, meaning we should
+                // not handle permissions on pre Android T devices.
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && hasPermissionInManifest(context, permissionNames, Manifest.permission.READ_MEDIA_VIDEO ))
+                    permissionNames.add(Manifest.permission.READ_MEDIA_VIDEO);
+                break;
+            case PermissionConstants.PERMISSION_GROUP_AUDIO:
+                // The READ_MEDIA_AUDIO permission is introduced in Android T, meaning we should
+                // not handle permissions on pre Android T devices.
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && hasPermissionInManifest(context, permissionNames, Manifest.permission.READ_MEDIA_AUDIO ))
+                    permissionNames.add(Manifest.permission.READ_MEDIA_AUDIO);
+                break;
+            case PermissionConstants.PERMISSION_GROUP_SCHEDULE_EXACT_ALARM:
+                // The SCHEDULE_EXACT_ALARM permission is introduced in Android S, meaning we should
+                // not handle permissions on pre Android S devices.
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && hasPermissionInManifest(context, permissionNames, Manifest.permission.SCHEDULE_EXACT_ALARM ))
+                    permissionNames.add(Manifest.permission.SCHEDULE_EXACT_ALARM)
+                break;
+            case PermissionConstants.PERMISSION_GROUP_MEDIA_LIBRARY:
             case PermissionConstants.PERMISSION_GROUP_REMINDERS:
             case PermissionConstants.PERMISSION_GROUP_UNKNOWN:
                 return null;

--- a/permission_handler_android/example/android/app/src/main/AndroidManifest.xml
+++ b/permission_handler_android/example/android/app/src/main/AndroidManifest.xml
@@ -16,6 +16,9 @@
     <!-- Permissions options for the `storage` group -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
 
     <!-- Permissions options for the `camera` group -->
     <uses-permission android:name="android.permission.CAMERA"/>
@@ -78,6 +81,9 @@
 
     <!-- Permissions options for the `access notification policy` group -->
     <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY"/>
+
+    <!-- Permissions options for the `alarm` group -->
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 
     <application
         android:name="${applicationName}"

--- a/permission_handler_android/pubspec.yaml
+++ b/permission_handler_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler_android
 description: Permission plugin for Flutter. This plugin provides the Android API to request and check permissions.
-version: 10.1.0
+version: 10.2.0
 homepage: https://github.com/baseflow/flutter-permission-handler
 
 environment:

--- a/permission_handler_apple/CHANGELOG.md
+++ b/permission_handler_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 9.0.7
+
+* Added new Android 13 permissions "SCHEDULE_EXACT_ALARM, READ_MEDIA_IMAGES, READ_MEDIA_VIDEO and READ_MEDIA_AUDIO" to PermissionHandlerEnums.h
+
 ## 9.0.6
 
 * Prevent appearing popup that asks to turn on Bluetooth on iOS

--- a/permission_handler_apple/ios/Classes/PermissionHandlerEnums.h
+++ b/permission_handler_apple/ios/Classes/PermissionHandlerEnums.h
@@ -142,7 +142,10 @@ typedef NS_ENUM(int, PermissionGroup) {
     PermissionGroupBluetoothScan,
     PermissionGroupBluetoothAdvertise,
     PermissionGroupBluetoothConnect,
-    PermissionGroupNearbyWifiDevices
+    PermissionGroupNearbyWifiDevices,
+    PermissiongroupVideos,
+    PermissionGroupAudio,
+    PermissionGroupScheduleExactAlarm
 };
 
 typedef NS_ENUM(int, PermissionStatus) {

--- a/permission_handler_apple/pubspec.yaml
+++ b/permission_handler_apple/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler_apple
 description: Permission plugin for Flutter. This plugin provides the iOS API to request and check permissions.
-version: 9.0.6
+version: 9.0.7
 homepage: https://github.com/baseflow/flutter-permission-handler
 
 environment:

--- a/permission_handler_windows/CHANGELOG.md
+++ b/permission_handler_windows/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 0.1.1
+## 0.1.2
+
+* Added new Android 13 permissions "SCHEDULE_EXACT_ALARM, READ_MEDIA_IMAGES, READ_MEDIA_VIDEO and READ_MEDIA_AUDIO" to permission_constants.h
+
+## 0.1.1
 
 * Added new Android 13 NEARBY_WIFI_DEVICES permission to permission_constants.h
 

--- a/permission_handler_windows/pubspec.yaml
+++ b/permission_handler_windows/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler_windows
 description: Permission plugin for Flutter. This plugin provides the Windows API to request and check permissions.
-version: 0.1.1
+version: 0.1.2
 homepage: https://github.com/baseflow/flutter-permission-handler
 
 flutter:

--- a/permission_handler_windows/windows/permission_constants.h
+++ b/permission_handler_windows/windows/permission_constants.h
@@ -42,7 +42,10 @@ public:
         BLUETOOTH_SCAN = 28,
         BLUETOOTH_ADVERTISE = 29,
         BLUETOOTH_CONNECT = 30,
-        NEARBY_WIFI_DEVICES = 31
+        NEARBY_WIFI_DEVICES = 31,
+        VIDEOS = 32,
+        AUDIO = 33,
+        SCHEDULE_EXACT_ALARM = 34
     };
 
     //PERMISSION_STATUS


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Added support in the android platform package for the new Android 13 permissions: SCHEDULE_EXACT_ALARM, READ_MEDIA_IMAGES, READ_MEDIA_VIDEO and READ_MEDIA_AUDIO

### :arrow_heading_down: What is the current behavior?
No support

### :new: What is the new behavior (if this is a feature change)?
Permissions supported

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
-

### :memo: Links to relevant issues/docs
[859](https://github.com/Baseflow/flutter-permission-handler/issues/859)

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
