### PR TITLE
Handle special permissions correctly when requesting multiple permissions

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.4.5
+
+* Updates the mentions of Android versions in the README, now following a format of 'Android {name} (API {number})'. For example: 'Android 13 (API 33)'.
+
 ## 10.4.4
 
 * Adds a section to the [FAQ](https://pub.dev/packages/permission_handler#faq) clarifying how to request background location permission on Android 10+ (API 29+).

--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.4.4
+
+* Adds a section to the [FAQ](https://pub.dev/packages/permission_handler#faq) clarifying how to request background location permission on Android 10+ (API 29+).
+
 ## 10.4.3
 
 * Updates example app to show relevant permissions on Android and iOS platforms.

--- a/permission_handler/README.md
+++ b/permission_handler/README.md
@@ -244,14 +244,17 @@ This will then bring up another permission popup asking you to `Keep Only While 
 
 ## FAQ
 
-### Requesting "storage" permissions always returns "denied" on Android 13, what can I do?
+### Requesting "storage" permissions always returns "denied" on Android 13+. What can I do?
 
 On Android the `Permission.storage` permission is linked to the Android `READ_EXTERNAL_STORAGE` and `WRITE_EXTERNAL_STORAGE` permissions. Starting from Android SDK 29 (Android 10) the `READ_EXTERNAL_STORAGE` and `WRITE_EXTERNAL_STORAGE` permissions have been marked deprecated and have been fully removed/ disabled since Android SDK 33 (Android 13). 
 
 If your application needs access to media files Google recommends using the `READ_MEDIA_IMAGES`, `READ_MEDIA_VIDEOS` or `READ_MEDIA_AUDIO` permissions instead. These can be requested using the `Permission.photos`, `Permission.videos` and `Permission.audio` respectively. To request these permissions make sure the `compileSdkVersion` in the `android/app/build.gradle` file is set to `33`.
 
-If your application needs access to Androids file system it is possible to request the `MANAGE_EXTERNAL_STORAGE` permission (using `Permission.manageExternalStorage`). As of Android SDK 30 (Android 11) the `MANAGE_EXTERNAL_STORAGE` permission is considered a high-risk or sensitive permission. There for it is required to [declare the use of these permissions](https://support.google.com/googleplay/android-developer/answer/9214102) if you intend to release the application via the Google Play Store. 
+If your application needs access to Androids file system it is possible to request the `MANAGE_EXTERNAL_STORAGE` permission (using `Permission.manageExternalStorage`). As of Android SDK 30 (Android 11) the `MANAGE_EXTERNAL_STORAGE` permission is considered a high-risk or sensitive permission. There for it is required to [declare the use of these permissions](https://support.google.com/googleplay/android-developer/answer/9214102) if you intend to release the application via the Google Play Store.
 
+### Requesting `Permission.locationAlways` always returns "denied" on Android 10+ (API 29+). What can I do?
+
+Starting with Android 10, apps are required to first obtain the permission to read the device's location in the foreground, before requesting to read the location in the background as well. When requesting for the 'location always' permission directly, or when requesting both permissions at the same time, the system will ignore the request. So, instead of calling only `Permission.location.request()`, make sure to first call either `Permission.location.request()` or `Permission.locationWhenInUse.request()`, and obtain permission to read the GPS. Once you obtain this permission, you can call `Permission.locationAlways.request()`. This will present the user with the option to update the settings so the location can always be read in the background. For more information, visit the [Android documentation on requesting location permissions](https://developer.android.com/training/location/permissions#request-only-foreground).
 
 ## Issues
 

--- a/permission_handler/README.md
+++ b/permission_handler/README.md
@@ -33,7 +33,7 @@ android.useAndroidX=true
 android.enableJetifier=true
 ```
 
-1. Make sure you set the `compileSdkVersion` in your "android/app/build.gradle" file to 33:
+2. Make sure you set the `compileSdkVersion` in your "android/app/build.gradle" file to 33:
 
 ```gradle
 android {
@@ -42,7 +42,7 @@ android {
 }
 ```
 
-1. Make sure you replace all the `android.` dependencies to their AndroidX counterparts (a full list can be found [here](https://developer.android.com/jetpack/androidx/migrate)).
+3. Make sure you replace all the `android.` dependencies to their AndroidX counterparts (a full list can be found [here](https://developer.android.com/jetpack/androidx/migrate)).
 
 Add permissions to your `AndroidManifest.xml` file.
 There's a `debug`, `main` and `profile` version which are chosen depending on how you start your app.
@@ -61,7 +61,7 @@ Add permission to your `Info.plist` file.
 
 The <kbd>permission_handler</kbd> plugin use [macros](https://github.com/Baseflow/flutter-permission-handler/blob/master/permission_handler_apple/ios/Classes/PermissionHandlerEnums.h) to control whether a permission is enabled.
 
-You must list permission you want to use in your application :
+You must list permission you want to use in your application:
 
 1. Add the following to your `Podfile` file:
 
@@ -171,7 +171,7 @@ You can get a `Permission`'s `status`, which is either `granted`, `denied`, `res
 ```dart
 var status = await Permission.camera.status;
 if (status.isDenied) {
-  // We didn't ask for permission yet or the permission has been denied before but not permanently.
+  // We didn't ask for permission yet or the permission has been denied before, but not permanently.
 }
 
 // You can can also directly ask the permission about its status.
@@ -246,11 +246,11 @@ This will then bring up another permission popup asking you to `Keep Only While 
 
 ### Requesting "storage" permissions always returns "denied" on Android 13+. What can I do?
 
-On Android the `Permission.storage` permission is linked to the Android `READ_EXTERNAL_STORAGE` and `WRITE_EXTERNAL_STORAGE` permissions. Starting from Android SDK 29 (Android 10) the `READ_EXTERNAL_STORAGE` and `WRITE_EXTERNAL_STORAGE` permissions have been marked deprecated and have been fully removed/ disabled since Android SDK 33 (Android 13). 
+On Android the `Permission.storage` permission is linked to the Android `READ_EXTERNAL_STORAGE` and `WRITE_EXTERNAL_STORAGE` permissions. Starting from Android 10 (API 29) the `READ_EXTERNAL_STORAGE` and `WRITE_EXTERNAL_STORAGE` permissions have been marked deprecated and have been fully removed/disabled since Android 13 (API 33).
 
 If your application needs access to media files Google recommends using the `READ_MEDIA_IMAGES`, `READ_MEDIA_VIDEOS` or `READ_MEDIA_AUDIO` permissions instead. These can be requested using the `Permission.photos`, `Permission.videos` and `Permission.audio` respectively. To request these permissions make sure the `compileSdkVersion` in the `android/app/build.gradle` file is set to `33`.
 
-If your application needs access to Androids file system it is possible to request the `MANAGE_EXTERNAL_STORAGE` permission (using `Permission.manageExternalStorage`). As of Android SDK 30 (Android 11) the `MANAGE_EXTERNAL_STORAGE` permission is considered a high-risk or sensitive permission. There for it is required to [declare the use of these permissions](https://support.google.com/googleplay/android-developer/answer/9214102) if you intend to release the application via the Google Play Store.
+If your application needs access to Android's file system, it is possible to request the `MANAGE_EXTERNAL_STORAGE` permission (using `Permission.manageExternalStorage`). As of Android 11 (API 30), the `MANAGE_EXTERNAL_STORAGE` permission is considered a high-risk or sensitive permission. Therefore it is required to [declare the use of these permissions](https://support.google.com/googleplay/android-developer/answer/9214102) if you intend to release the application via the Google Play Store.
 
 ### Requesting `Permission.locationAlways` always returns "denied" on Android 10+ (API 29+). What can I do?
 

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -2,7 +2,7 @@ name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
 repository: https://github.com/baseflow/flutter-permission-handler
 issue_tracker: https://github.com/Baseflow/flutter-permission-handler/issues
-version: 10.4.3
+version: 10.4.4
 
 environment:
   sdk: ">=2.15.0 <4.0.0"

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -2,7 +2,7 @@ name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
 repository: https://github.com/baseflow/flutter-permission-handler
 issue_tracker: https://github.com/Baseflow/flutter-permission-handler/issues
-version: 10.4.4
+version: 10.4.5
 
 environment:
   sdk: ">=2.15.0 <4.0.0"

--- a/permission_handler_android/CHANGELOG.md
+++ b/permission_handler_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.3.6
+
+* Fixes a bug where requesting multiple permissions would crash the app if at least one of the permissions was a [special permission](https://developer.android.com/guide/topics/permissions/overview#special).
+
 ## 10.3.5
 
 * Fixes a bug where `Permission.ScheduleExactAlarm` was not opening the settings

--- a/permission_handler_android/CHANGELOG.md
+++ b/permission_handler_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 10.3.5
+
+* Fixes a bug where `Permission.ScheduleExactAlarm` was not opening the settings
+screen.
+
 ## 10.3.4
 
 * Fixes a bug where the permission status would return 'permanently denied'

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionConstants.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionConstants.java
@@ -13,6 +13,7 @@ final class PermissionConstants {
     static final int PERMISSION_CODE_SYSTEM_ALERT_WINDOW = 211;
     static final int PERMISSION_CODE_REQUEST_INSTALL_PACKAGES = 212;
     static final int PERMISSION_CODE_ACCESS_NOTIFICATION_POLICY = 213;
+    static final int PERMISSION_CODE_SCHEDULE_EXACT_ALARM = 214;
 
     //PERMISSION_GROUP
     static final int PERMISSION_GROUP_CALENDAR = 0;

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
@@ -17,6 +17,7 @@ import android.util.Log;
 
 import androidx.annotation.Nullable;
 import androidx.core.app.ActivityCompat;
+import androidx.core.app.AlarmManagerCompat;
 import androidx.core.app.NotificationManagerCompat;
 import androidx.core.content.ContextCompat;
 
@@ -43,7 +44,8 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
                 requestCode != PermissionConstants.PERMISSION_CODE_MANAGE_EXTERNAL_STORAGE &&
                 requestCode != PermissionConstants.PERMISSION_CODE_SYSTEM_ALERT_WINDOW &&
                 requestCode != PermissionConstants.PERMISSION_CODE_REQUEST_INSTALL_PACKAGES &&
-                requestCode != PermissionConstants.PERMISSION_CODE_ACCESS_NOTIFICATION_POLICY) {
+                requestCode != PermissionConstants.PERMISSION_CODE_ACCESS_NOTIFICATION_POLICY &&
+                requestCode != PermissionConstants.PERMISSION_CODE_SCHEDULE_EXACT_ALARM) {
             return false;
         }
 
@@ -89,6 +91,16 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
                         ? PermissionConstants.PERMISSION_STATUS_GRANTED
                         : PermissionConstants.PERMISSION_STATUS_DENIED;
                 permission = PermissionConstants.PERMISSION_GROUP_ACCESS_NOTIFICATION_POLICY;
+            } else {
+                return false;
+            }
+        } else if (requestCode == PermissionConstants.PERMISSION_CODE_SCHEDULE_EXACT_ALARM) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                AlarmManager alarmManager = (AlarmManager) activity.getSystemService(Context.ALARM_SERVICE);
+                status = alarmManager.canScheduleExactAlarms()
+                        ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                        : PermissionConstants.PERMISSION_STATUS_DENIED;
+                permission = PermissionConstants.PERMISSION_GROUP_SCHEDULE_EXACT_ALARM;
             } else {
                 return false;
             }
@@ -282,6 +294,10 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
                 executeSimpleIntent(
                         Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS,
                         PermissionConstants.PERMISSION_CODE_ACCESS_NOTIFICATION_POLICY);
+            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && permission == PermissionConstants.PERMISSION_GROUP_SCHEDULE_EXACT_ALARM) {
+                executeIntent(
+                        Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM,
+                        PermissionConstants.PERMISSION_CODE_SCHEDULE_EXACT_ALARM);
             } else {
                 permissionsToRequest.addAll(names);
             }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
@@ -18,7 +18,6 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.app.ActivityCompat;
-import androidx.core.app.AlarmManagerCompat;
 import androidx.core.app.NotificationManagerCompat;
 import androidx.core.content.ContextCompat;
 
@@ -59,17 +58,17 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
     @Override
     public boolean onActivityResult(int requestCode, int resultCode, Intent data) {
         if (requestCode != PermissionConstants.PERMISSION_CODE_IGNORE_BATTERY_OPTIMIZATIONS &&
-                requestCode != PermissionConstants.PERMISSION_CODE_MANAGE_EXTERNAL_STORAGE &&
-                requestCode != PermissionConstants.PERMISSION_CODE_SYSTEM_ALERT_WINDOW &&
-                requestCode != PermissionConstants.PERMISSION_CODE_REQUEST_INSTALL_PACKAGES &&
-                requestCode != PermissionConstants.PERMISSION_CODE_ACCESS_NOTIFICATION_POLICY &&
-                requestCode != PermissionConstants.PERMISSION_CODE_SCHEDULE_EXACT_ALARM) {
+            requestCode != PermissionConstants.PERMISSION_CODE_MANAGE_EXTERNAL_STORAGE &&
+            requestCode != PermissionConstants.PERMISSION_CODE_SYSTEM_ALERT_WINDOW &&
+            requestCode != PermissionConstants.PERMISSION_CODE_REQUEST_INSTALL_PACKAGES &&
+            requestCode != PermissionConstants.PERMISSION_CODE_ACCESS_NOTIFICATION_POLICY &&
+            requestCode != PermissionConstants.PERMISSION_CODE_SCHEDULE_EXACT_ALARM) {
             return false;
         }
 
         int status = resultCode == Activity.RESULT_OK
-                ? PermissionConstants.PERMISSION_STATUS_GRANTED
-                : PermissionConstants.PERMISSION_STATUS_DENIED;
+            ? PermissionConstants.PERMISSION_STATUS_GRANTED
+            : PermissionConstants.PERMISSION_STATUS_DENIED;
 
         int permission;
 
@@ -78,8 +77,8 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
         } else if (requestCode == PermissionConstants.PERMISSION_CODE_MANAGE_EXTERNAL_STORAGE) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                 status = Environment.isExternalStorageManager()
-                        ? PermissionConstants.PERMISSION_STATUS_GRANTED
-                        : PermissionConstants.PERMISSION_STATUS_DENIED;
+                    ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                    : PermissionConstants.PERMISSION_STATUS_DENIED;
             } else {
                 return false;
             }
@@ -87,8 +86,8 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
         } else if (requestCode == PermissionConstants.PERMISSION_CODE_SYSTEM_ALERT_WINDOW) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 status = Settings.canDrawOverlays(activity)
-                        ? PermissionConstants.PERMISSION_STATUS_GRANTED
-                        : PermissionConstants.PERMISSION_STATUS_DENIED;
+                    ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                    : PermissionConstants.PERMISSION_STATUS_DENIED;
                 permission = PermissionConstants.PERMISSION_GROUP_SYSTEM_ALERT_WINDOW;
             } else {
                 return false;
@@ -96,8 +95,8 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
         } else if (requestCode == PermissionConstants.PERMISSION_CODE_REQUEST_INSTALL_PACKAGES) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 status = activity.getPackageManager().canRequestPackageInstalls()
-                        ? PermissionConstants.PERMISSION_STATUS_GRANTED
-                        : PermissionConstants.PERMISSION_STATUS_DENIED;
+                    ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                    : PermissionConstants.PERMISSION_STATUS_DENIED;
                 permission = PermissionConstants.PERMISSION_GROUP_REQUEST_INSTALL_PACKAGES;
             } else {
                 return false;
@@ -106,8 +105,8 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 NotificationManager notificationManager = (NotificationManager) activity.getSystemService(Application.NOTIFICATION_SERVICE);
                 status = notificationManager.isNotificationPolicyAccessGranted()
-                        ? PermissionConstants.PERMISSION_STATUS_GRANTED
-                        : PermissionConstants.PERMISSION_STATUS_DENIED;
+                    ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                    : PermissionConstants.PERMISSION_STATUS_DENIED;
                 permission = PermissionConstants.PERMISSION_GROUP_ACCESS_NOTIFICATION_POLICY;
             } else {
                 return false;
@@ -116,8 +115,8 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 AlarmManager alarmManager = (AlarmManager) activity.getSystemService(Context.ALARM_SERVICE);
                 status = alarmManager.canScheduleExactAlarms()
-                        ? PermissionConstants.PERMISSION_STATUS_GRANTED
-                        : PermissionConstants.PERMISSION_STATUS_DENIED;
+                    ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                    : PermissionConstants.PERMISSION_STATUS_DENIED;
                 permission = PermissionConstants.PERMISSION_GROUP_SCHEDULE_EXACT_ALARM;
             } else {
                 return false;
@@ -148,14 +147,14 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
         }
 
         if (requestResults == null) {
-           return false;
+            return false;
         }
 
         for (int i = 0; i < permissions.length; i++) {
             final String permissionName = permissions[i];
 
             @PermissionConstants.PermissionGroup final int permission =
-                    PermissionUtils.parseManifestName(permissionName);
+                PermissionUtils.parseManifestName(permissionName);
 
             if (permission == PermissionConstants.PERMISSION_GROUP_UNKNOWN)
                 continue;
@@ -165,44 +164,44 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
             if (permission == PermissionConstants.PERMISSION_GROUP_MICROPHONE) {
                 if (!requestResults.containsKey(PermissionConstants.PERMISSION_GROUP_MICROPHONE)) {
                     requestResults.put(
-                            PermissionConstants.PERMISSION_GROUP_MICROPHONE,
-                            PermissionUtils.toPermissionStatus(this.activity, permissionName, result));
+                        PermissionConstants.PERMISSION_GROUP_MICROPHONE,
+                        PermissionUtils.toPermissionStatus(this.activity, permissionName, result));
                 }
                 if (!requestResults.containsKey(PermissionConstants.PERMISSION_GROUP_SPEECH)) {
                     requestResults.put(
-                            PermissionConstants.PERMISSION_GROUP_SPEECH,
-                            PermissionUtils.toPermissionStatus(this.activity, permissionName, result));
+                        PermissionConstants.PERMISSION_GROUP_SPEECH,
+                        PermissionUtils.toPermissionStatus(this.activity, permissionName, result));
                 }
             } else if (permission == PermissionConstants.PERMISSION_GROUP_LOCATION_ALWAYS) {
                 @PermissionConstants.PermissionStatus int permissionStatus =
-                        PermissionUtils.toPermissionStatus(this.activity, permissionName, result);
+                    PermissionUtils.toPermissionStatus(this.activity, permissionName, result);
 
                 if (!requestResults.containsKey(PermissionConstants.PERMISSION_GROUP_LOCATION_ALWAYS)) {
                     requestResults.put(PermissionConstants.PERMISSION_GROUP_LOCATION_ALWAYS, permissionStatus);
                 }
             } else if (permission == PermissionConstants.PERMISSION_GROUP_LOCATION) {
                 @PermissionConstants.PermissionStatus int permissionStatus =
-                        PermissionUtils.toPermissionStatus(this.activity, permissionName, result);
+                    PermissionUtils.toPermissionStatus(this.activity, permissionName, result);
 
                 if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
                     if (!requestResults.containsKey(PermissionConstants.PERMISSION_GROUP_LOCATION_ALWAYS)) {
                         requestResults.put(
-                                PermissionConstants.PERMISSION_GROUP_LOCATION_ALWAYS,
-                                permissionStatus);
+                            PermissionConstants.PERMISSION_GROUP_LOCATION_ALWAYS,
+                            permissionStatus);
                     }
                 }
 
                 if (!requestResults.containsKey(PermissionConstants.PERMISSION_GROUP_LOCATION_WHEN_IN_USE)) {
                     requestResults.put(
-                            PermissionConstants.PERMISSION_GROUP_LOCATION_WHEN_IN_USE,
-                            permissionStatus);
+                        PermissionConstants.PERMISSION_GROUP_LOCATION_WHEN_IN_USE,
+                        permissionStatus);
                 }
 
                 requestResults.put(permission, permissionStatus);
             } else if (!requestResults.containsKey(permission)) {
                 requestResults.put(
-                        permission,
-                        PermissionUtils.toPermissionStatus(this.activity, permissionName, result));
+                    permission,
+                    PermissionUtils.toPermissionStatus(this.activity, permissionName, result));
             }
 
             PermissionUtils.updatePermissionShouldShowStatus(this.activity, permission);
