### PR TITLE
Fix Unhandled Exception: type 'int' is not a subtype of type 'FutureO…

### DIFF
--- a/permission_handler_platform_interface/lib/src/method_channel/method_channel_permission_handler.dart
+++ b/permission_handler_platform_interface/lib/src/method_channel/method_channel_permission_handler.dart
@@ -90,7 +90,10 @@ class MethodChannelPermissionHandler extends PermissionHandlerPlatform {
       Permission permission) async {
     final shouldShowRationale = await _methodChannel.invokeMethod(
         'shouldShowRequestPermissionRationale', permission.value);
-
+    // calling this on ios will return an int value 0, this will cause type cast error
+    if (shouldShowRationale is int){
+      return shouldShowRationale > 0;
+    }
     return shouldShowRationale ?? false;
   }
 }


### PR DESCRIPTION


*Exception throw while calling shouldShowRequestPermissionRationale in ios*

*List at least one fixed issue.*
dart Unhandled Exception: type 'int' is not a subtype of type 'FutureOr<bool>'

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [ ] I made sure all existing and new tests are passing.
- [ ] I ran `dart format .` and committed any changes.
- [ ] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
