### PR TITLE
Return 'permanently denied' as permission status

### DIFF
--- a/permission_handler_android/CHANGELOG.md
+++ b/permission_handler_android/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 11.0.0
 
-* Fixes a bug where the permission status would return 'denied' regardless of
-whether the status was 'denied' or 'permanently denied'.
+* **BREAKING CHANGE:** Fixes a bug where the permission status would return 'denied' regardless of whether the status was 'denied' or 'permanently denied'.
 
 ## 10.3.5
 

--- a/permission_handler_android/CHANGELOG.md
+++ b/permission_handler_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 11.0.0
+
+* Fixes a bug where the permission status would return 'denied' regardless of
+whether the status was 'denied' or 'permanently denied'.
+
 ## 10.3.5
 
 * Fixes a bug where `Permission.ScheduleExactAlarm` was not opening the settings

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/MethodCallHandlerImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/MethodCallHandlerImpl.java
@@ -54,17 +54,11 @@ final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
                 break;
             }
             case "checkPermissionStatus": {
-                /*
-                 Use the Activity as Context if possible, for smarted permission status resolution.
-                 If the activity is not available (the application is running in the background),
-                 use the ApplicationContext instead. See PermissionUtils.determineDeniedVariant()
-                 for more information.
-                */
-                final Context context = activity != null ? activity : applicationContext;
                 @PermissionConstants.PermissionGroup final int permission = Integer.parseInt(call.arguments.toString());
                 permissionManager.checkPermissionStatus(
                         permission,
-                        context,
+                        applicationContext,
+                        activity,
                         result::success);
                 break;
             }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/MethodCallHandlerImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/MethodCallHandlerImpl.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 
 import androidx.annotation.Nullable;
+
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.Result;
@@ -19,10 +20,10 @@ final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
     private final ServiceManager serviceManager;
 
     MethodCallHandlerImpl(
-            Context applicationContext,
-            AppSettingsManager appSettingsManager,
-            PermissionManager permissionManager,
-            ServiceManager serviceManager) {
+        Context applicationContext,
+        AppSettingsManager appSettingsManager,
+        PermissionManager permissionManager,
+        ServiceManager serviceManager) {
         this.applicationContext = applicationContext;
         this.appSettingsManager = appSettingsManager;
         this.permissionManager = permissionManager;
@@ -33,68 +34,67 @@ final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
     private Activity activity;
 
     public void setActivity(@Nullable Activity activity) {
-      this.activity = activity;
+        this.activity = activity;
     }
 
-  @Override
-    public void onMethodCall(@NonNull MethodCall call, @NonNull final Result result)
-    {
+    @Override
+    public void onMethodCall(@NonNull MethodCall call, @NonNull final Result result) {
         switch (call.method) {
             case "checkServiceStatus": {
                 @PermissionConstants.PermissionGroup final int permission = Integer.parseInt(call.arguments.toString());
                 serviceManager.checkServiceStatus(
-                        permission,
-                        applicationContext,
-                        result::success,
-                        (String errorCode, String errorDescription) -> result.error(
-                                errorCode,
-                                errorDescription,
-                                null));
+                    permission,
+                    applicationContext,
+                    result::success,
+                    (String errorCode, String errorDescription) -> result.error(
+                        errorCode,
+                        errorDescription,
+                        null));
 
                 break;
             }
             case "checkPermissionStatus": {
                 @PermissionConstants.PermissionGroup final int permission = Integer.parseInt(call.arguments.toString());
                 permissionManager.checkPermissionStatus(
-                        permission,
-                        applicationContext,
-                        activity,
-                        result::success);
+                    permission,
+                    applicationContext,
+                    activity,
+                    result::success);
                 break;
             }
             case "requestPermissions":
                 final List<Integer> permissions = call.arguments();
                 permissionManager.requestPermissions(
-                        permissions,
-                        activity,
-                        result::success,
-                        (String errorCode, String errorDescription) -> result.error(
-                                errorCode,
-                                errorDescription,
-                                null));
+                    permissions,
+                    activity,
+                    result::success,
+                    (String errorCode, String errorDescription) -> result.error(
+                        errorCode,
+                        errorDescription,
+                        null));
 
                 break;
             case "shouldShowRequestPermissionRationale": {
                 @PermissionConstants.PermissionGroup final int permission = Integer.parseInt(call.arguments.toString());
                 permissionManager.shouldShowRequestPermissionRationale(
-                        permission,
-                        activity,
-                        result::success,
-                        (String errorCode, String errorDescription) -> result.error(
-                                errorCode,
-                                errorDescription,
-                                null));
+                    permission,
+                    activity,
+                    result::success,
+                    (String errorCode, String errorDescription) -> result.error(
+                        errorCode,
+                        errorDescription,
+                        null));
 
                 break;
             }
             case "openAppSettings":
                 appSettingsManager.openAppSettings(
-                        applicationContext,
-                        result::success,
-                        (String errorCode, String errorDescription) -> result.error(
-                                errorCode,
-                                errorDescription,
-                                null));
+                    applicationContext,
+                    result::success,
+                    (String errorCode, String errorDescription) -> result.error(
+                        errorCode,
+                        errorDescription,
+                        null));
 
                 break;
             default:

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/MethodCallHandlerImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/MethodCallHandlerImpl.java
@@ -1,11 +1,8 @@
 package com.baseflow.permissionhandler;
 