@@ -233,13 +232,13 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
     }
 
     void checkPermissionStatus(
-            @PermissionConstants.PermissionGroup int permission,
-            Context context,
-            CheckPermissionsSuccessCallback successCallback) {
+        @PermissionConstants.PermissionGroup int permission,
+        Context context,
+        CheckPermissionsSuccessCallback successCallback) {
 
         successCallback.onSuccess(determinePermissionStatus(
-                permission,
-                context));
+            permission,
+            context));
     }
 
     /**
@@ -265,20 +264,20 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
      * When these methods receive request results, they check whether all permissions that were
      * requested through this method were handled, and if so, return the result back to Dart.
      *
-     * @param permissions the permissions that are requested.
-     * @param activity the activity.
+     * @param permissions     the permissions that are requested.
+     * @param activity        the activity.
      * @param successCallback the callback for returning the permission results.
-     * @param errorCallback the callback to call in case of an error.
+     * @param errorCallback   the callback to call in case of an error.
      */
     void requestPermissions(
-            List<Integer> permissions,
-            Activity activity,
-            RequestPermissionsSuccessCallback successCallback,
-            ErrorCallback errorCallback) {
+        List<Integer> permissions,
+        Activity activity,
+        RequestPermissionsSuccessCallback successCallback,
+        ErrorCallback errorCallback) {
         if (pendingRequestCount > 0) {
             errorCallback.onError(
-                    "PermissionHandler.PermissionManager",
-                    "A request for permissions is already running, please wait for it to finish before doing another request (note that you can request multiple permissions at the same time).");
+                "PermissionHandler.PermissionManager",
+                "A request for permissions is already running, please wait for it to finish before doing another request (note that you can request multiple permissions at the same time).");
             return;
         }
 
