### PR TITLE
Clarify background location permission docs

### DIFF
--- a/permission_handler_platform_interface/CHANGELOG.md
+++ b/permission_handler_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.11.4
+* Clarifies the documentation on requesting background location permission
+through `Permission.locationAlways` on Android 10+ (API 29+).
+
 ## 3.11.3
 
 * Updates the documentation for the `Permission.bluetooth` permission regarding the limitations of the permission on iOS.

--- a/permission_handler_platform_interface/lib/src/permissions.dart
+++ b/permission_handler_platform_interface/lib/src/permissions.dart
@@ -56,15 +56,16 @@ class Permission {
   /// different:
   ///
   /// **Android:**
-  /// - When running on Android Q and above: Background Location Permission
+  /// - When running on Android Q and above: Background Location Permission.
+  /// <br>**Please note**: To request this permission, the user needs to grant foreground
+  /// location permissions first. You can do this by using either
+  /// [Permission.location] or [Permission.locationWhenInUse]. Then, requesting
+  /// [Permission.locationAlways] will show an additional dialog or open the
+  /// location permission app settings, allowing the user to change the location
+  /// access to 'allow all the time'.
   /// - When running on Android < Q: Fine and Coarse Location
   ///
   /// **iOS:** CoreLocation - Always
-  /// - When requesting this permission, the user needs to grant permission for
-  /// the `locationWhenInUse` permission first, clicking on the
-  /// `Allow While Using App` option on the popup. After allowing the
-  /// permission, the user can request the `locationAlways` permission and can
-  /// click on the `Change To Always Allow` option.
   static const locationAlways = PermissionWithService._(4);
 
   /// Permission for accessing the device's location when the app is running in

--- a/permission_handler_platform_interface/pubspec.yaml
+++ b/permission_handler_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the permission_handler plugin.
 homepage: https://github.com/baseflow/flutter-permission-handler/tree/master/permission_handler_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 3.11.3
+version: 3.11.4
 
 dependencies:
   flutter:


### PR DESCRIPTION
Clarifies the permission documentation on requesting background location permission through `Permission.locationAlways` on Android 10+ (API 29+).

Issue #781 is an instance of users being confused by how the permission works.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [ ] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