-import android.app.Activity;
 import android.content.Context;
 
 import androidx.annotation.NonNull;
-
-import androidx.annotation.Nullable;
 
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
@@ -30,13 +27,6 @@ final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
         this.serviceManager = serviceManager;
     }
 
-    @Nullable
-    private Activity activity;
-
-    public void setActivity(@Nullable Activity activity) {
-        this.activity = activity;
-    }
-
     @Override
     public void onMethodCall(@NonNull MethodCall call, @NonNull final Result result) {
         switch (call.method) {
@@ -57,8 +47,6 @@ final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
                 @PermissionConstants.PermissionGroup final int permission = Integer.parseInt(call.arguments.toString());
                 permissionManager.checkPermissionStatus(
                     permission,
-                    applicationContext,
-                    activity,
                     result::success);
                 break;
             }
@@ -66,7 +54,6 @@ final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
                 final List<Integer> permissions = call.arguments();
                 permissionManager.requestPermissions(
                     permissions,
-                    activity,
                     result::success,
                     (String errorCode, String errorDescription) -> result.error(
                         errorCode,
@@ -78,7 +65,6 @@ final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
                 @PermissionConstants.PermissionGroup final int permission = Integer.parseInt(call.arguments.toString());
                 permissionManager.shouldShowRequestPermissionRationale(
                     permission,
-                    activity,
                     result::success,
                     (String errorCode, String errorDescription) -> result.error(
                         errorCode,

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/MethodCallHandlerImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/MethodCallHandlerImpl.java
@@ -57,7 +57,7 @@ final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
                 @PermissionConstants.PermissionGroup final int permission = Integer.parseInt(call.arguments.toString());
                 permissionManager.checkPermissionStatus(
                         permission,
-                        applicationContext,
+                        activity,
                         result::success);
                 break;
             }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/MethodCallHandlerImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/MethodCallHandlerImpl.java
@@ -54,10 +54,17 @@ final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
                 break;
             }
             case "checkPermissionStatus": {
+                /*
+                 Use the Activity as Context if possible, for smarted permission status resolution.
+                 If the activity is not available (the application is running in the background),
+                 use the ApplicationContext instead. See PermissionUtils.determineDeniedVariant()
+                 for more information.
+                */
+                final Context context = activity != null ? activity : applicationContext;
                 @PermissionConstants.PermissionGroup final int permission = Integer.parseInt(call.arguments.toString());
                 permissionManager.checkPermissionStatus(
                         permission,
-                        activity,
+                        context,
                         result::success);
                 break;
             }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
@@ -59,6 +59,8 @@ public final class PermissionHandlerPlugin implements FlutterPlugin, ActivityAwa
 
     @Override
     public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
+        this.permissionManager = new PermissionManager(binding.getApplicationContext());
+
         startListening(
             binding.getApplicationContext(),
             binding.getBinaryMessenger()

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
@@ -13,7 +13,7 @@ import io.flutter.plugin.common.MethodChannel;
 /**
  * Platform implementation of the permission_handler Flutter plugin.
  *
- * <p>Instantiate this in an add to app scenario to gracefully handle activity and context changes.
+ * <p>Instantiate this in an add-to-app scenario to gracefully handle activity and context changes.
  * See {@code com.example.permissionhandlerexample.MainActivity} for an example.
  *
  * <p>Call {@link #registerWith(io.flutter.plugin.common.PluginRegistry.Registrar)} to register an
@@ -21,7 +21,8 @@ import io.flutter.plugin.common.MethodChannel;
  */
 public final class PermissionHandlerPlugin implements FlutterPlugin, ActivityAware {
 
-    private final PermissionManager permissionManager;
+    private PermissionManager permissionManager;
+
     private MethodChannel methodChannel;
 
     @SuppressWarnings("deprecation")
@@ -31,10 +32,6 @@ public final class PermissionHandlerPlugin implements FlutterPlugin, ActivityAwa
 
     @Nullable
     private MethodCallHandlerImpl methodCallHandler;
-
-    public PermissionHandlerPlugin() {
-        this.permissionManager = new PermissionManager();
-    }
 
     /**
      * Registers a plugin implementation that uses the stable {@code io.flutter.plugin.common}
@@ -48,6 +45,7 @@ public final class PermissionHandlerPlugin implements FlutterPlugin, ActivityAwa
         final PermissionHandlerPlugin plugin = new PermissionHandlerPlugin();
 
         plugin.pluginRegistrar = registrar;
+        plugin.permissionManager = new PermissionManager(registrar.context());
         plugin.registerListeners();
 
         plugin.startListening(registrar.context(), registrar.messenger());
@@ -124,14 +122,14 @@ public final class PermissionHandlerPlugin implements FlutterPlugin, ActivityAwa
     private void startListeningToActivity(
         Activity activity
     ) {
-        if (methodCallHandler != null) {
-            methodCallHandler.setActivity(activity);
+        if (permissionManager != null) {
+            permissionManager.setActivity(activity);
         }
     }
 
     private void stopListeningToActivity() {
-        if (methodCallHandler != null) {
-            methodCallHandler.setActivity(null);
+        if (permissionManager != null) {
+            permissionManager.setActivity(null);
         }
     }
 

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
@@ -42,7 +42,7 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
     /**
      * The number of pending permission requests.
      * <p>
-     * This number is set by {@link this#requestPermissions(List, Activity, RequestPermissionsSuccessCallback, ErrorCallback)}
+     * This number is set by {@link this#requestPermissions(List, RequestPermissionsSuccessCallback, ErrorCallback)}
      * and then reduced when receiving results in {@link this#onActivityResult(int, int, Intent)}
      * and {@link this#onRequestPermissionsResult(int, String[], int[])}.
      */
@@ -54,7 +54,7 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
      * {@link this#onActivityResult(int, int, Intent)} and
      * {@link this#onRequestPermissionsResult(int, String[], int[])}.
      * It is (re)initialized when new permissions are requested through
-     * {@link this#requestPermissions(List, Activity, RequestPermissionsSuccessCallback, ErrorCallback)}.
+     * {@link this#requestPermissions(List, RequestPermissionsSuccessCallback, ErrorCallback)}.
      */
     private Map<Integer, Integer> requestResults;
 
@@ -284,13 +284,11 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
      * requested through this method were handled, and if so, return the result back to Dart.
      *
      * @param permissions     the permissions that are requested.
-     * @param activity        the activity.
      * @param successCallback the callback for returning the permission results.
      * @param errorCallback   the callback to call in case of an error.
      */
     void requestPermissions(
         List<Integer> permissions,
-        Activity activity,
         RequestPermissionsSuccessCallback successCallback,
         ErrorCallback errorCallback) {
         if (pendingRequestCount > 0) {

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
@@ -211,12 +211,12 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
 
     void checkPermissionStatus(
             @PermissionConstants.PermissionGroup int permission,
-            Activity activity,
+            Context context,
             CheckPermissionsSuccessCallback successCallback) {
 
         successCallback.onSuccess(determinePermissionStatus(
                 permission,
-                activity));
+                context));
     }
 
     void requestPermissions(
@@ -327,25 +327,25 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
     @PermissionConstants.PermissionStatus
     private int determinePermissionStatus(
             @PermissionConstants.PermissionGroup int permission,
-            Activity activity) {
+            Context context) {
 
         if (permission == PermissionConstants.PERMISSION_GROUP_NOTIFICATION) {
-            return checkNotificationPermissionStatus(activity);
+            return checkNotificationPermissionStatus(context);
         }
 
         if (permission == PermissionConstants.PERMISSION_GROUP_BLUETOOTH) {
-            return checkBluetoothPermissionStatus(activity);
+            return checkBluetoothPermissionStatus(context);
         }
 
         if (permission == PermissionConstants.PERMISSION_GROUP_BLUETOOTH_CONNECT
                 || permission == PermissionConstants.PERMISSION_GROUP_BLUETOOTH_SCAN
                 || permission == PermissionConstants.PERMISSION_GROUP_BLUETOOTH_ADVERTISE){
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
-                return checkBluetoothPermissionStatus(activity);
+                return checkBluetoothPermissionStatus(context);
             }
         }
 
-        final List<String> names = PermissionUtils.getManifestNames(activity, permission);
+        final List<String> names = PermissionUtils.getManifestNames(context, permission);
 
         if (names == null) {
             Log.d(PermissionConstants.LOG_TAG, "No android specific permissions needed for: " + permission);
@@ -378,14 +378,14 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
                 : PermissionConstants.PERMISSION_STATUS_DENIED;
         }
 
-        final boolean targetsMOrHigher = activity.getApplicationInfo().targetSdkVersion >= Build.VERSION_CODES.M;
+        final boolean targetsMOrHigher = context.getApplicationInfo().targetSdkVersion >= Build.VERSION_CODES.M;
 
         for (String name : names) {
             // Only handle them if the client app actually targets a API level greater than M.
             if (targetsMOrHigher) {
                 if (permission == PermissionConstants.PERMISSION_GROUP_IGNORE_BATTERY_OPTIMIZATIONS) {
-                    String packageName = activity.getPackageName();
-                    PowerManager pm = (PowerManager) activity.getSystemService(Context.POWER_SERVICE);
+                    String packageName = context.getPackageName();
+                    PowerManager pm = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
                     // PowerManager.isIgnoringBatteryOptimizations has been included in Android M first.
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                         if (pm != null && pm.isIgnoringBatteryOptimizations(packageName)) {
@@ -410,7 +410,7 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
 
                 if (permission == PermissionConstants.PERMISSION_GROUP_SYSTEM_ALERT_WINDOW) {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                        return Settings.canDrawOverlays(activity)
+                        return Settings.canDrawOverlays(context)
                                 ? PermissionConstants.PERMISSION_STATUS_GRANTED
                                 : PermissionConstants.PERMISSION_STATUS_DENIED;
                     }
@@ -418,7 +418,7 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
 
                 if (permission == PermissionConstants.PERMISSION_GROUP_REQUEST_INSTALL_PACKAGES) {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                        return activity.getPackageManager().canRequestPackageInstalls()
+                        return context.getPackageManager().canRequestPackageInstalls()
                                 ? PermissionConstants.PERMISSION_STATUS_GRANTED
                                 : PermissionConstants.PERMISSION_STATUS_DENIED;
                     }
@@ -426,7 +426,7 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
 
                 if (permission == PermissionConstants.PERMISSION_GROUP_ACCESS_NOTIFICATION_POLICY) {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                        NotificationManager notificationManager = (NotificationManager) activity.getSystemService(Application.NOTIFICATION_SERVICE);
+                        NotificationManager notificationManager = (NotificationManager) context.getSystemService(Application.NOTIFICATION_SERVICE);
                         return notificationManager.isNotificationPolicyAccessGranted()
                                 ? PermissionConstants.PERMISSION_STATUS_GRANTED
                                 : PermissionConstants.PERMISSION_STATUS_DENIED;
@@ -435,7 +435,7 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
 
                 if (permission == PermissionConstants.PERMISSION_GROUP_SCHEDULE_EXACT_ALARM) {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                        AlarmManager alarmManager = (AlarmManager) activity.getSystemService(Context.ALARM_SERVICE);
+                        AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
                         return alarmManager.canScheduleExactAlarms()
                                 ? PermissionConstants.PERMISSION_STATUS_GRANTED
                                 : PermissionConstants.PERMISSION_STATUS_DENIED;
@@ -444,9 +444,9 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
                     }
                 }
 
-                final int permissionStatus = ContextCompat.checkSelfPermission(activity, name);
+                final int permissionStatus = ContextCompat.checkSelfPermission(context, name);
                 if (permissionStatus != PackageManager.PERMISSION_GRANTED) {
-                    return PermissionUtils.determineDeniedVariant(activity, name);
+                    return PermissionUtils.determineDeniedVariant(context, name);
                 }
             }
         }
@@ -498,21 +498,21 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
     }
 
     @PermissionConstants.PermissionStatus
-    private int checkNotificationPermissionStatus(Activity activity) {
+    private int checkNotificationPermissionStatus(Context context) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-            NotificationManagerCompat manager = NotificationManagerCompat.from(activity);
-            boolean isGranted = manager.areNotificationsEnabled();
+            NotificationManagerCompat manager = NotificationManagerCompat.from(context);
+            final boolean isGranted = manager.areNotificationsEnabled();
             if (isGranted) {
                 return PermissionConstants.PERMISSION_STATUS_GRANTED;
             }
             return PermissionConstants.PERMISSION_STATUS_DENIED;
         }
 
-        final int status = activity.checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS);
-        return PermissionUtils.toPermissionStatus(
-            activity,
-            Manifest.permission.POST_NOTIFICATIONS,
-            status);
+        final int status = context.checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS);
+        if (status == PackageManager.PERMISSION_GRANTED) {
+            return PermissionConstants.PERMISSION_STATUS_GRANTED;
+        }
+        return PermissionConstants.PERMISSION_STATUS_DENIED;
     }
 
     @PermissionConstants.PermissionStatus

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
@@ -41,17 +41,17 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
     @Override
     public boolean onActivityResult(int requestCode, int resultCode, Intent data) {
         if (requestCode != PermissionConstants.PERMISSION_CODE_IGNORE_BATTERY_OPTIMIZATIONS &&
-                requestCode != PermissionConstants.PERMISSION_CODE_MANAGE_EXTERNAL_STORAGE &&
-                requestCode != PermissionConstants.PERMISSION_CODE_SYSTEM_ALERT_WINDOW &&
-                requestCode != PermissionConstants.PERMISSION_CODE_REQUEST_INSTALL_PACKAGES &&
-                requestCode != PermissionConstants.PERMISSION_CODE_ACCESS_NOTIFICATION_POLICY &&
-                requestCode != PermissionConstants.PERMISSION_CODE_SCHEDULE_EXACT_ALARM) {
+            requestCode != PermissionConstants.PERMISSION_CODE_MANAGE_EXTERNAL_STORAGE &&
+            requestCode != PermissionConstants.PERMISSION_CODE_SYSTEM_ALERT_WINDOW &&
+            requestCode != PermissionConstants.PERMISSION_CODE_REQUEST_INSTALL_PACKAGES &&
+            requestCode != PermissionConstants.PERMISSION_CODE_ACCESS_NOTIFICATION_POLICY &&
+            requestCode != PermissionConstants.PERMISSION_CODE_SCHEDULE_EXACT_ALARM) {
             return false;
         }
 
         int status = resultCode == Activity.RESULT_OK
-                ? PermissionConstants.PERMISSION_STATUS_GRANTED
-                : PermissionConstants.PERMISSION_STATUS_DENIED;
+            ? PermissionConstants.PERMISSION_STATUS_GRANTED
+            : PermissionConstants.PERMISSION_STATUS_DENIED;
 
         int permission;
 
@@ -60,8 +60,8 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
         } else if (requestCode == PermissionConstants.PERMISSION_CODE_MANAGE_EXTERNAL_STORAGE) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                 status = Environment.isExternalStorageManager()
-                        ? PermissionConstants.PERMISSION_STATUS_GRANTED
-                        : PermissionConstants.PERMISSION_STATUS_DENIED;
+                    ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                    : PermissionConstants.PERMISSION_STATUS_DENIED;
             } else {
                 return false;
             }
@@ -69,8 +69,8 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
         } else if (requestCode == PermissionConstants.PERMISSION_CODE_SYSTEM_ALERT_WINDOW) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 status = Settings.canDrawOverlays(activity)
-                        ? PermissionConstants.PERMISSION_STATUS_GRANTED
-                        : PermissionConstants.PERMISSION_STATUS_DENIED;
+                    ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                    : PermissionConstants.PERMISSION_STATUS_DENIED;
                 permission = PermissionConstants.PERMISSION_GROUP_SYSTEM_ALERT_WINDOW;
             } else {
                 return false;
@@ -78,8 +78,8 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
         } else if (requestCode == PermissionConstants.PERMISSION_CODE_REQUEST_INSTALL_PACKAGES) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 status = activity.getPackageManager().canRequestPackageInstalls()
-                        ? PermissionConstants.PERMISSION_STATUS_GRANTED
-                        : PermissionConstants.PERMISSION_STATUS_DENIED;
+                    ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                    : PermissionConstants.PERMISSION_STATUS_DENIED;
                 permission = PermissionConstants.PERMISSION_GROUP_REQUEST_INSTALL_PACKAGES;
             } else {
                 return false;
@@ -88,8 +88,8 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 NotificationManager notificationManager = (NotificationManager) activity.getSystemService(Application.NOTIFICATION_SERVICE);
                 status = notificationManager.isNotificationPolicyAccessGranted()
-                        ? PermissionConstants.PERMISSION_STATUS_GRANTED
-                        : PermissionConstants.PERMISSION_STATUS_DENIED;
+                    ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                    : PermissionConstants.PERMISSION_STATUS_DENIED;
                 permission = PermissionConstants.PERMISSION_GROUP_ACCESS_NOTIFICATION_POLICY;
             } else {
                 return false;
@@ -98,8 +98,8 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 AlarmManager alarmManager = (AlarmManager) activity.getSystemService(Context.ALARM_SERVICE);
                 status = alarmManager.canScheduleExactAlarms()
-                        ? PermissionConstants.PERMISSION_STATUS_GRANTED
-                        : PermissionConstants.PERMISSION_STATUS_DENIED;
+                    ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                    : PermissionConstants.PERMISSION_STATUS_DENIED;
                 permission = PermissionConstants.PERMISSION_GROUP_SCHEDULE_EXACT_ALARM;
             } else {
                 return false;
@@ -126,14 +126,14 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
         }
 
         if (requestResults == null) {
-           return false;
+            return false;
         }
 
         for (int i = 0; i < permissions.length; i++) {
             final String permissionName = permissions[i];
 
             @PermissionConstants.PermissionGroup final int permission =
-                    PermissionUtils.parseManifestName(permissionName);
+                PermissionUtils.parseManifestName(permissionName);
 
             if (permission == PermissionConstants.PERMISSION_GROUP_UNKNOWN)
                 continue;
@@ -143,44 +143,44 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
             if (permission == PermissionConstants.PERMISSION_GROUP_MICROPHONE) {
                 if (!requestResults.containsKey(PermissionConstants.PERMISSION_GROUP_MICROPHONE)) {
                     requestResults.put(
-                            PermissionConstants.PERMISSION_GROUP_MICROPHONE,
-                            PermissionUtils.toPermissionStatus(this.activity, permissionName, result));
+                        PermissionConstants.PERMISSION_GROUP_MICROPHONE,
+                        PermissionUtils.toPermissionStatus(this.activity, permissionName, result));
                 }
                 if (!requestResults.containsKey(PermissionConstants.PERMISSION_GROUP_SPEECH)) {
                     requestResults.put(
-                            PermissionConstants.PERMISSION_GROUP_SPEECH,
-                            PermissionUtils.toPermissionStatus(this.activity, permissionName, result));
+                        PermissionConstants.PERMISSION_GROUP_SPEECH,
+                        PermissionUtils.toPermissionStatus(this.activity, permissionName, result));
                 }
             } else if (permission == PermissionConstants.PERMISSION_GROUP_LOCATION_ALWAYS) {
                 @PermissionConstants.PermissionStatus int permissionStatus =
-                        PermissionUtils.toPermissionStatus(this.activity, permissionName, result);
+                    PermissionUtils.toPermissionStatus(this.activity, permissionName, result);
 
                 if (!requestResults.containsKey(PermissionConstants.PERMISSION_GROUP_LOCATION_ALWAYS)) {
                     requestResults.put(PermissionConstants.PERMISSION_GROUP_LOCATION_ALWAYS, permissionStatus);
                 }
             } else if (permission == PermissionConstants.PERMISSION_GROUP_LOCATION) {
                 @PermissionConstants.PermissionStatus int permissionStatus =
-                        PermissionUtils.toPermissionStatus(this.activity, permissionName, result);
+                    PermissionUtils.toPermissionStatus(this.activity, permissionName, result);
 
                 if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
                     if (!requestResults.containsKey(PermissionConstants.PERMISSION_GROUP_LOCATION_ALWAYS)) {
                         requestResults.put(
-                                PermissionConstants.PERMISSION_GROUP_LOCATION_ALWAYS,
-                                permissionStatus);
+                            PermissionConstants.PERMISSION_GROUP_LOCATION_ALWAYS,
+                            permissionStatus);
                     }
                 }
 
                 if (!requestResults.containsKey(PermissionConstants.PERMISSION_GROUP_LOCATION_WHEN_IN_USE)) {
                     requestResults.put(
-                            PermissionConstants.PERMISSION_GROUP_LOCATION_WHEN_IN_USE,
-                            permissionStatus);
+                        PermissionConstants.PERMISSION_GROUP_LOCATION_WHEN_IN_USE,
+                        permissionStatus);
                 }
 
                 requestResults.put(permission, permissionStatus);
             } else if (!requestResults.containsKey(permission)) {
                 requestResults.put(
-                        permission,
-                        PermissionUtils.toPermissionStatus(this.activity, permissionName, result));
+                    permission,
+                    PermissionUtils.toPermissionStatus(this.activity, permissionName, result));
             }
 
             PermissionUtils.updatePermissionShouldShowStatus(this.activity, permission);