@@ -286,8 +285,8 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
             Log.d(PermissionConstants.LOG_TAG, "Unable to detect current Activity.");
 
             errorCallback.onError(
-                    "PermissionHandler.PermissionManager",
-                    "Unable to detect current Android Activity.");
+                "PermissionHandler.PermissionManager",
+                "Unable to detect current Android Activity.");
             return;
         }
 
@@ -333,35 +332,29 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
 
             // Request special permissions.
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && permission == PermissionConstants.PERMISSION_GROUP_IGNORE_BATTERY_OPTIMIZATIONS) {
-                executeIntent(
-                        Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
-                        PermissionConstants.PERMISSION_CODE_IGNORE_BATTERY_OPTIMIZATIONS);
-                pendingRequestCount++;
+                launchSpecialPermission(
+                    Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
+                    PermissionConstants.PERMISSION_CODE_IGNORE_BATTERY_OPTIMIZATIONS);
             } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && permission == PermissionConstants.PERMISSION_GROUP_MANAGE_EXTERNAL_STORAGE) {
-                executeIntent(
-                        Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION,
-                        PermissionConstants.PERMISSION_CODE_MANAGE_EXTERNAL_STORAGE);
-                pendingRequestCount++;
+                launchSpecialPermission(
+                    Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION,
+                    PermissionConstants.PERMISSION_CODE_MANAGE_EXTERNAL_STORAGE);
             } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && permission == PermissionConstants.PERMISSION_GROUP_SYSTEM_ALERT_WINDOW) {
-                executeIntent(
-                        Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
-                        PermissionConstants.PERMISSION_CODE_SYSTEM_ALERT_WINDOW);
-                pendingRequestCount++;
+                launchSpecialPermission(
+                    Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
+                    PermissionConstants.PERMISSION_CODE_SYSTEM_ALERT_WINDOW);
             } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && permission == PermissionConstants.PERMISSION_GROUP_REQUEST_INSTALL_PACKAGES) {
-                executeIntent(
-                        Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
-                        PermissionConstants.PERMISSION_CODE_REQUEST_INSTALL_PACKAGES);
-                pendingRequestCount++;
+                launchSpecialPermission(
+                    Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
+                    PermissionConstants.PERMISSION_CODE_REQUEST_INSTALL_PACKAGES);
             } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && permission == PermissionConstants.PERMISSION_GROUP_ACCESS_NOTIFICATION_POLICY) {
-                executeSimpleIntent(
-                        Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS,
-                        PermissionConstants.PERMISSION_CODE_ACCESS_NOTIFICATION_POLICY);
-                pendingRequestCount++;
+                launchSpecialPermission(
+                    Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS,
+                    PermissionConstants.PERMISSION_CODE_ACCESS_NOTIFICATION_POLICY);
             } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && permission == PermissionConstants.PERMISSION_GROUP_SCHEDULE_EXACT_ALARM) {
-                executeIntent(
-                        Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM,
-                        PermissionConstants.PERMISSION_CODE_SCHEDULE_EXACT_ALARM);
-                pendingRequestCount++;
+                launchSpecialPermission(
+                    Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM,
+                    PermissionConstants.PERMISSION_CODE_SCHEDULE_EXACT_ALARM);
             } else {
                 permissionsToRequest.addAll(names);
                 pendingRequestCount += names.size();
@@ -372,9 +365,9 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
         if (permissionsToRequest.size() > 0) {
             final String[] requestPermissions = permissionsToRequest.toArray(new String[0]);
             ActivityCompat.requestPermissions(
-                    activity,
-                    requestPermissions,
-                    PermissionConstants.PERMISSION_CODE);
+                activity,
+                requestPermissions,
+                PermissionConstants.PERMISSION_CODE);
         }
 
         // Post results immediately if no requests are pending.
