### PR TITLE
Fix android bluetooth permission request above api version 30

### DIFF
--- a/permission_handler_android/CHANGELOG.md
+++ b/permission_handler_android/CHANGELOG.md
@@ -1,20 +1,24 @@
+## 10.2.1
+
+* Check for BLUETOOTH_SCAN, BLUETOOTH_ADVERTISE or BLUETOOTH_CONNECT instead of BLUETOOTH permissions on api versions above 30.
+
 ## 10.2.0
 
-* Added support for the new Android 13 permissions: SCHEDULE_EXACT_ALARM, READ_MEDIA_IMAGES, READ_MEDIA_VIDEO and READ_MEDIA_AUDIO
+- Added support for the new Android 13 permissions: SCHEDULE_EXACT_ALARM, READ_MEDIA_IMAGES, READ_MEDIA_VIDEO and READ_MEDIA_AUDIO
 
 ## 10.1.0
 
-* Added support for the new Android 13 permission: NEARBY_WIFI_DEVICES.
+- Added support for the new Android 13 permission: NEARBY_WIFI_DEVICES.
 
 ## 10.0.0
 
- * __BREAKING CHANGE__: Updated Android `compileSdkVersion` to `33` to handle the new `POST_NOTIFICATIONS` permission.
- > When updating to version 10.0.0 make sure to update the `android/app/build.gradle` file and set the `compileSdkVersion` to `33`.
+- **BREAKING CHANGE**: Updated Android `compileSdkVersion` to `33` to handle the new `POST_NOTIFICATIONS` permission.
+  > When updating to version 10.0.0 make sure to update the `android/app/build.gradle` file and set the `compileSdkVersion` to `33`.
 
 ## 9.0.2+1
 
-* Undoes PR [#765](https://github.com/baseflow/flutter-permission-handler/pull/765) which by mistake requests write_external_storage permission based on the target SDK instead of the actual SDK of the Android device.
+- Undoes PR [#765](https://github.com/baseflow/flutter-permission-handler/pull/765) which by mistake requests write_external_storage permission based on the target SDK instead of the actual SDK of the Android device.
 
 ## 9.0.2
 
-* Moves Android implementation into its own package.
+- Moves Android implementation into its own package.

--- a/permission_handler_android/example/lib/main.dart
+++ b/permission_handler_android/example/lib/main.dart
@@ -98,7 +98,7 @@ class _PermissionState extends State<PermissionWidget> {
     return ListTile(
       title: Text(
         _permission.toString(),
-        style: Theme.of(context).textTheme.bodyText1,
+        style: Theme.of(context).textTheme.bodyLarge,
       ),
       subtitle: Text(
         _permissionStatus.toString(),

--- a/permission_handler_android/pubspec.yaml
+++ b/permission_handler_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler_android
 description: Permission plugin for Flutter. This plugin provides the Android API to request and check permissions.
-version: 10.2.0
+version: 10.2.1
 homepage: https://github.com/baseflow/flutter-permission-handler
 
 environment:


### PR DESCRIPTION
The BLUETOOTH permission was removed in api version 30 in favor of BLUETOOTH_SCAN, BLUETOOTH_ADVERTISE and BLUETOOTH_CONNECT.

This means that manifests targetting api version above 30 will not have this permission set. For these versions the manifest should be checked for the new permissions.

This change ensures that the documented behavior of the bluetooth permission always returning `true` is true.

Fixes issues #884

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix for Android api versions above 30 requesting Bluetooth permissions.

### :arrow_heading_down: What is the current behavior?
`Permission.bluetooth` return denied instead of the documented always allowed (https://pub.dev/documentation/permission_handler_platform_interface/latest/permission_handler_platform_interface/Permission/bluetooth-constant.html)

### :new: What is the new behavior (if this is a feature change)?
This commit brings the code in line with the documented behavior

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Test on api versions after 30 with a manifest that only includes one of the new permissions, and either no BLUETOOTH permission, or `<uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />

### :memo: Links to relevant issues/docs
- https://pub.dev/documentation/permission_handler_platform_interface/latest/permission_handler_platform_interface/Permission/bluetooth-constant.html
- https://github.com/Baseflow/flutter-permission-handler/issues/884

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
