### PR TITLE
Moves Java compile arguments

### DIFF
--- a/permission_handler_android/CHANGELOG.md
+++ b/permission_handler_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.3.3
+
+* Migrates the Gradle compile arguments to the example app, so they are not enforced upon consumers of the plugin.
+
 ## 10.3.2
 
 * Updates example app to show `Permission.photos` and hide `Permission.bluetooth`.

--- a/permission_handler_android/android/build.gradle
+++ b/permission_handler_android/android/build.gradle
@@ -1,6 +1,5 @@
 group 'com.baseflow.permissionhandler'
 version '1.0'
-def args = ["-Xlint:deprecation","-Xlint:unchecked","-Werror"]
 
 buildscript {
     repositories {
@@ -18,10 +17,6 @@ rootProject.allprojects {
         google()
         mavenCentral()
     }
-}
-
-project.getTasks().withType(JavaCompile){
-    options.compilerArgs.addAll(args)
 }
 
 apply plugin: 'com.android.library'

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
@@ -122,25 +122,24 @@ public class PermissionUtils {
                 break;
 
             case PermissionConstants.PERMISSION_GROUP_LOCATION_ALWAYS:
+            case PermissionConstants.PERMISSION_GROUP_LOCATION_WHEN_IN_USE:
+            case PermissionConstants.PERMISSION_GROUP_LOCATION:
                 // Note that the LOCATION_ALWAYS will deliberately fallthrough to the LOCATION
                 // case on pre Android Q devices. The ACCESS_BACKGROUND_LOCATION permission was only
                 // introduced in Android Q, before it should be treated as the ACCESS_COARSE_LOCATION or
                 // ACCESS_FINE_LOCATION.
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                if (permission == PermissionConstants.PERMISSION_GROUP_LOCATION_ALWAYS && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                     if (hasPermissionInManifest(context, permissionNames, Manifest.permission.ACCESS_BACKGROUND_LOCATION))
                         permissionNames.add(Manifest.permission.ACCESS_BACKGROUND_LOCATION);
                     break;
                 }
-            case PermissionConstants.PERMISSION_GROUP_LOCATION_WHEN_IN_USE:
-            case PermissionConstants.PERMISSION_GROUP_LOCATION:
+
                 if (hasPermissionInManifest(context, permissionNames, Manifest.permission.ACCESS_COARSE_LOCATION))
                     permissionNames.add(Manifest.permission.ACCESS_COARSE_LOCATION);
 
                 if (hasPermissionInManifest(context, permissionNames, Manifest.permission.ACCESS_FINE_LOCATION))
                     permissionNames.add(Manifest.permission.ACCESS_FINE_LOCATION);
                 break;
-
-
             case PermissionConstants.PERMISSION_GROUP_SPEECH:
             case PermissionConstants.PERMISSION_GROUP_MICROPHONE:
                 if (hasPermissionInManifest(context, permissionNames, Manifest.permission.RECORD_AUDIO))
@@ -191,7 +190,7 @@ public class PermissionUtils {
                         permissionNames.add(Manifest.permission.BODY_SENSORS_BACKGROUND);
                     }
                 }
-
+                break;
             case PermissionConstants.PERMISSION_GROUP_SMS:
                 if (hasPermissionInManifest(context, permissionNames, Manifest.permission.SEND_SMS))
                     permissionNames.add(Manifest.permission.SEND_SMS);

--- a/permission_handler_android/example/android/build.gradle
+++ b/permission_handler_android/example/android/build.gradle
@@ -16,12 +16,6 @@ allprojects {
     }
 }
 
-def args = ["-Xlint:deprecation","-Xlint:unchecked","-Werror"]
-
-project.getTasks().withType(JavaCompile){
-    options.compilerArgs.addAll(args)
-}
-
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
@@ -30,4 +24,16 @@ subprojects {
 
 tasks.register("clean", Delete) {
     delete rootProject.buildDir
+}
+
+// Build the plugin project with warnings enabled. This is here rather than
+// in the plugin itself to avoid breaking clients that have different
+// warnings (e.g., deprecation warnings from a newer SDK than this project
+// builds with).
+gradle.projectsEvaluated {
+    project(":permission_handler_android") {
+        tasks.withType(JavaCompile) {
+            options.compilerArgs << "-Xlint:all" << "-Werror"
+        }
+    }
 }

--- a/permission_handler_android/example/android/build.gradle
+++ b/permission_handler_android/example/android/build.gradle
@@ -16,6 +16,12 @@ allprojects {
     }
 }
 
+def args = ["-Xlint:deprecation","-Xlint:unchecked","-Werror"]
+
+project.getTasks().withType(JavaCompile){
+    options.compilerArgs.addAll(args)
+}
+
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"

--- a/permission_handler_android/pubspec.yaml
+++ b/permission_handler_android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: permission_handler_android
 description: Permission plugin for Flutter. This plugin provides the Android API to request and check permissions.
 homepage: https://github.com/baseflow/flutter-permission-handler
-version: 10.3.2
+version: 10.3.3
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
Currently the `permission_handler_android` package adds the `"-Xlint:deprecation","-Xlint:unchecked","-Werror"` build arguments which ensure that the Java compiler throws an error if the code contains "deprecation" or "unchecked" warnings.

Unfortunately the arguments are added in the `android/build.gradle` file which result that the arguments are populated all the through to the consuming app. This means if the consuming app (or other plugins used by the consuming app) contains "deprecation" or "unchecked" warnings the app will not compile. While this might be good practice, developers should be allowed to make their own choice and this should not be enforced upon them by the permission_handler plugin.

This PR will move the use of the compiler argument to the example app which will no longer enforce them onto consumers, but will still allow us to ensure the `permission_handler` specific Java code doesn't contain any of these warnings.

Resolves #910

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