@@ -385,8 +378,8 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
 
     @PermissionConstants.PermissionStatus
     private int determinePermissionStatus(
-            @PermissionConstants.PermissionGroup int permission,
-            Context context) {
+        @PermissionConstants.PermissionGroup int permission,
+        Context context) {
 
         if (permission == PermissionConstants.PERMISSION_GROUP_NOTIFICATION) {
             return checkNotificationPermissionStatus(context);
@@ -397,8 +390,8 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
         }
 
         if (permission == PermissionConstants.PERMISSION_GROUP_BLUETOOTH_CONNECT
-                || permission == PermissionConstants.PERMISSION_GROUP_BLUETOOTH_SCAN
-                || permission == PermissionConstants.PERMISSION_GROUP_BLUETOOTH_ADVERTISE){
+            || permission == PermissionConstants.PERMISSION_GROUP_BLUETOOTH_SCAN
+            || permission == PermissionConstants.PERMISSION_GROUP_BLUETOOTH_ADVERTISE) {
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
                 return checkBluetoothPermissionStatus(context);
             }
@@ -463,23 +456,23 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
                     }
 
                     return Environment.isExternalStorageManager()
-                            ? PermissionConstants.PERMISSION_STATUS_GRANTED
-                            : PermissionConstants.PERMISSION_STATUS_DENIED;
+                        ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                        : PermissionConstants.PERMISSION_STATUS_DENIED;
                 }
 
                 if (permission == PermissionConstants.PERMISSION_GROUP_SYSTEM_ALERT_WINDOW) {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                         return Settings.canDrawOverlays(context)
-                                ? PermissionConstants.PERMISSION_STATUS_GRANTED
-                                : PermissionConstants.PERMISSION_STATUS_DENIED;
+                            ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                            : PermissionConstants.PERMISSION_STATUS_DENIED;
                     }
                 }
 
                 if (permission == PermissionConstants.PERMISSION_GROUP_REQUEST_INSTALL_PACKAGES) {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                         return context.getPackageManager().canRequestPackageInstalls()
-                                ? PermissionConstants.PERMISSION_STATUS_GRANTED
-                                : PermissionConstants.PERMISSION_STATUS_DENIED;
+                            ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                            : PermissionConstants.PERMISSION_STATUS_DENIED;
                     }
                 }
 
