### PR TITLE
Fixes misalignment with BODY_SENSORS_BACKGROUND

### DIFF
--- a/permission_handler_platform_interface/CHANGELOG.md
+++ b/permission_handler_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.11.0+1
+
+* **HOTFIX**: Fixes misalignment in the `Permission` enum after adding the new BODY_SENSORS_BACKGROUND permission.
+
 ## 3.11.0
 
 * Adds support for the new Android 13 permission: BODY_SENSORS_BACKGROUND.

--- a/permission_handler_platform_interface/lib/src/permissions.dart
+++ b/permission_handler_platform_interface/lib/src/permissions.dart
@@ -217,7 +217,6 @@ class Permission {
     photosAddOnly,
     reminders,
     sensors,
-    sensorsAlways,
     sms,
     speech,
     storage,
@@ -239,7 +238,8 @@ class Permission {
     nearbyWifiDevices,
     videos,
     audio,
-    scheduleExactAlarm
+    scheduleExactAlarm,
+    sensorsAlways,
   ];
 
   static const List<String> _names = <String>[
@@ -256,7 +256,6 @@ class Permission {
     'photosAddOnly',
     'reminders',
     'sensors',
-    'sensorsAlways',
     'sms',
     'speech',
     'storage',
@@ -278,7 +277,8 @@ class Permission {
     'nearbyWifiDevices',
     'videos',
     'audio',
-    'scheduleExactAlarm'
+    'scheduleExactAlarm',
+    'sensorsAlways',
   ];
 
   @override

--- a/permission_handler_platform_interface/pubspec.yaml
+++ b/permission_handler_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the permission_handler plugin.
 homepage: https://github.com/baseflow/flutter-permission-handler/tree/master/permission_handler_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 3.11.0
+version: 3.11.0+1
 
 dependencies:
   flutter:


### PR DESCRIPTION
Fixes misalignment in the `Permission` enum after adding the new BODY_SENSORS_BACKGROUND permission.

*List at least one fixed issue.*

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