@@ -218,33 +218,33 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
      * have access to an application context regardless of whether the activity is null, a context
      * must be supplied.
      *
-     * @param permission the permission for which to determine the status.
-     * @param context the application context, used for checking various permission APIs.
-     * @param activity the activity that allows us to distinguish between 'denied' and
-     * 'permanently denied' statuses.
+     * @param permission      the permission for which to determine the status.
+     * @param context         the application context, used for checking various permission APIs.
+     * @param activity        the activity that allows us to distinguish between 'denied' and
+     *                        'permanently denied' statuses.
      * @param successCallback the callback to which the resolved status must be supplied.
      */
     void checkPermissionStatus(
-            final @PermissionConstants.PermissionGroup int permission,
-            final @NonNull Context context,
-            final @Nullable Activity activity,
-            final CheckPermissionsSuccessCallback successCallback) {
+        final @PermissionConstants.PermissionGroup int permission,
+        final @NonNull Context context,
+        final @Nullable Activity activity,
+        final CheckPermissionsSuccessCallback successCallback) {
 
         successCallback.onSuccess(determinePermissionStatus(
-                permission,
-                context,
-                activity));
+            permission,
+            context,
+            activity));
     }
 
     void requestPermissions(
-            List<Integer> permissions,
-            Activity activity,
-            RequestPermissionsSuccessCallback successCallback,
-            ErrorCallback errorCallback) {
+        List<Integer> permissions,
+        Activity activity,
+        RequestPermissionsSuccessCallback successCallback,
+        ErrorCallback errorCallback) {
         if (ongoing) {
             errorCallback.onError(
-                    "PermissionHandler.PermissionManager",
-                    "A request for permissions is already running, please wait for it to finish before doing another request (note that you can request multiple permissions at the same time).");
+                "PermissionHandler.PermissionManager",
+                "A request for permissions is already running, please wait for it to finish before doing another request (note that you can request multiple permissions at the same time).");
             return;
         }
 
