### PR TITLE
Issue #988: Provisional Notification Permissions Part 1/3

### DIFF
--- a/permission_handler_platform_interface/CHANGELOG.md
+++ b/permission_handler_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.10.0
+
+* Added support for iOS 12+ Provisional Notification permissions.
+
 ## 3.9.0
 
 * Added support for the new Android 13 permissions: SCHEDULE_EXACT_ALARM, READ_MEDIA_IMAGES, READ_MEDIA_VIDEO and READ_MEDIA_AUDIO

--- a/permission_handler_platform_interface/lib/src/permission_status.dart
+++ b/permission_handler_platform_interface/lib/src/permission_status.dart
@@ -23,6 +23,10 @@ enum PermissionStatus {
   /// dialog will not be shown when requesting this permission. The user may
   /// still change the permission status in the settings.
   permanentlyDenied,
+
+  /// The application is provisionally authorized to post noninterruptive user notifications.
+  /// *Only supported on iOS (iOS12+).*
+  provisional,
 }
 
 /// Conversion extension methods for the [PermissionStatus] type.
@@ -40,6 +44,8 @@ extension PermissionStatusValue on PermissionStatus {
         return 3;
       case PermissionStatus.permanentlyDenied:
         return 4;
+      case PermissionStatus.provisional:
+        return 5;
       default:
         throw UnimplementedError();
     }
@@ -53,6 +59,7 @@ extension PermissionStatusValue on PermissionStatus {
       PermissionStatus.restricted,
       PermissionStatus.limited,
       PermissionStatus.permanentlyDenied,
+      PermissionStatus.provisional,
     ][value];
   }
 }
@@ -79,7 +86,7 @@ extension PermissionStatusGetters on PermissionStatus {
   /// The user may still change the permission status in the settings.
   ///
   /// *On iOS:*
-  /// If the user has denied acces to the requested feature.
+  /// If the user has denied access to the requested feature.
   /// The user may still change the permission status in the settings
   ///
   /// WARNING: This can only be determined AFTER requesting this permission.
@@ -88,6 +95,9 @@ extension PermissionStatusGetters on PermissionStatus {
 
   /// Indicates that permission for limited use of the resource is granted.
   bool get isLimited => this == PermissionStatus.limited;
+
+  /// If the application is provisionally authorized to post noninterruptive user notifications.
+  bool get isProvisional => this == PermissionStatus.provisional;
 }
 
 /// Utility getter extensions for the `Future<PermissionStatus>` type.
@@ -111,11 +121,15 @@ extension FuturePermissionStatusGetters on Future<PermissionStatus> {
   /// The user may still change the permission status in the settings.
   ///
   /// *On iOS:*
-  /// If the user has denied acces to the requested feature.
+  /// If the user has denied access to the requested feature.
   /// The user may still change the permission status in the settings
   Future<bool> get isPermanentlyDenied async =>
       (await this).isPermanentlyDenied;
 
   /// Indicates that permission for limited use of the resource is granted.
   Future<bool> get isLimited async => (await this).isLimited;
+
+  /// If the application is provisionally authorized to post noninterruptive user notifications.
+  /// *Only supported on iOS.*
+  Future<bool> get isProvisional async => (await this).isProvisional;
 }

--- a/permission_handler_platform_interface/pubspec.yaml
+++ b/permission_handler_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the permission_handler plugin.
 homepage: https://github.com/baseflow/flutter-permission-handler/tree/master/permission_handler_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 3.9.0
+version: 3.10.0
 
 dependencies:
   flutter:

--- a/permission_handler_platform_interface/test/src/permission_status_test.dart
+++ b/permission_handler_platform_interface/test/src/permission_status_test.dart
@@ -2,11 +2,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:permission_handler_platform_interface/permission_handler_platform_interface.dart';
 
 void main() {
-  group('PermissionSatus', () {
-    test('PermissionStatus should contain 5 options', () {
+  group('PermissionStatus', () {
+    test('PermissionStatus should contain 6 options', () {
       const values = PermissionStatus.values;
 
-      expect(values.length, 5);
+      expect(values.length, 6);
     });
 
     test('PermissionStatus enum should have items in correct index', () {
@@ -17,16 +17,18 @@ void main() {
       expect(values[2], PermissionStatus.restricted);
       expect(values[3], PermissionStatus.limited);
       expect(values[4], PermissionStatus.permanentlyDenied);
+      expect(values[5], PermissionStatus.provisional);
     });
   });
 
   group('PermissionStatusValue', () {
-    test('PermissonStatusValue returns right integer', () {
+    test('PermissionStatusValue returns right integer', () {
       expect(PermissionStatus.denied.value, 0);
       expect(PermissionStatus.granted.value, 1);
       expect(PermissionStatus.restricted.value, 2);
       expect(PermissionStatus.limited.value, 3);
       expect(PermissionStatus.permanentlyDenied.value, 4);
+      expect(PermissionStatus.provisional.value, 5);
     });
 
     test(
@@ -40,6 +42,8 @@ void main() {
       expect(PermissionStatusValue.statusByValue(3), PermissionStatus.limited);
       expect(PermissionStatusValue.statusByValue(4),
           PermissionStatus.permanentlyDenied);
+      expect(
+          PermissionStatusValue.statusByValue(5), PermissionStatus.provisional);
     });
   });
 
@@ -50,6 +54,7 @@ void main() {
       expect(PermissionStatus.restricted.isRestricted, true);
       expect(PermissionStatus.limited.isLimited, true);
       expect(PermissionStatus.permanentlyDenied.isPermanentlyDenied, true);
+      expect(PermissionStatus.provisional.isProvisional, true);
     });
 
     test('Getters should return false if statement is not met', () {
@@ -58,6 +63,7 @@ void main() {
       expect(PermissionStatus.restricted.isDenied, false);
       expect(PermissionStatus.limited.isDenied, false);
       expect(PermissionStatus.permanentlyDenied.isDenied, false);
+      expect(PermissionStatus.provisional.isDenied, false);
     });
   });
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Implements the `platform_interface` part of #988 

### :arrow_heading_down: What is the current behavior?

* This package is not aware of the provisional status of notifications on iOS 12+.  

### :new: What is the new behavior (if this is a feature change)?

- [x] Adds the `provisional` permission status so that it can be used in a followup PR.  Split here so the package versioning works out.
- [x] Updates tests
- [x] Minor doc typo fix 

### :boom: Does this PR introduce a breaking change?

* It does introduce a new enum value which would be a breaking change for client code that switches on the enum and does not have a default case.  However, given that this is very small and because existing code is very likely running with a `pubspec.lock`, it should have limited impact.

### :bug: Recommendations for testing

* No direct testing impact in this changeset, though there will be in followup PR that adds detection for the new status.

### :memo: Links to relevant issues/docs

#988 

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
