### PR TITLE
Allow querying Bluetooth service status on iOS (Apple)

### DIFF
--- a/permission_handler_apple/CHANGELOG.md
+++ b/permission_handler_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 9.1.4
+
+* Adds checking whether Bluetooth service is enabled through `Permission.bluetooth.serviceStatus`.
+
 ## 9.1.3
 
 * Fixes an issue where the `Permission.location.request()`, `Permission.locationWhenInUse.request()` and `Permission.locationAlways.request()` calls returned `PermissionStatus.denied` regardless of the actual permission status.

--- a/permission_handler_apple/example/lib/main.dart
+++ b/permission_handler_apple/example/lib/main.dart
@@ -36,8 +36,8 @@ class _PermissionHandlerWidgetState extends State<PermissionHandlerWidget> {
           children: Permission.values
               .where((permission) {
                 return permission != Permission.unknown &&
+                    permission != Permission.phone &&
                     permission != Permission.sms &&
-                    permission != Permission.storage &&
                     permission != Permission.ignoreBatteryOptimizations &&
                     permission != Permission.accessMediaLocation &&
                     permission != Permission.activityRecognition &&
@@ -47,7 +47,12 @@ class _PermissionHandlerWidgetState extends State<PermissionHandlerWidget> {
                     permission != Permission.accessNotificationPolicy &&
                     permission != Permission.bluetoothScan &&
                     permission != Permission.bluetoothAdvertise &&
-                    permission != Permission.bluetoothConnect;
+                    permission != Permission.bluetoothConnect &&
+                    permission != Permission.nearbyWifiDevices &&
+                    permission != Permission.videos &&
+                    permission != Permission.audio &&
+                    permission != Permission.scheduleExactAlarm &&
+                    permission != Permission.sensorsAlways;
               })
               .map((permission) => PermissionWidget(permission))
               .toList()),

--- a/permission_handler_apple/ios/Classes/PermissionManager.m
+++ b/permission_handler_apple/ios/Classes/PermissionManager.m
@@ -9,6 +9,8 @@
     NSMutableArray <id <PermissionStrategy>> *_strategyInstances;
 }
 
