### PR TITLE
Made bluetooth an instance of PermissionWithService

### DIFF
--- a/permission_handler_platform_interface/CHANGELOG.md
+++ b/permission_handler_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.9.1
+
+* Changed `Permission.bluetooth` into an instance of `PermissionWithService` instead of `Permission` in order to determine iOS native's `CBManagerStatePoweredOn`.
+
 ## 3.9.0
 
 * Added support for the new Android 13 permissions: SCHEDULE_EXACT_ALARM, READ_MEDIA_IMAGES, READ_MEDIA_VIDEO and READ_MEDIA_AUDIO

--- a/permission_handler_platform_interface/lib/src/permissions.dart
+++ b/permission_handler_platform_interface/lib/src/permissions.dart
@@ -120,7 +120,7 @@ class Permission {
 
   /// iOS 13 and above: The authorization state of Core Bluetooth manager.
   /// When running < iOS 13 or Android this is always allowed.
-  static const bluetooth = Permission._(21);
+  static const bluetooth = PermissionWithService._(21);
 
   /// Android: Allows an application a broad access to external storage in
   /// scoped storage.

--- a/permission_handler_platform_interface/pubspec.yaml
+++ b/permission_handler_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the permission_handler plugin.
 homepage: https://github.com/baseflow/flutter-permission-handler/tree/master/permission_handler_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 3.9.0
+version: 3.9.1
 
 dependencies:
   flutter:


### PR DESCRIPTION
Closes #773.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This allows users to access `Permission.bluetooth.serviceStatus`


### :arrow_heading_down: What is the current behavior?
Users can only access `Permission.bluetooth.status`


### :new: What is the new behavior (if this is a feature change)?
Users can access both `Permission.bluetooth.status` and `Permission.bluetooth.serviceStatus`


### :boom: Does this PR introduce a breaking change?
Not that I know of


### :bug: Recommendations for testing
Try determining iOS's `CBManagerStatePoweredOn` via `Permission.bluetooth.serviceStatus`


### :memo: Links to relevant issues/docs
On `BluetoothPermissionStrategy.m` line 36, there exists a means to view the iOS device's `CBManagerStatePoweredOn`. However, there doesn't appear to be a way to ever actually determine this status from the Flutter side as only `PermissionWithService`s can get `serviceStatus` (`permission_handler.dart` line 97). `bluetooth` is an instance of `Permission`, not `PermissionWithService`, thus we can never invoke `serviceStatus`, meaning we will never invoke a `checkServiceStatus` method to native iOS with bluetooth permission group.


### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.