@@ -252,8 +252,8 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
             Log.d(PermissionConstants.LOG_TAG, "Unable to detect current Activity.");
 
             errorCallback.onError(
-                    "PermissionHandler.PermissionManager",
-                    "Unable to detect current Android Activity.");
+                "PermissionHandler.PermissionManager",
+                "Unable to detect current Android Activity.");
             return;
         }
 
@@ -298,28 +298,28 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && permission == PermissionConstants.PERMISSION_GROUP_IGNORE_BATTERY_OPTIMIZATIONS) {
                 executeIntent(
-                        Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
-                        PermissionConstants.PERMISSION_CODE_IGNORE_BATTERY_OPTIMIZATIONS);
+                    Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
+                    PermissionConstants.PERMISSION_CODE_IGNORE_BATTERY_OPTIMIZATIONS);
             } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && permission == PermissionConstants.PERMISSION_GROUP_MANAGE_EXTERNAL_STORAGE) {
                 executeIntent(
-                        Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION,
-                        PermissionConstants.PERMISSION_CODE_MANAGE_EXTERNAL_STORAGE);
+                    Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION,
+                    PermissionConstants.PERMISSION_CODE_MANAGE_EXTERNAL_STORAGE);
             } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && permission == PermissionConstants.PERMISSION_GROUP_SYSTEM_ALERT_WINDOW) {
                 executeIntent(
-                        Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
-                        PermissionConstants.PERMISSION_CODE_SYSTEM_ALERT_WINDOW);
+                    Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
+                    PermissionConstants.PERMISSION_CODE_SYSTEM_ALERT_WINDOW);
             } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && permission == PermissionConstants.PERMISSION_GROUP_REQUEST_INSTALL_PACKAGES) {
                 executeIntent(
-                        Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
-                        PermissionConstants.PERMISSION_CODE_REQUEST_INSTALL_PACKAGES);
+                    Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
+                    PermissionConstants.PERMISSION_CODE_REQUEST_INSTALL_PACKAGES);
             } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && permission == PermissionConstants.PERMISSION_GROUP_ACCESS_NOTIFICATION_POLICY) {
                 executeSimpleIntent(
-                        Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS,
-                        PermissionConstants.PERMISSION_CODE_ACCESS_NOTIFICATION_POLICY);
+                    Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS,
+                    PermissionConstants.PERMISSION_CODE_ACCESS_NOTIFICATION_POLICY);
             } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && permission == PermissionConstants.PERMISSION_GROUP_SCHEDULE_EXACT_ALARM) {
                 executeIntent(
-                        Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM,
-                        PermissionConstants.PERMISSION_CODE_SCHEDULE_EXACT_ALARM);
+                    Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM,
+                    PermissionConstants.PERMISSION_CODE_SCHEDULE_EXACT_ALARM);
             } else {
                 permissionsToRequest.addAll(names);
             }
