### PR TITLE
Remove callback on undetermined location status

### DIFF
--- a/permission_handler_apple/CHANGELOG.md
+++ b/permission_handler_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 9.1.3
+
+* Fixes an issue where the `Permission.location.request()`, `Permission.locationWhenInUse.request()` and `Permission.locationAlways.request()` calls returned `PermissionStatus.denied` regardless of the actual permission status.
+
 ## 9.1.2
 
 * Fixes an issue where the `Permission.locationAlways.request()` call hangs when the application was granted "Allow once" permissions for fetching location coordinates.

--- a/permission_handler_apple/ios/Classes/strategies/LocationPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/LocationPermissionStrategy.m
@@ -98,7 +98,7 @@ NSString *const UserDefaultPermissionRequestedKey = @"org.baseflow.permission_ha
 // This is called when the location manager is first initialized and raises the following situations:
 // 1. When we first request [PermissionGroupLocationWhenInUse] and then [PermissionGroupLocationAlways]
 //    this will be called when the [CLLocationManager] is first initialized with
-//    [kCLAuthorizationStatusAuthorizedWhenInUse]. As a consequence we send back the result to early.
+//    [kCLAuthorizationStatusAuthorizedWhenInUse]. As a consequence we send back the result too early.
 // 2. When we first request [PermissionGroupLocationWhenInUse] and then [PermissionGroupLocationAlways]
 //    and the user doesn't allow for [kCLAuthorizationStatusAuthorizedAlways] this method is not called
 //    at all.
@@ -108,7 +108,6 @@ NSString *const UserDefaultPermissionRequestedKey = @"org.baseflow.permission_ha
     }
     
     if (status == kCLAuthorizationStatusNotDetermined) {
-        _permissionStatusHandler(PermissionStatusDenied);
         return;
     }
 

--- a/permission_handler_apple/pubspec.yaml
+++ b/permission_handler_apple/pubspec.yaml
@@ -2,7 +2,7 @@ name: permission_handler_apple
 description: Permission plugin for Flutter. This plugin provides the iOS API to request and check permissions.
 repository: https://github.com/baseflow/flutter-permission-handler
 issue_tracker: https://github.com/Baseflow/flutter-permission-handler/issues
-version: 9.1.2
+version: 9.1.3
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
In a previous update to the plugin, we return `PermissionStatusDenied` when the location status is `Undetermined`. This is not correct however, as this status is emitted by iOS when the permission dialog is opened. This leads to a bug where the permission status returned by Dart is always `PermissionStatus.denied`, regardless of the response of the user.

Closes #1086

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [ ] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [ ] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
