### PR TITLE
Added missing `return` statement on iOS.

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.2.1
+
+* iOS: Added missing `return` statement to prevent unexpected behavior in `requestPermissions` method.
+
 ## 10.2.0
 
 * Added support for the new Android 13 permissions: SCHEDULE_EXACT_ALARM, READ_MEDIA_IMAGES, READ_MEDIA_VIDEO and READ_MEDIA_AUDIO

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-version: 10.2.0
+version: 10.2.1
 repository: https://github.com/baseflow/flutter-permission-handler
 issue_tracker: https://github.com/Baseflow/flutter-permission-handler/issues
 
@@ -23,7 +23,7 @@ dependencies:
     sdk: flutter
   meta: ^1.7.0
   permission_handler_android: ^10.2.0
-  permission_handler_apple: ^9.0.7
+  permission_handler_apple: ^9.0.8
   permission_handler_windows: ^0.1.2
   permission_handler_platform_interface: ^3.9.0
 

--- a/permission_handler_apple/CHANGELOG.md
+++ b/permission_handler_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 9.0.8
+
+* iOS: Added missing `return` statement to prevent unexpected behavior in `requestPermissions` method.
+
 ## 9.0.7
 
 * Added new Android 13 permissions "SCHEDULE_EXACT_ALARM, READ_MEDIA_IMAGES, READ_MEDIA_VIDEO and READ_MEDIA_AUDIO" to PermissionHandlerEnums.h

--- a/permission_handler_apple/ios/Classes/PermissionHandlerPlugin.m
+++ b/permission_handler_apple/ios/Classes/PermissionHandlerPlugin.m
@@ -34,6 +34,7 @@
     } else if ([@"requestPermissions" isEqualToString:call.method]) {
         if (_methodResult != nil) {
             result([FlutterError errorWithCode:@"ERROR_ALREADY_REQUESTING_PERMISSIONS" message:@"A request for permissions is already running, please wait for it to finish before doing another request (note that you can request multiple permissions at the same time)." details:nil]);
+            return;
         }
         
         _methodResult = result;

--- a/permission_handler_apple/pubspec.yaml
+++ b/permission_handler_apple/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler_apple
 description: Permission plugin for Flutter. This plugin provides the iOS API to request and check permissions.
-version: 9.0.7
+version: 9.0.8
 homepage: https://github.com/baseflow/flutter-permission-handler
 
 environment:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix on iOS

### :arrow_heading_down: What is the current behavior?
The current behaviour is that if there is already an ongoing permission request, flutter `result` for the new request will be called twice, first will `FlutterError` and then with an actual request result. It is also possible that the previous result will never be called because the new result is by mistake stored in `_methodResult` property.

### :new: What is the new behavior (if this is a feature change)?
-

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Try to perform multiple permission requests simultaneously.

### :memo: Links to relevant issues/docs
-

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