@@ -330,9 +330,9 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
             ongoing = true;
 
             ActivityCompat.requestPermissions(
-                    activity,
-                    requestPermissions,
-                    PermissionConstants.PERMISSION_CODE);
+                activity,
+                requestPermissions,
+                PermissionConstants.PERMISSION_CODE);
         } else {
             ongoing = false;
             if (requestResults.size() > 0) {
@@ -343,9 +343,9 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
 
     @PermissionConstants.PermissionStatus
     private int determinePermissionStatus(
-            final @PermissionConstants.PermissionGroup int permission,
-            final @NonNull Context context,
-            final @Nullable Activity activity) {
+        final @PermissionConstants.PermissionGroup int permission,
+        final @NonNull Context context,
+        final @Nullable Activity activity) {
 
         if (permission == PermissionConstants.PERMISSION_GROUP_NOTIFICATION) {
             return checkNotificationPermissionStatus(context);
@@ -356,8 +356,8 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
         }
 
         if (permission == PermissionConstants.PERMISSION_GROUP_BLUETOOTH_CONNECT
-                || permission == PermissionConstants.PERMISSION_GROUP_BLUETOOTH_SCAN
-                || permission == PermissionConstants.PERMISSION_GROUP_BLUETOOTH_ADVERTISE){
+            || permission == PermissionConstants.PERMISSION_GROUP_BLUETOOTH_SCAN
+            || permission == PermissionConstants.PERMISSION_GROUP_BLUETOOTH_ADVERTISE) {
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
                 return checkBluetoothPermissionStatus(context);
             }
@@ -422,23 +422,23 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
                     }
 
                     return Environment.isExternalStorageManager()
-                            ? PermissionConstants.PERMISSION_STATUS_GRANTED
-                            : PermissionConstants.PERMISSION_STATUS_DENIED;
+                        ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                        : PermissionConstants.PERMISSION_STATUS_DENIED;
                 }
 
                 if (permission == PermissionConstants.PERMISSION_GROUP_SYSTEM_ALERT_WINDOW) {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                         return Settings.canDrawOverlays(context)
-                                ? PermissionConstants.PERMISSION_STATUS_GRANTED
-                                : PermissionConstants.PERMISSION_STATUS_DENIED;
+                            ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                            : PermissionConstants.PERMISSION_STATUS_DENIED;
                     }
                 }
 
                 if (permission == PermissionConstants.PERMISSION_GROUP_REQUEST_INSTALL_PACKAGES) {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                         return context.getPackageManager().canRequestPackageInstalls()
-                                ? PermissionConstants.PERMISSION_STATUS_GRANTED
-                                : PermissionConstants.PERMISSION_STATUS_DENIED;
+                            ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                            : PermissionConstants.PERMISSION_STATUS_DENIED;
                     }
                 }
 
