### PR TITLE
Fix displayed permissions in example app

### DIFF
--- a/permission_handler_android/CHANGELOG.md
+++ b/permission_handler_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.3.1
+
+* Updates example app to show `Permission.photos` and hide `Permission.bluetooth`.
+
 ## 10.3.0
 
 * Adds support for the new Android 13 permission: BODY_SENSORS_BACKGROUND.

--- a/permission_handler_android/example/lib/main.dart
+++ b/permission_handler_android/example/lib/main.dart
@@ -37,9 +37,9 @@ class _PermissionHandlerWidgetState extends State<PermissionHandlerWidget> {
               .where((permission) {
                 return permission != Permission.unknown &&
                     permission != Permission.mediaLibrary &&
-                    permission != Permission.photos &&
                     permission != Permission.photosAddOnly &&
                     permission != Permission.reminders &&
+                    permission != Permission.bluetooth &&
                     permission != Permission.appTrackingTransparency &&
                     permission != Permission.criticalAlerts;
               })

--- a/permission_handler_android/pubspec.yaml
+++ b/permission_handler_android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: permission_handler_android
 description: Permission plugin for Flutter. This plugin provides the Android API to request and check permissions.
 homepage: https://github.com/baseflow/flutter-permission-handler
-version: 10.3.0
+version: 10.3.1
 
 environment:
   sdk: ">=2.15.0 <4.0.0"
@@ -18,7 +18,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  permission_handler_platform_interface: ^3.11.0
+  permission_handler_platform_interface: ^3.11.2
 
 dev_dependencies:
   flutter_lints: ^1.0.4


### PR DESCRIPTION
This PR updates the example app so it shows `Permission.phone` and hides `Permission.bluetooth`. This is according to the documentation of the permissions in `permission_handler_platform_interface`.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
