### PR TITLE
fix typo in documentation

### DIFF
--- a/permission_handler_platform_interface/lib/src/permissions.dart
+++ b/permission_handler_platform_interface/lib/src/permissions.dart
@@ -137,7 +137,7 @@ class Permission {
   /// different:
   ///
   /// **Android:**
-  /// - On Android TIRAMISU and higher this permission is deprecrated and always
+  /// - On Android TIRAMISU and higher this permission is deprecated and always
   /// returns `PermissionStatus.denied`, instead use `Permission.photos`,
   /// `Permission.video`, `Permission.audio` or
   /// `Permission.manageExternalStorage`. For more information see our


### PR DESCRIPTION
fix typo in word the 'deprecated'

*List at least one fixed issue.*
- fix type

## Pre-launch Checklist

- [done] I made sure the project builds.
- [done] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [done] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [done] I updated `CHANGELOG.md` to add a description of the change.
- [done] I updated/added relevant documentation (doc comments with `///`).
- [done] I rebased onto `main`.
- [done] I added new tests to check the change I am making, or this PR does not need tests.
- [done] I made sure all existing and new tests are passing.
- [done] I ran `dart format .` and committed any changes.
- [done] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
