### PR TITLE
added namespace for AGP8 compatibility

### DIFF
--- a/permission_handler_android/android/build.gradle
+++ b/permission_handler_android/android/build.gradle
@@ -27,6 +27,11 @@ project.getTasks().withType(JavaCompile){
 apply plugin: 'com.android.library'
 
 android {
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.baseflow.permissionhandler'
+    }
+
     compileSdkVersion 33
 
     compileOptions {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
adding namespace in `build.gradle` for compatibility with AGP 8

### :arrow_heading_down: What is the current behavior?
no behaviour change

### :new: What is the new behavior (if this is a feature change)?
no behaviour change

### :boom: Does this PR introduce a breaking change?
no

### :bug: Recommendations for testing
use AGP 8

### :memo: Links to relevant issues/docs
cf Flutter packages comment/solution:
- https://github.com/flutter/packages/commit/6284c2d4e46a5d289e77cb03a9457543b97f750b
- https://github.com/flutter/packages/commit/a86beafa8912609275225847198c9c0164957d09

### :thinking: Checklist before submitting

- [X] I made sure all projects build.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [ ] I updated CHANGELOG.md to add a description of the change.
- [X] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [X] I updated the relevant documentation.
- [X] I rebased onto current `master`.