@@ -446,8 +446,8 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                         NotificationManager notificationManager = (NotificationManager) context.getSystemService(Application.NOTIFICATION_SERVICE);
                         return notificationManager.isNotificationPolicyAccessGranted()
-                                ? PermissionConstants.PERMISSION_STATUS_GRANTED
-                                : PermissionConstants.PERMISSION_STATUS_DENIED;
+                            ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                            : PermissionConstants.PERMISSION_STATUS_DENIED;
                     }
                 }
 
@@ -455,8 +455,8 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                         AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
                         return alarmManager.canScheduleExactAlarms()
-                                ? PermissionConstants.PERMISSION_STATUS_GRANTED
-                                : PermissionConstants.PERMISSION_STATUS_DENIED;
+                            ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                            : PermissionConstants.PERMISSION_STATUS_DENIED;
                     } else {
                         return PermissionConstants.PERMISSION_STATUS_GRANTED;
                     }
@@ -484,16 +484,16 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
     }
 
     void shouldShowRequestPermissionRationale(
-            int permission,
-            Activity activity,
-            ShouldShowRequestPermissionRationaleSuccessCallback successCallback,
-            ErrorCallback errorCallback) {
+        int permission,
+        Activity activity,
+        ShouldShowRequestPermissionRationaleSuccessCallback successCallback,
+        ErrorCallback errorCallback) {
         if (activity == null) {
             Log.d(PermissionConstants.LOG_TAG, "Unable to detect current Activity.");
 
             errorCallback.onError(
-                    "PermissionHandler.PermissionManager",
-                    "Unable to detect current Android Activity.");
+                "PermissionHandler.PermissionManager",
+                "Unable to detect current Android Activity.");
             return;
         }
 

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
@@ -447,12 +447,12 @@ public class PermissionUtils {
      */
     @PermissionConstants.PermissionStatus
     static int toPermissionStatus(
-        final Context context,
+        final @Nullable Activity activity,
         final String permissionName,
         int grantResult) {
 
         if (grantResult == PackageManager.PERMISSION_DENIED) {
-            return determineDeniedVariant(context, permissionName);
+            return determineDeniedVariant(activity, permissionName);
         }
 
         return PermissionConstants.PERMISSION_STATUS_GRANTED;
@@ -462,21 +462,19 @@ public class PermissionUtils {
      * Determines whether a permission was either 'denied' or 'permanently denied'.
      * <p>
      * To distinguish between these two variants, the method needs access to an {@link Activity}.
-     * To that end, it checks if the provided {@link Context} is of type {@link Activity}. If it is,
-     * permission type resolution will work as expected. If a regular {@link Context} is provided
-     * instead, the result will always be resolved to 'denied'.
+     * If the provided activity is null, the result will always be resolved to 'denied'.
      *
-     * @param context the context needed to resolve.
+     * @param activity the activity needed to resolve the permission status.
      * @param permissionName the name of the permission.
      * @return either {@link PermissionConstants#PERMISSION_STATUS_DENIED} or
-     * {@link PermissionConstants#PERMISSION_STATUS_NEVER_ASK_AGAIN}
+     * {@link PermissionConstants#PERMISSION_STATUS_NEVER_ASK_AGAIN}.
      */
     @PermissionConstants.PermissionStatus
     static int determineDeniedVariant(
-        final Context context,
+        final @Nullable Activity activity,
         final String permissionName) {
 
-        if (!(context instanceof Activity)) {
+        if (activity == null) {
             return PermissionConstants.PERMISSION_STATUS_DENIED;
         }
 
@@ -484,14 +482,14 @@ public class PermissionUtils {
             return PermissionConstants.PERMISSION_STATUS_DENIED;
         }
 
-        final boolean wasDeniedBefore = PermissionUtils.wasPermissionDeniedBefore(context, permissionName);
-        final boolean shouldShowRational = !PermissionUtils.isNeverAskAgainSelected((Activity) context, permissionName);
+        final boolean wasDeniedBefore = PermissionUtils.wasPermissionDeniedBefore(activity, permissionName);
+        final boolean shouldShowRational = !PermissionUtils.isNeverAskAgainSelected(activity, permissionName);
 
         //noinspection SimplifiableConditionalExpression
         final boolean isDenied = wasDeniedBefore ? !shouldShowRational : shouldShowRational;
 
         if (!wasDeniedBefore && isDenied) {
-            setPermissionDenied(context, permissionName);
+            setPermissionDenied(activity, permissionName);
         }
 
         if (wasDeniedBefore && isDenied) {

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
@@ -440,7 +440,7 @@ public class PermissionUtils {
      * @param activity       the activity for context
      * @param permissionName the name of the permission
      * @param grantResult    the result of the permission intent. Either
-     * {@link PackageManager#PERMISSION_DENIED} or {@link PackageManager#PERMISSION_GRANTED}.
+     *                       {@link PackageManager#PERMISSION_DENIED} or {@link PackageManager#PERMISSION_GRANTED}.
      * @return {@link PermissionConstants#PERMISSION_STATUS_GRANTED},
      * {@link PermissionConstants#PERMISSION_STATUS_DENIED}, or
      * {@link PermissionConstants#PERMISSION_STATUS_NEVER_ASK_AGAIN}.
@@ -464,7 +464,7 @@ public class PermissionUtils {
      * To distinguish between these two variants, the method needs access to an {@link Activity}.
      * If the provided activity is null, the result will always be resolved to 'denied'.
      *
-     * @param activity the activity needed to resolve the permission status.
+     * @param activity       the activity needed to resolve the permission status.
      * @param permissionName the name of the permission.
      * @return either {@link PermissionConstants#PERMISSION_STATUS_DENIED} or
      * {@link PermissionConstants#PERMISSION_STATUS_NEVER_ASK_AGAIN}.

--- a/permission_handler_android/pubspec.yaml
+++ b/permission_handler_android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: permission_handler_android
 description: Permission plugin for Flutter. This plugin provides the Android API to request and check permissions.
 homepage: https://github.com/baseflow/flutter-permission-handler
-version: 10.3.5
+version: 11.0.0
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
Currently there is a discrepancy between a permission's status and its request result. Permission statuses are always 'denied', even if the request result is 'permanently denied'. This PR fixes that bug by leveraging the logic added in #1125.

@mvanbeusekom do you agree that a permission's status should be able to return 'permanently denied'? I noticed statuses can also return 'restricted', so maybe you want to treat a permission's status and its request result differently? On iOS, the status always returns 'permanently denied' (note that permissions can only be asked once on iOS).
@mvanbeusekom should this change be labeled as breaking? Some folks might be depending on the exact return value of a permission's status.

This PR fixes #936. Note that the mentioned issue does not seem to be particular to only the microphone permission, but rather, all permissions that show the user a dialog (so not the ones that open the settings page).

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [ ] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
