### PR TITLE
Fix double 'onSuccess' call when checking BT service status

### DIFF
--- a/permission_handler_android/CHANGELOG.md
+++ b/permission_handler_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.3.1
+
+* Fixes `java.lang.IllegalStateException: Reply already submitted` when checking status of Bluetooth service.
+
 ## 10.3.0
 
 * Adds support for the new Android 13 permission: BODY_SENSORS_BACKGROUND.

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ServiceManager.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ServiceManager.java
@@ -53,6 +53,7 @@ final class ServiceManager {
                     : PermissionConstants.SERVICE_STATUS_DISABLED;
 
             successCallback.onSuccess(serviceStatus);
+            return;
         }
 
         if (permission == PermissionConstants.PERMISSION_GROUP_PHONE) {

--- a/permission_handler_android/pubspec.yaml
+++ b/permission_handler_android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: permission_handler_android
 description: Permission plugin for Flutter. This plugin provides the Android API to request and check permissions.
 homepage: https://github.com/baseflow/flutter-permission-handler
-version: 10.3.0
+version: 10.3.1
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
Fixes #1094.

Currently if the status of Bluetooth service is checked (see https://github.com/Baseflow/flutter-permission-handler/issues/773, and my comment for how I currently do it), an exception is thrown:

```
Launching lib/main.dart on Nexus 5 in debug mode...
✓  Built build/app/outputs/flutter-apk/app-debug.apk.
Connecting to VM Service at ws://127.0.0.1:50209/4CUXZdFqgsA=/ws
E/MethodChannel#flutter.baseflow.com/permissions/methods(17691): Failed to handle method call
E/MethodChannel#flutter.baseflow.com/permissions/methods(17691): java.lang.IllegalStateException: Reply already submitted
E/MethodChannel#flutter.baseflow.com/permissions/methods(17691): 	at io.flutter.embedding.engine.dart.DartMessenger$Reply.reply(DartMessenger.java:435)
E/MethodChannel#flutter.baseflow.com/permissions/methods(17691): 	at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler$1.success(MethodChannel.java:263)
E/MethodChannel#flutter.baseflow.com/permissions/methods(17691): 	at com.baseflow.permissionhandler.MethodCallHandlerImpl$$ExternalSyntheticLambda0.onSuccess(D8$$SyntheticClass)
E/MethodChannel#flutter.baseflow.com/permissions/methods(17691): 	at com.baseflow.permissionhandler.ServiceManager.checkServiceStatus(ServiceManager.java:97)
E/MethodChannel#flutter.baseflow.com/permissions/methods(17691): 	at com.baseflow.permissionhandler.MethodCallHandlerImpl.onMethodCall(MethodCallHandlerImpl.java:45)
E/MethodChannel#flutter.baseflow.com/permissions/methods(17691): 	at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler.onMessage(MethodChannel.java:258)
E/MethodChannel#flutter.baseflow.com/permissions/methods(17691): 	at io.flutter.embedding.engine.dart.DartMessenger.invokeHandler(DartMessenger.java:295)
E/MethodChannel#flutter.baseflow.com/permissions/methods(17691): 	at io.flutter.embedding.engine.dart.DartMessenger.lambda$dispatchMessageToQueue$0$io-flutter-embedding-engine-dart-DartMessenger(DartMessenger.java:322)
E/MethodChannel#flutter.baseflow.com/permissions/methods(17691): 	at io.flutter.embedding.engine.dart.DartMessenger$$ExternalSyntheticLambda0.run(D8$$SyntheticClass)
E/MethodChannel#flutter.baseflow.com/permissions/methods(17691): 	at android.os.Handler.handleCallback(Handler.java:739)
E/MethodChannel#flutter.baseflow.com/permissions/methods(17691): 	at android.os.Handler.dispatchMessage(Handler.java:95)
E/MethodChannel#flutter.baseflow.com/permissions/methods(17691): 	at android.os.Looper.loop(Looper.java:148)
E/MethodChannel#flutter.baseflow.com/permissions/methods(17691): 	at android.app.ActivityThread.main(ActivityThread.java:5417)
E/MethodChannel#flutter.baseflow.com/permissions/methods(17691): 	at java.lang.reflect.Method.invoke(Native Method)
E/MethodChannel#flutter.baseflow.com/permissions/methods(17691): 	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
E/MethodChannel#flutter.baseflow.com/permissions/methods(17691): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
E/DartMessenger(17691): Uncaught exception in binary message listener
E/DartMessenger(17691): java.lang.IllegalStateException: Reply already submitted
E/DartMessenger(17691): 	at io.flutter.embedding.engine.dart.DartMessenger$Reply.reply(DartMessenger.java:435)
E/DartMessenger(17691): 	at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler.onMessage(MethodChannel.java:278)
E/DartMessenger(17691): 	at io.flutter.embedding.engine.dart.DartMessenger.invokeHandler(DartMessenger.java:295)
E/DartMessenger(17691): 	at io.flutter.embedding.engine.dart.DartMessenger.lambda$dispatchMessageToQueue$0$io-flutter-embedding-engine-dart-DartMessenger(DartMessenger.java:322)
E/DartMessenger(17691): 	at io.flutter.embedding.engine.dart.DartMessenger$$ExternalSyntheticLambda0.run(D8$$SyntheticClass)
E/DartMessenger(17691): 	at android.os.Handler.handleCallback(Handler.java:739)
E/DartMessenger(17691): 	at android.os.Handler.dispatchMessage(Handler.java:95)
E/DartMessenger(17691): 	at android.os.Looper.loop(Looper.java:148)
E/DartMessenger(17691): 	at android.app.ActivityThread.main(ActivityThread.java:5417)
E/DartMessenger(17691): 	at java.lang.reflect.Method.invoke(Native Method)
E/DartMessenger(17691): 	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
E/DartMessenger(17691): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
```
This is caused by a missing return, which causes `onSuccess` to be called twice.

This PR fixes this issue by adding the missing return, just like for all the other permissions that have a corresponding `if` block.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`). (Not applicable, no documentation needed.)
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests. (No tests exist for Android.)
- [x] I made sure all existing and new tests are passing. (No tests exist for Android.)
- [x] I ran `dart format .` and committed any changes. (Not applicable, change in Android code only.)
- [x] I ran `flutter analyze` and fixed any errors. (Not application, change in Android code only.)

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