+static id <PermissionStrategy> _pendingPermissionStrategy;
+
 - (instancetype)initWithStrategyInstances {
     self = [super init];
     if (self) {
@@ -26,9 +28,11 @@
 }
 
 + (void)checkServiceStatus:(enum PermissionGroup)permission result:(FlutterResult)result {
-    id <PermissionStrategy> permissionStrategy = [PermissionManager createPermissionStrategy:permission];
-    ServiceStatus status = [permissionStrategy checkServiceStatus:permission];
-    result([Codec encodeServiceStatus:status]);
+    _pendingPermissionStrategy = [PermissionManager createPermissionStrategy:permission];
+    
+    [_pendingPermissionStrategy checkServiceStatus:permission completionHandler:^(ServiceStatus serviceStatus) {
+        result([Codec encodeServiceStatus:serviceStatus]);
+    }];
 }
 
 - (void)requestPermissions:(NSArray *)permissions completion:(PermissionRequestCompletion)completion {

--- a/permission_handler_apple/ios/Classes/strategies/AppTrackingTransparencyPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/AppTrackingTransparencyPermissionStrategy.m
@@ -20,8 +20,8 @@
     return PermissionStatusGranted;
 }
 
-- (ServiceStatus)checkServiceStatus:(PermissionGroup)permission {
-    return ServiceStatusNotApplicable;
+- (void)checkServiceStatus:(PermissionGroup)permission completionHandler:(ServiceStatusHandler)completionHandler {
+    completionHandler(ServiceStatusNotApplicable);
 }
 
 - (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {

--- a/permission_handler_apple/ios/Classes/strategies/AudioVideoPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/AudioVideoPermissionStrategy.m
@@ -22,8 +22,8 @@
     return PermissionStatusDenied;
 }
 
-- (ServiceStatus)checkServiceStatus:(PermissionGroup)permission {
-    return ServiceStatusNotApplicable;
+- (void)checkServiceStatus:(PermissionGroup)permission completionHandler:(ServiceStatusHandler)completionHandler {
+    completionHandler(ServiceStatusNotApplicable);
 }
 
 - (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {

--- a/permission_handler_apple/ios/Classes/strategies/BluetoothPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/BluetoothPermissionStrategy.m
@@ -23,14 +23,36 @@
     }
 }
 
+/// Reads the permission status of the Bluetooth service.
+///
+/// The behavior differs across iOS versions:
+/// - Starting with iOS 13.1, this function returns the expected result.
+/// - On iOS 13.0, applications are unable to check for the permission status without triggering a
+/// permission request. Therefore, `PermissionStatusDenied` is always returned. To obtain the
+/// actual permission status, the application should request permission using `requestPermission()`.
+/// If the permission was already granted, no dialog will pop up.
+/// - Below iOS 13.0, applications do not have to ask for permission to use Bluetooth. Therefore,
+/// `PermissionStatusGranted` is always returned.
 - (PermissionStatus)checkPermissionStatus:(PermissionGroup)permission {
-    if (@available(iOS 13.0, *)) {
-        CBManagerAuthorization blePermission = [_centralManager authorization];
+    if (@available(iOS 13.1, *)) {
+        CBManagerAuthorization blePermission = [CBCentralManager authorization];
+        
         return [BluetoothPermissionStrategy parsePermission:blePermission];
+    } else if (@available(iOS 13.0, *)) {
+        return PermissionStatusDenied;
     }
     return PermissionStatusGranted;
 }
 
+/// Asynchronously requests the status of the Bluetooth service.
+///
+/// The result will be fetched in `handleCheckServiceStatusCallback`, which will in turn call
+/// `completionHandler` with either `ServiceStatusEnabled` or `ServiceStatusDisabled`.
+///
+/// If the Bluetooth permission has been requested and was denied, this will return `ServiceStatusDisabled`,
+/// regardless of the actual state of the Bluetooth service.
+/// If the Bluetooth permission has not been granted or denied yet, this call will trigger a permission dialog, asking
+/// the user to give the application access to Bluetooth.
 - (void)checkServiceStatus:(PermissionGroup)permission completionHandler:(ServiceStatusHandler)completionHandler {
     [self initManagerIfNeeded];
     
@@ -38,13 +60,13 @@
     _requestedPermission = permission;
 }
 
-- (void)handleCheckServiceStatusCallback {
+- (void)handleCheckServiceStatusCallback:(CBCentralManager *)centralManager {
     if (@available(iOS 10, *)) {
-        ServiceStatus serviceStatus = [_centralManager state] == CBManagerStatePoweredOn ? ServiceStatusEnabled : ServiceStatusDisabled;
+        ServiceStatus serviceStatus = [centralManager state] == CBManagerStatePoweredOn ? ServiceStatusEnabled : ServiceStatusDisabled;
         _serviceStatusHandler(serviceStatus);
     }
     #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    ServiceStatus serviceStatus = [_centralManager state] == CBCentralManagerStatePoweredOn ? ServiceStatusEnabled : ServiceStatusDisabled;
+    ServiceStatus serviceStatus = [centralManager state] == CBCentralManagerStatePoweredOn ? ServiceStatusEnabled : ServiceStatusDisabled;
     _serviceStatusHandler(serviceStatus);
 }
 
@@ -61,9 +83,14 @@
     _requestedPermission = permission;
 }
 
-- (void)handleRequestPermissionCallback {
-    PermissionStatus permissionStatus = [self checkPermissionStatus:_requestedPermission];
-    _permissionStatusHandler(permissionStatus);
+- (void)handleRequestPermissionCallback:(CBCentralManager *)centralManager {
+    if (@available(iOS 13.0, *)) {
+        CBManagerAuthorization blePermission = [centralManager authorization];
+        PermissionStatus permissionStatus = [BluetoothPermissionStrategy parsePermission:blePermission];
+        _permissionStatusHandler(permissionStatus);
+    } else {
+        _permissionStatusHandler(PermissionStatusGranted);
+    }
 }
 
 + (PermissionStatus)parsePermission:(CBManagerAuthorization)bluetoothPermission API_AVAILABLE(ios(13)) {
@@ -81,11 +108,11 @@
 
 - (void)centralManagerDidUpdateState:(nonnull CBCentralManager *)centralManager {
     if (_permissionStatusHandler != nil) {
-        [self handleRequestPermissionCallback];
+        [self handleRequestPermissionCallback:centralManager];
     }
     
     if (_serviceStatusHandler != nil) {
-        [self handleCheckServiceStatusCallback];
+        [self handleCheckServiceStatusCallback:centralManager];
     }
 }
 

--- a/permission_handler_apple/ios/Classes/strategies/ContactPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/ContactPermissionStrategy.m
@@ -13,8 +13,8 @@
     return [ContactPermissionStrategy permissionStatus];
 }
 
-- (ServiceStatus)checkServiceStatus:(PermissionGroup)permission {
-    return ServiceStatusNotApplicable;
+- (void)checkServiceStatus:(PermissionGroup)permission completionHandler:(ServiceStatusHandler)completionHandler {
+    completionHandler(ServiceStatusNotApplicable);
 }
 
 - (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {

--- a/permission_handler_apple/ios/Classes/strategies/CriticalAlertsPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/CriticalAlertsPermissionStrategy.m
@@ -15,8 +15,8 @@
   return [CriticalAlertsPermissionStrategy permissionStatus];
 }
 
-- (ServiceStatus)checkServiceStatus:(PermissionGroup)permission {
-  return ServiceStatusNotApplicable;
+- (void)checkServiceStatus:(PermissionGroup)permission completionHandler:(ServiceStatusHandler)completionHandler {
+    completionHandler(ServiceStatusNotApplicable);
 }
 
 - (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {

--- a/permission_handler_apple/ios/Classes/strategies/EventPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/EventPermissionStrategy.m
@@ -23,8 +23,8 @@
     return PermissionStatusDenied;
 }
 
-- (ServiceStatus)checkServiceStatus:(PermissionGroup)permission {
-    return ServiceStatusNotApplicable;
+- (void)checkServiceStatus:(PermissionGroup)permission completionHandler:(ServiceStatusHandler)completionHandler {
+    completionHandler(ServiceStatusNotApplicable);
 }
 
 - (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {

--- a/permission_handler_apple/ios/Classes/strategies/LocationPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/LocationPermissionStrategy.m
@@ -35,8 +35,8 @@ NSString *const UserDefaultPermissionRequestedKey = @"org.baseflow.permission_ha
     return [LocationPermissionStrategy permissionStatus:permission];
 }
 
-- (ServiceStatus)checkServiceStatus:(PermissionGroup)permission {
-    return [CLLocationManager locationServicesEnabled] ? ServiceStatusEnabled : ServiceStatusDisabled;
+- (void)checkServiceStatus:(PermissionGroup)permission completionHandler:(ServiceStatusHandler)completionHandler {
+    completionHandler([CLLocationManager locationServicesEnabled] ? ServiceStatusEnabled : ServiceStatusDisabled);
 }
 
 - (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {

--- a/permission_handler_apple/ios/Classes/strategies/MediaLibraryPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/MediaLibraryPermissionStrategy.m
@@ -13,8 +13,8 @@
     return [MediaLibraryPermissionStrategy permissionStatus];
 }
 
-- (ServiceStatus)checkServiceStatus:(PermissionGroup)permission {
-    return ServiceStatusNotApplicable;
+- (void)checkServiceStatus:(PermissionGroup)permission completionHandler:(ServiceStatusHandler)completionHandler {
+    completionHandler(ServiceStatusNotApplicable);
 }
 
 - (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {

--- a/permission_handler_apple/ios/Classes/strategies/NotificationPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/NotificationPermissionStrategy.m
@@ -15,8 +15,8 @@
   return [NotificationPermissionStrategy permissionStatus];
 }
 
-- (ServiceStatus)checkServiceStatus:(PermissionGroup)permission {
-  return ServiceStatusNotApplicable;
+- (void)checkServiceStatus:(PermissionGroup)permission completionHandler:(ServiceStatusHandler)completionHandler {
+    completionHandler(ServiceStatusNotApplicable);
 }
 
 - (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {

--- a/permission_handler_apple/ios/Classes/strategies/PermissionStrategy.h
+++ b/permission_handler_apple/ios/Classes/strategies/PermissionStrategy.h
@@ -6,12 +6,13 @@
 #import <Foundation/Foundation.h>
 #import "PermissionHandlerEnums.h"
 
+typedef void (^ServiceStatusHandler)(ServiceStatus serviceStatus);
 typedef void (^PermissionStatusHandler)(PermissionStatus permissionStatus);
 
 @protocol PermissionStrategy <NSObject>
 - (PermissionStatus)checkPermissionStatus:(PermissionGroup)permission;
 
-- (ServiceStatus)checkServiceStatus:(PermissionGroup)permission;
+- (void)checkServiceStatus:(PermissionGroup)permission completionHandler:(ServiceStatusHandler)completionHandler;
 
 - (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler;
 @end

--- a/permission_handler_apple/ios/Classes/strategies/PhonePermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/PhonePermissionStrategy.m
@@ -16,13 +16,12 @@
   return PermissionStatusDenied;
 }
 
-- (ServiceStatus)checkServiceStatus:(PermissionGroup)permission {
+- (void)checkServiceStatus:(PermissionGroup)permission completionHandler:(ServiceStatusHandler)completionHandler {
   // https://stackoverflow.com/a/5095058
   if (![[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:@"tel://"]]) {
-    return ServiceStatusNotApplicable;
+      completionHandler(ServiceStatusNotApplicable);
   }
-  
-  return [self canDevicePlaceAPhoneCall] ? ServiceStatusEnabled : ServiceStatusDisabled;
+  completionHandler([self canDevicePlaceAPhoneCall] ? ServiceStatusEnabled : ServiceStatusDisabled);
 }
 
 - (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {

--- a/permission_handler_apple/ios/Classes/strategies/PhotoPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/PhotoPermissionStrategy.m
@@ -24,8 +24,8 @@
     return [PhotoPermissionStrategy permissionStatus:addOnlyAccessLevel];
 }
 
-- (ServiceStatus)checkServiceStatus:(PermissionGroup)permission {
-    return ServiceStatusNotApplicable;
+- (void)checkServiceStatus:(PermissionGroup)permission completionHandler:(ServiceStatusHandler)completionHandler {
+    completionHandler(ServiceStatusNotApplicable);
 }
 
 - (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {

--- a/permission_handler_apple/ios/Classes/strategies/SensorPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/SensorPermissionStrategy.m
@@ -12,14 +12,15 @@
     return [SensorPermissionStrategy permissionStatus];
 }
 
-- (ServiceStatus)checkServiceStatus:(PermissionGroup)permission {
+- (void)checkServiceStatus:(PermissionGroup)permission completionHandler:(ServiceStatusHandler)completionHandler {
     if (@available(iOS 11.0, *)) {
-        return [CMMotionActivityManager isActivityAvailable]
-        ? ServiceStatusEnabled
-        : ServiceStatusDisabled;
+        completionHandler([CMMotionActivityManager isActivityAvailable]
+          ? ServiceStatusEnabled
+          : ServiceStatusDisabled
+        );
     }
     
-    return ServiceStatusDisabled;
+    completionHandler(ServiceStatusDisabled);
 }
 
 - (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {

--- a/permission_handler_apple/ios/Classes/strategies/SpeechPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/SpeechPermissionStrategy.m
@@ -12,8 +12,8 @@
     return [SpeechPermissionStrategy permissionStatus];
 }
 
-- (ServiceStatus)checkServiceStatus:(PermissionGroup)permission {
-    return ServiceStatusNotApplicable;
+- (void)checkServiceStatus:(PermissionGroup)permission completionHandler:(ServiceStatusHandler)completionHandler {
+    completionHandler(ServiceStatusNotApplicable);
 }
 
 - (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {

--- a/permission_handler_apple/ios/Classes/strategies/StoragePermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/StoragePermissionStrategy.m
@@ -13,8 +13,8 @@
     return [StoragePermissionStrategy permissionStatus];
 }
 
-- (ServiceStatus)checkServiceStatus:(PermissionGroup)permission {
-    return ServiceStatusNotApplicable;
+- (void)checkServiceStatus:(PermissionGroup)permission completionHandler:(ServiceStatusHandler)completionHandler {
+    completionHandler(ServiceStatusNotApplicable);
 }
 
 - (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {

--- a/permission_handler_apple/ios/Classes/strategies/UnknownPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/UnknownPermissionStrategy.m
@@ -12,8 +12,8 @@
     return PermissionStatusDenied;
 }
 
-- (ServiceStatus)checkServiceStatus:(PermissionGroup)permission {
-    return ServiceStatusDisabled;
+- (void)checkServiceStatus:(PermissionGroup)permission completionHandler:(ServiceStatusHandler)completionHandler {
+    completionHandler(ServiceStatusDisabled);
 }
 
 - (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {

--- a/permission_handler_apple/pubspec.yaml
+++ b/permission_handler_apple/pubspec.yaml
@@ -2,7 +2,7 @@ name: permission_handler_apple
 description: Permission plugin for Flutter. This plugin provides the iOS API to request and check permissions.
 repository: https://github.com/baseflow/flutter-permission-handler
 issue_tracker: https://github.com/Baseflow/flutter-permission-handler/issues
-version: 9.1.3
+version: 9.1.4
 
 environment:
   sdk: ">=2.15.0 <4.0.0"
@@ -18,7 +18,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  permission_handler_platform_interface: ^3.11.0
+  permission_handler_platform_interface: ^3.11.2
 
 dev_dependencies:
   flutter_lints: ^1.0.4


### PR DESCRIPTION
This PR updates the Apple implementation, fixing an issue where the Bluetooth service status was never resolved properly. To this end it
- Makes `checkServiceStatus` async
- Keeps track of `PermissionStrategy` in `PermissionManager` (hold the reference to guarantee that the callback fires)

Additionally, it updates the displayed permission in the example app, as these were out of sync with the newest permissions.

This PR is part of feature #773.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [ ] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
