### PR TITLE
Open settings screen when requesting 'schedule exact alarm'

### DIFF
--- a/permission_handler_android/CHANGELOG.md
+++ b/permission_handler_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 10.3.5
+
+* Fixes a bug where `Permission.ScheduleExactAlarm` was not opening the settings
+screen.
+
 ## 10.3.4
 
 * Fixes a bug where the permission status would return 'permanently denied'

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionConstants.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionConstants.java
@@ -13,6 +13,7 @@ final class PermissionConstants {
     static final int PERMISSION_CODE_SYSTEM_ALERT_WINDOW = 211;
     static final int PERMISSION_CODE_REQUEST_INSTALL_PACKAGES = 212;
     static final int PERMISSION_CODE_ACCESS_NOTIFICATION_POLICY = 213;
+    static final int PERMISSION_CODE_SCHEDULE_EXACT_ALARM = 214;
 
     //PERMISSION_GROUP
     static final int PERMISSION_GROUP_CALENDAR = 0;

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
@@ -17,6 +17,7 @@ import android.util.Log;
 
 import androidx.annotation.Nullable;
 import androidx.core.app.ActivityCompat;
+import androidx.core.app.AlarmManagerCompat;
 import androidx.core.app.NotificationManagerCompat;
 import androidx.core.content.ContextCompat;
 
@@ -43,7 +44,8 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
                 requestCode != PermissionConstants.PERMISSION_CODE_MANAGE_EXTERNAL_STORAGE &&
                 requestCode != PermissionConstants.PERMISSION_CODE_SYSTEM_ALERT_WINDOW &&
                 requestCode != PermissionConstants.PERMISSION_CODE_REQUEST_INSTALL_PACKAGES &&
-                requestCode != PermissionConstants.PERMISSION_CODE_ACCESS_NOTIFICATION_POLICY) {
+                requestCode != PermissionConstants.PERMISSION_CODE_ACCESS_NOTIFICATION_POLICY &&
+                requestCode != PermissionConstants.PERMISSION_CODE_SCHEDULE_EXACT_ALARM) {
             return false;
         }
 
@@ -89,6 +91,16 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
                         ? PermissionConstants.PERMISSION_STATUS_GRANTED
                         : PermissionConstants.PERMISSION_STATUS_DENIED;
                 permission = PermissionConstants.PERMISSION_GROUP_ACCESS_NOTIFICATION_POLICY;
+            } else {
+                return false;
+            }
+        } else if (requestCode == PermissionConstants.PERMISSION_CODE_SCHEDULE_EXACT_ALARM) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                AlarmManager alarmManager = (AlarmManager) activity.getSystemService(Context.ALARM_SERVICE);
+                status = alarmManager.canScheduleExactAlarms()
+                        ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                        : PermissionConstants.PERMISSION_STATUS_DENIED;
+                permission = PermissionConstants.PERMISSION_GROUP_SCHEDULE_EXACT_ALARM;
             } else {
                 return false;
             }
@@ -282,6 +294,10 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
                 executeSimpleIntent(
                         Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS,
                         PermissionConstants.PERMISSION_CODE_ACCESS_NOTIFICATION_POLICY);
+            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && permission == PermissionConstants.PERMISSION_GROUP_SCHEDULE_EXACT_ALARM) {
+                executeIntent(
+                        Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM,
+                        PermissionConstants.PERMISSION_CODE_SCHEDULE_EXACT_ALARM);
             } else {
                 permissionsToRequest.addAll(names);
             }

--- a/permission_handler_android/pubspec.yaml
+++ b/permission_handler_android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: permission_handler_android
 description: Permission plugin for Flutter. This plugin provides the Android API to request and check permissions.
 homepage: https://github.com/baseflow/flutter-permission-handler
-version: 10.3.4
+version: 10.3.5
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
When requesting the 'schedule exact alarm' permission, the user should be redirected to the application's setting screen where they can grant the permission. In the current version of the plugin, the `Intent` to open this screen is never fired. This PR adds the logic to open the screen and come back to the user with the result.

Closes #1137.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [ ] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
