### PR TITLE
updated version of dependencies

### DIFF
--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
-version: 10.2.0
+version: 10.2.1
 repository: https://github.com/baseflow/flutter-permission-handler
 issue_tracker: https://github.com/Baseflow/flutter-permission-handler/issues
 
@@ -22,8 +22,8 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.7.0
-  permission_handler_android: ^10.2.0
-  permission_handler_apple: ^9.0.7
+  permission_handler_android: ^10.2.1
+  permission_handler_apple: ^9.0.8
   permission_handler_windows: ^0.1.2
   permission_handler_platform_interface: ^3.9.0
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This resolves AGP issue #1043 by updating the permission_handler_android dependency to the version with the already fixed AGP.

### :arrow_heading_down: What is the current behavior?
If the user doesn't override permission_handler_android dependency in the pubspec, he still gets the namespace issue.

### :new: What is the new behavior (if this is a feature change)?
The user does not need to do anything other than use this latest version and the AGP issue is resolved.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md)).
- [ ] I updated the relevant documentation.
- [x] I rebased onto current `master`.
