### PR TITLE
Fix exact alarm permission status check on Android

### DIFF
--- a/permission_handler_android/CHANGELOG.md
+++ b/permission_handler_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.2.1
+
+* Fixed SCHEDULE_EXACT_ALARM status check on Android 12 and 13
+
 ## 10.2.0
 
 * Added support for the new Android 13 permissions: SCHEDULE_EXACT_ALARM, READ_MEDIA_IMAGES, READ_MEDIA_VIDEO and READ_MEDIA_AUDIO

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
@@ -2,8 +2,8 @@ package com.baseflow.permissionhandler;
 
 import android.Manifest;
 import android.app.Activity;
+import android.app.AlarmManager;
 import android.app.Application;
-import android.app.Notification;
 import android.app.NotificationManager;
 import android.content.Context;
 import android.content.Intent;
@@ -409,6 +409,17 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
                         return notificationManager.isNotificationPolicyAccessGranted()
                                 ? PermissionConstants.PERMISSION_STATUS_GRANTED
                                 : PermissionConstants.PERMISSION_STATUS_DENIED;
+                    }
+                }
+
+                if (permission == PermissionConstants.PERMISSION_GROUP_SCHEDULE_EXACT_ALARM) {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                        AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+                        return alarmManager.canScheduleExactAlarms()
+                                ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                                : PermissionConstants.PERMISSION_STATUS_DENIED;
+                    } else {
+                        return PermissionConstants.PERMISSION_STATUS_GRANTED;
                     }
                 }
 

--- a/permission_handler_android/pubspec.yaml
+++ b/permission_handler_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler_android
 description: Permission plugin for Flutter. This plugin provides the Android API to request and check permissions.
-version: 10.2.0
+version: 10.2.1
 homepage: https://github.com/baseflow/flutter-permission-handler
 
 environment:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

Plugin always returns `granted` for `SCHEDULE_EXACT_ALARM` permission on Android 12 and 13 even if user revokes the permission in app settings.

### :new: What is the new behavior (if this is a feature change)?

Plugin checks status of `SCHEDULE_EXACT_ALARM` properly as it is recommended in https://developer.android.com/about/versions/14/changes/schedule-exact-alarms

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Try to run current version of the plugin on Android 12 or 13 and revoke alarm permission. Note, this particular permission is not in `Permissions` section, but is a separate menu item in `App info`:
<img width="432" alt="Screenshot 2023-04-05 at 18 07 36" src="https://user-images.githubusercontent.com/13467769/230124005-dc7d948d-c4b2-4bb7-bb2c-4515622c6c66.png">

### :memo: Links to relevant issues/docs

There is a bug report about this issue already: https://github.com/Baseflow/flutter-permission-handler/issues/987

Official documentation: https://developer.android.com/about/versions/14/changes/schedule-exact-alarms

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
