### PR TITLE
Fix 'Permanently denied' on permission dialog dismiss

### DIFF
--- a/permission_handler_android/CHANGELOG.md
+++ b/permission_handler_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 10.3.4
+
+* Fixes a bug where the permission status would return 'permanently denied'
+instead of 'denied' when the user would dismiss the permission dialog.
+
 ## 10.3.3
 
 * Migrates the Gradle compile arguments to the example app, so they are not enforced upon consumers of the plugin.

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
@@ -399,17 +399,17 @@ public class PermissionUtils {
      * State machine diagram:
      * <p>
      * Dismissed
-     * ┌┐
+     *    ┌┐
      * ┌──┘▼─────┐  Granted ┌───────┐
      * │Not asked├──────────►Granted│
      * └─┬───────┘          └─▲─────┘
-     * │           Granted  │
-     * │Denied  ┌───────────┘
-     * │        │
+     *   │           Granted  │
+     *   │Denied  ┌───────────┘
+     *   │        │
      * ┌─▼────────┴┐        ┌────────────────────────────────┐
      * │Denied once├────────►Denied twice(permanently denied)│
      * └──▲┌───────┘ Denied └────────────────────────────────┘
-     * └┘
+     *    └┘
      * Dismissed
      * <p>
      * Scenario table listing output of

--- a/permission_handler_android/pubspec.yaml
+++ b/permission_handler_android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: permission_handler_android
 description: Permission plugin for Flutter. This plugin provides the Android API to request and check permissions.
 homepage: https://github.com/baseflow/flutter-permission-handler
-version: 10.3.3
+version: 10.3.4
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
In newer Android versions, permission dialogs can be dismissed. The OS does not give information to the application to determine whether the permission was explicitly denied, or if the dialog was dismissed. We used to check whether the permission was denied or permanently denied by checking the output of `shouldShowRational`. When dismissing the dialog, however, the result of `shouldShowRational` is the same as if the permission was permanently denied. We were therefore unable to distinguish whether the permission was denied permanently, or whether the user dismissed the dialog. Several reports emerged about this issue.

When reviewing this PR, please test all use cases to make sure the changes are correct. I went over all* of them, but it is important that a second person verifies that everything behaves as expected.

Closes:
#709
#757
#919
#1072

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [ ] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