@@ -487,8 +480,8 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                         NotificationManager notificationManager = (NotificationManager) context.getSystemService(Application.NOTIFICATION_SERVICE);
                         return notificationManager.isNotificationPolicyAccessGranted()
-                                ? PermissionConstants.PERMISSION_STATUS_GRANTED
-                                : PermissionConstants.PERMISSION_STATUS_DENIED;
+                            ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                            : PermissionConstants.PERMISSION_STATUS_DENIED;
                     }
                 }
 
@@ -496,8 +489,8 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                         AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
                         return alarmManager.canScheduleExactAlarms()
-                                ? PermissionConstants.PERMISSION_STATUS_GRANTED
-                                : PermissionConstants.PERMISSION_STATUS_DENIED;
+                            ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                            : PermissionConstants.PERMISSION_STATUS_DENIED;
                     } else {
                         return PermissionConstants.PERMISSION_STATUS_GRANTED;
                     }
@@ -512,29 +505,37 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
         return PermissionConstants.PERMISSION_STATUS_GRANTED;
     }
 
-    private void executeIntent(String action, int requestCode) {
-        String packageName = activity.getPackageName();
-        Intent intent = new Intent();
-        intent.setAction(action);
-        intent.setData(Uri.parse("package:" + packageName));
+    /**
+     * Launches a request for a <a href="https://developer.android.com/training/permissions/requesting-special">special permission</a>.
+     * <p>
+     * There is a special case for {@link Settings#ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS}. See
+     * <a href="https://github.com/Baseflow/flutter-permission-handler/pull/587#discussion_r649295489">this comment</a>
+     * for more details.
+     *
+     * @param permissionAction the action for launching the settings page for a particular permission.
+     * @param requestCode      a request code to verify incoming results.
+     */
+    private void launchSpecialPermission(String permissionAction, int requestCode) {
+        Intent intent = new Intent(permissionAction);
+        if (!permissionAction.equals(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS)) {
+            String packageName = activity.getPackageName();
+            intent.setData(Uri.parse("package:" + packageName));
+        }
         activity.startActivityForResult(intent, requestCode);
-    }
-
-    private void executeSimpleIntent(String action, int requestCode) {
-        activity.startActivityForResult(new Intent(action), requestCode);
+        pendingRequestCount++;
     }
 
     void shouldShowRequestPermissionRationale(
-            int permission,
-            Activity activity,
-            ShouldShowRequestPermissionRationaleSuccessCallback successCallback,
-            ErrorCallback errorCallback) {
+        int permission,
+        Activity activity,
+        ShouldShowRequestPermissionRationaleSuccessCallback successCallback,
+        ErrorCallback errorCallback) {
         if (activity == null) {
             Log.d(PermissionConstants.LOG_TAG, "Unable to detect current Activity.");
 
             errorCallback.onError(
-                    "PermissionHandler.PermissionManager",
-                    "Unable to detect current Android Activity.");
+                "PermissionHandler.PermissionManager",
+                "Unable to detect current Android Activity.");
             return;
         }
 

--- a/permission_handler_android/pubspec.yaml
+++ b/permission_handler_android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: permission_handler_android
 description: Permission plugin for Flutter. This plugin provides the Android API to request and check permissions.
 homepage: https://github.com/baseflow/flutter-permission-handler
-version: 10.3.4
+version: 10.3.5
 
 environment:
   sdk: ">=2.15.0 <4.0.0"

--- a/permission_handler_android/pubspec.yaml
+++ b/permission_handler_android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: permission_handler_android
 description: Permission plugin for Flutter. This plugin provides the Android API to request and check permissions.
 homepage: https://github.com/baseflow/flutter-permission-handler
-version: 10.3.5
+version: 10.3.6
 
 environment:
   sdk: ">=2.15.0 <4.0.0"

--- a/permission_handler_platform_interface/CHANGELOG.md
+++ b/permission_handler_platform_interface/CHANGELOG.md
@@ -1,4 +1,9 @@
+## 3.11.5
+
+* Updates the mentions of Android versions throughout the plugin, now following a format of 'Android {name} (API {number})'. For example: 'Android 13 (API 33)'.
+
 ## 3.11.4
+
 * Clarifies the documentation on requesting background location permission
 through `Permission.locationAlways` on Android 10+ (API 29+).
 

--- a/permission_handler_platform_interface/CHANGELOG.md
+++ b/permission_handler_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.11.4
+* Clarifies the documentation on requesting background location permission
+through `Permission.locationAlways` on Android 10+ (API 29+).
+
 ## 3.11.3
 
 * Updates the documentation for the `Permission.bluetooth` permission regarding the limitations of the permission on iOS.

--- a/permission_handler_platform_interface/lib/src/permission_status.dart
+++ b/permission_handler_platform_interface/lib/src/permission_status.dart
@@ -24,7 +24,9 @@ enum PermissionStatus {
   /// still change the permission status in the settings.
   permanentlyDenied,
 
-  /// The application is provisionally authorized to post noninterruptive user notifications.
+  /// The application is provisionally authorized to post noninterruptive user
+  /// notifications.
+  ///
   /// *Only supported on iOS (iOS12+).*
   provisional,
 }
@@ -80,9 +82,10 @@ extension PermissionStatusGetters on PermissionStatus {
   bool get isRestricted => this == PermissionStatus.restricted;
 
   /// *On Android:*
-  /// If the user denied access to the requested feature and selected to never
-  /// again show a request for this permission (pre API 30) or the user denied
-  /// permissions for a second time (API 30 and higher).
+  /// Android 11+ (API 30+): whether the user denied the permission for a second
+  /// time.
+  /// Below Android 11 (API 30): whether the user denied access to the requested
+  /// feature and selected to never again show a request.
   /// The user may still change the permission status in the settings.
   ///
   /// *On iOS:*
@@ -96,7 +99,8 @@ extension PermissionStatusGetters on PermissionStatus {
   /// Indicates that permission for limited use of the resource is granted.
   bool get isLimited => this == PermissionStatus.limited;
 
-  /// If the application is provisionally authorized to post noninterruptive user notifications.
+  /// If the application is provisionally authorized to post noninterruptive
+  /// user notifications.
   bool get isProvisional => this == PermissionStatus.provisional;
 }
 
@@ -111,13 +115,15 @@ extension FuturePermissionStatusGetters on Future<PermissionStatus> {
   /// If the OS denied access to the requested feature. The user cannot change
   /// this app's status, possibly due to active restrictions such as parental
   /// controls being in place.
+  ///
   /// *Only supported on iOS.*
   Future<bool> get isRestricted async => (await this).isRestricted;
 
   /// *On Android:*
-  /// If the user denied access to the requested feature and selected to never
-  /// again show a request for this permission (pre API 30) or the user denied
-  /// permissions for a second time (API 30 and higher).
+  /// Android 11+ (API 30+): whether the user denied the permission for a second
+  /// time.
+  /// Below Android 11 (API 30): whether the user denied access to the requested
+  /// feature and selected to never again show a request.
   /// The user may still change the permission status in the settings.
   ///
   /// *On iOS:*
@@ -129,7 +135,9 @@ extension FuturePermissionStatusGetters on Future<PermissionStatus> {
   /// Indicates that permission for limited use of the resource is granted.
   Future<bool> get isLimited async => (await this).isLimited;
 
-  /// If the application is provisionally authorized to post noninterruptive user notifications.
+  /// If the application is provisionally authorized to post noninterruptive
+  /// user notifications.
+  ///
   /// *Only supported on iOS.*
   Future<bool> get isProvisional async => (await this).isProvisional;
 }

--- a/permission_handler_platform_interface/lib/src/permissions.dart
+++ b/permission_handler_platform_interface/lib/src/permissions.dart
@@ -56,15 +56,16 @@ class Permission {
   /// different:
   ///
   /// **Android:**
-  /// - When running on Android Q and above: Background Location Permission
+  /// - When running on Android Q and above: Background Location Permission.
+  /// <br>**Please note**: To request this permission, the user needs to grant foreground
+  /// location permissions first. You can do this by using either
+  /// [Permission.location] or [Permission.locationWhenInUse]. Then, requesting
+  /// [Permission.locationAlways] will show an additional dialog or open the
+  /// location permission app settings, allowing the user to change the location
+  /// access to 'allow all the time'.
   /// - When running on Android < Q: Fine and Coarse Location
   ///
   /// **iOS:** CoreLocation - Always
-  /// - When requesting this permission, the user needs to grant permission for
-  /// the `locationWhenInUse` permission first, clicking on the
-  /// `Allow While Using App` option on the popup. After allowing the
-  /// permission, the user can request the `locationAlways` permission and can
-  /// click on the `Change To Always Allow` option.
   static const locationAlways = PermissionWithService._(4);
 
   /// Permission for accessing the device's location when the app is running in

--- a/permission_handler_platform_interface/lib/src/permissions.dart
+++ b/permission_handler_platform_interface/lib/src/permissions.dart
@@ -56,14 +56,15 @@ class Permission {
   /// different:
   ///
   /// **Android:**
-  /// - When running on Android Q and above: Background Location Permission.
-  /// <br>**Please note**: To request this permission, the user needs to grant foreground
-  /// location permissions first. You can do this by using either
+  /// - When running on Android 10 (API 29) and above: Background Location
+  /// Permission.
+  /// <p>**Please note**: To request this permission, the user needs to grant
+  /// foreground location permissions first. You can do this by using either
   /// [Permission.location] or [Permission.locationWhenInUse]. Then, requesting
   /// [Permission.locationAlways] will show an additional dialog or open the
   /// location permission app settings, allowing the user to change the location
   /// access to 'allow all the time'.
-  /// - When running on Android < Q: Fine and Coarse Location
+  /// - When running below Android 10 (API 29): Fine and Coarse Location
   ///
   /// **iOS:** CoreLocation - Always
   static const locationAlways = PermissionWithService._(4);
@@ -93,9 +94,9 @@ class Permission {
   /// different:
   ///
   /// **Android:**
-  /// - When running on Android TIRAMISU and above: Read image files from
+  /// - When running on Android 13 (API 33) and above: Read image files from
   /// external storage
-  /// - When running on Android < TIRAMISU: Nothing
+  /// - When running below Android 13 (API 33): Nothing
   ///
   /// **iOS:**
   /// - When running Photos (iOS 14+ read & write access level)
@@ -138,12 +139,12 @@ class Permission {
   /// different:
   ///
   /// **Android:**
-  /// - On Android TIRAMISU and higher this permission is deprecated and always
-  /// returns `PermissionStatus.denied`, instead use `Permission.photos`,
+  /// - On Android 13 (API 33) and above, this permission is deprecated and
+  /// always returns `PermissionStatus.denied`. Instead use `Permission.photos`,
   /// `Permission.video`, `Permission.audio` or
   /// `Permission.manageExternalStorage`. For more information see our
   /// [FAQ](https://pub.dev/packages/permission_handler#faq).
-  /// - On Android < TIRAMISU the `READ_EXTERNAL_STORAGE` and
+  /// - Below Android 13 (API 33), the `READ_EXTERNAL_STORAGE` and
   /// `WRITE_EXTERNAL_STORAGE` permissions are requested (depending on the
   /// definitions in the AndroidManifest.xml) file.
   ///
@@ -157,13 +158,17 @@ class Permission {
   /// Permission for pushing notifications.
   static const notification = Permission._(17);
 
-  /// Permission for accessing the device's media library (Android Q+ only).
+  /// Permission for accessing the device's media library.
+  ///
+  /// Android 10+ (API 29+)
   ///
   /// Allows an application to access any geographic locations persisted in the
   /// user's shared collection.
   static const accessMediaLocation = Permission._(18);
 
-  /// Permission for accessing the activity recognition (Android Q+ only).
+  /// Permission for accessing the activity recognition.
+  ///
+  /// Android 10+ (API 29+)
   static const activityRecognition = Permission._(19);
 
   /// The unknown only used for return type, never requested.
@@ -193,7 +198,9 @@ class Permission {
   /// the user for Bluetooth permission if the permission was not yet requested.
   static const bluetooth = PermissionWithService._(21);
 
-  /// Permission for accessing the device's external storage. (Android R+ only).
+  /// Permission for accessing the device's external storage.
+  ///
+  /// Android 11+ (API 30+)
   ///
   /// Allows an application a broad access to external storage in scoped
   /// storage.
@@ -219,7 +226,9 @@ class Permission {
   /// Allows an app to create windows shown on top of all other apps.
   static const systemAlertWindow = Permission._(23);
 
-  /// Permission for requesting installing packages (Android M+ only).
+  /// Permission for requesting installing packages.
+  ///
+  /// Android Marshmallow+ (API 23+)
   static const requestInstallPackages = Permission._(24);
 
   /// Permission for accessing the device's tracking state (iOS only).
@@ -234,39 +243,57 @@ class Permission {
   /// Allow for sending notifications that override the ringer.
   static const criticalAlerts = Permission._(26);
 
-  /// Permission for accessing the device's notification policy (Android M+ only).
+  /// Permission for accessing the device's notification policy.
+  ///
+  /// Android Marshmallow+ (API 23+)
   ///
   /// Allows the user to access the notification policy of the phone.
   /// EX: Allows app to turn on and off do-not-disturb.
   static const accessNotificationPolicy = Permission._(27);
 
-  /// Permission for scanning for Bluetooth devices (Android S+ only).
+  /// Permission for scanning for Bluetooth devices.
+  ///
+  /// Android 12+ (API 31+)
   static const bluetoothScan = Permission._(28);
 
-  /// Permission for advertising Bluetooth devices (Android S+ only).
+  /// Permission for advertising Bluetooth devices
+  ///
+  /// Android 12+ (API 31+)
   ///
   /// Allows the user to make this device discoverable to other Bluetooth
   /// devices.
   static const bluetoothAdvertise = Permission._(29);
 
-  /// Permission for connecting to Bluetooth devices (Android S+ only).
+  /// Permission for connecting to Bluetooth devices.
+  ///
+  /// Android 12+ (API 31+)
   ///
   /// Allows the user to connect with already paired Bluetooth devices.
   static const bluetoothConnect = Permission._(30);
 
-  /// Permission for connecting to nearby devices via Wi-Fi (Android T+ only).
+  /// Permission for connecting to nearby devices via Wi-Fi.
+  ///
+  /// Android 13+ (API 33+)
   static const nearbyWifiDevices = Permission._(31);
 
-  /// Permission for accessing the device's video files from external storage (Android T+ only).
+  /// Permission for accessing the device's video files from external storage.
+  ///
+  /// Android 13+ (API 33+)
   static const videos = Permission._(32);
 
-  /// Permission for accessing the device's audio files from external storage (Android T+ only).
+  /// Permission for accessing the device's audio files from external storage.
+  ///
+  /// Android 13+ (API 33+)
   static const audio = Permission._(33);
 
-  /// Permission for scheduling exact alarms (Android S+ only).
+  /// Permission for scheduling exact alarms.
+  ///
+  /// Android 12+ (API 31+)
   static const scheduleExactAlarm = Permission._(34);
 
-  /// Permission for accessing the device's sensors in background (Android T+ only).
+  /// Permission for accessing the device's sensors in background.
+  ///
+  /// Android 13+ (API 33+)
   static const sensorsAlways = Permission._(35);
 
   /// Returns a list of all possible [PermissionGroup] values.

--- a/permission_handler_platform_interface/pubspec.yaml
+++ b/permission_handler_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the permission_handler plugin.
 homepage: https://github.com/baseflow/flutter-permission-handler/tree/master/permission_handler_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 3.11.3
+version: 3.11.4
 
 dependencies:
   flutter:

--- a/permission_handler_platform_interface/pubspec.yaml
+++ b/permission_handler_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the permission_handler plugin.
 homepage: https://github.com/baseflow/flutter-permission-handler/tree/master/permission_handler_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 3.11.4
+version: 3.11.5
 
 dependencies:
   flutter:


### PR DESCRIPTION
# Context
Android distinguishes between [runtime permissions](https://developer.android.com/guide/topics/permissions/overview#runtime) and [special permissions](https://developer.android.com/guide/topics/permissions/overview#special). Runtime permissions give an app additional access to restricted data or let the app perform restricted actions that more substantially affect the system and other apps. These permissions present the user with a dialog where they can choose to grant or deny the permission. Special permissions guard access to system resources that are particularly sensitive or not directly related to user privacy. These permissions are requested by sending an `Intent` to the OS. The OS will open a special settings page where the user can grant the permission. Runtime permission request results will be reported through `onRequestPermissionsResult(int, String[], int[])`, while special permissions request results will be reported through `onActivityResult(int, int, Intent)`.

# Problem statement
Currently, the code submits all permission request results for runtime permissions at the same time, and the results of special permissions separately. This is a mistake, as we can only return the results to Dart once. Instead, we should keep track of the number of pending requests and only return the results once all of them are in. This PR implements exactly that.

Closes #539, #761, #1126

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [ ] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
