### PR TITLE
fix/1158: Return permanentlyDenied for Permission.notification.status

### DIFF
--- a/permission_handler_android/CHANGELOG.md
+++ b/permission_handler_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 11.0.3
+
+* Fixes a bug where `Permission.notification.status` would never return `permanentlyDenied` on Android.
+
 ## 11.0.2
 
 * Fixes a bug where `Permission.Phone` would always return 'denied' when requesting the permission status.

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
@@ -609,7 +609,7 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
         if (status == PackageManager.PERMISSION_GRANTED) {
             return PermissionConstants.PERMISSION_STATUS_GRANTED;
         }
-        return PermissionConstants.PERMISSION_STATUS_DENIED;
+        return PermissionUtils.determineDeniedVariant(activity, Manifest.permission.POST_NOTIFICATIONS);
     }
 
     @PermissionConstants.PermissionStatus

--- a/permission_handler_android/pubspec.yaml
+++ b/permission_handler_android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: permission_handler_android
 description: Permission plugin for Flutter. This plugin provides the Android API to request and check permissions.
 homepage: https://github.com/baseflow/flutter-permission-handler
-version: 11.0.2
+version: 11.0.3
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
Fixes #1158.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
