### PR TITLE
Mention use of granular media permissions in AndroidManifest

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 10.4.0+1
+
+* Updates AndroidManifest documentation in the example application with regards
+  to the use of READ_EXTERNAL_STORAGE, READ_MEDIA_IMAGES, READ_MEDIA_VIDEO and
+  READ_MEDIA_AUDIO permissions.
+
 ## 10.4.0
 
 * Adds support for the new Android 13 permission: BODY_SENSORS_BACKGROUND.

--- a/permission_handler/example/android/app/src/main/AndroidManifest.xml
+++ b/permission_handler/example/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,13 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.baseflow.permissionhandler.example">
 
+    <uses-feature
+        android:name="android.hardware.telephony"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
+
     <!--
     Internet permissions do not affect the `permission_handler` plugin, but are required if your app needs access to
     the internet.
@@ -14,8 +21,14 @@
     <uses-permission android:name="android.permission.GET_ACCOUNTS"/>
 
     <!-- Permissions options for the `storage` group -->
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <!-- Read storage permission for Android 12 and lower -->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <!--
+      Granular media permissions for Android 13 and newer.
+      See https://developer.android.com/about/versions/13/behavior-changes-13#granular-media-permissions
+      for more information.
+    -->
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -2,7 +2,7 @@ name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
 repository: https://github.com/baseflow/flutter-permission-handler
 issue_tracker: https://github.com/Baseflow/flutter-permission-handler/issues
-version: 10.4.0
+version: 10.4.0+1
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
This PR updates the documentation of the Android Manifest of the example app, adding to the explanation of the `READ_EXTERNAL_STORAGE`, `READ_MEDIA_IMAGES`, `READ_MEDIA_VIDEO` and `READ_MEDIA_AUDIO` permissions. It aims to give a bit more context to the [changes in Android 13](https://developer.android.com/about/versions/13/behavior-changes-13#granular-media-permissions). This file is references in the README, and probably a common-seen file for users of the plugin.

Closes #955, #1026, #1066.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [ ] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
