### PR TITLE
Reply already submitted in Android 13 while user request permissions

### DIFF
--- a/permission_handler_android/CHANGELOG.md
+++ b/permission_handler_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 11.0.1
+
+* Fixes `java.lang.IllegalStateException: Reply already submitted` when requesting post notification permission.
+
 ## 11.0.0
 
 * **BREAKING CHANGE:** Fixes a bug where the permission status would return 'denied' regardless of whether the status was 'denied' or 'permanently denied'.

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
@@ -162,7 +162,7 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
         }
 
         if (permissions.length == 0 && grantResults.length == 0) {
-            Log.w(PermissionConstants.LOG_TAG, "onRequestPermissionsResult is called without results");
+            Log.w(PermissionConstants.LOG_TAG, "onRequestPermissionsResult is called without results. This is probably caused by interfering request codes. If you see this error, please file an issue in flutter-permission-handler, including a list of plugins used by this application: https://github.com/Baseflow/flutter-permission-handler/issues");
             return false;
         }
 

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
@@ -161,6 +161,11 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
             return false;
         }
 
+        if (permissions.length == 0 && grantResults.length == 0) {
+            Log.w(PermissionConstants.LOG_TAG, "onRequestPermissionsResult is called without results");
+            return false;
+        }
+
         for (int i = 0; i < permissions.length; i++) {
             final String permissionName = permissions[i];
 

--- a/permission_handler_android/pubspec.yaml
+++ b/permission_handler_android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: permission_handler_android
 description: Permission plugin for Flutter. This plugin provides the Android API to request and check permissions.
 homepage: https://github.com/baseflow/flutter-permission-handler
-version: 11.0.0
+version: 11.0.1
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
Reply already submitted in Android 13 while user request permissions (eg. post_notification, locations)

*List at least one fixed issue.*
Fatal Exception: java.lang.RuntimeException
Failure delivering result ResultInfo{who=@android:requestPermissions:, request=24, result=-1, data=Intent { act=android.content.pm.action.REQUEST_PERMISSIONS (has extras) }} to activity: java.lang.IllegalStateException: Reply already submitted

io.flutter.embedding.engine.dart.DartMessenger$Reply.reply (DartMessenger.java:435)
io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler$1.success (MethodChannel.java:263)
com.baseflow.permissionhandler.g.a (Unknown Source:2)
com.baseflow.permissionhandler.n.onRequestPermissionsResult (PermissionManager.java:173)
io.flutter.embedding.engine.FlutterEngineConnectionRegistry$FlutterEngineActivityPluginBinding.onRequestPermissionsResult (FlutterEngineConnectionRegistry.java:779)
io.flutter.embedding.engine.FlutterEngineConnectionRegistry.onRequestPermissionsResult (FlutterEngineConnectionRegistry.java:411)
io.flutter.embedding.android.FlutterActivityAndFragmentDelegate.onRequestPermissionsResult (FlutterActivityAndFragmentDelegate.java:761)
io.flutter.embedding.android.FlutterActivity.onRequestPermissionsResult (FlutterActivity.java:795)

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [ ] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [ ] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
