### PR TITLE
Refactor Permission Handling for Improved Readability

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 11.0.1
 
-* Refactor Permission Handling for Improved Readability
+* Adds extension methods to the `PermissionStatus` enum allowing developers to register callback methods, which will improve code readability.
 
 ## 11.0.0
 

--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 11.0.1
+
+* Refactor Permission Handling for Improved Readability
+
 ## 11.0.0
 
 * **BREAKING CHANGE:** Updates `permission_handler_android` dependency to version 11.0.0.

--- a/permission_handler/lib/permission_handler.dart
+++ b/permission_handler/lib/permission_handler.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:permission_handler_platform_interface/permission_handler_platform_interface.dart';
 
@@ -87,61 +89,61 @@ extension PermissionCheckShortcuts on Permission {
 /// Define an extension named PermissionCallbacks for adding callback handlers to Permission objects.
 extension PermissionCallbacks on Permission {
   /// Callback for when permission is denied.
-  static late VoidCallback? onDenied;
+  static FutureOr<void>? Function()? onDenied;
 
   /// Callback for when permission is granted.
-  static late VoidCallback? onGranted;
+  static FutureOr<void>? Function()? onGranted;
 
   /// Callback for when permission is permanently denied.
-  static late VoidCallback? onPermanentlyDenied;
+  static FutureOr<void>? Function()? onPermanentlyDenied;
 
-  /// Callback for when permission is permanently restricted.
-  static late VoidCallback? onRestricted;
+  /// Callback for when permission is restricted.
+  static FutureOr<void>? Function()? onRestricted;
 
   /// Callback for when permission is limited.
-  static late VoidCallback? onLimited;
+  static FutureOr<void>? Function()? onLimited;
 
   /// Callback for when permission is Provisional.
-  static late VoidCallback? onProvisional;
+  static FutureOr<void>? Function()? onProvisional;
 
   /// Method to set a callback for when permission is denied.
-  Permission onDeniedCallback(VoidCallback? callback) {
+  Permission onDeniedCallback(FutureOr<void>? Function()? callback) {
     onDenied = callback;
     return this;
   }
 
   /// Method to set a callback for when permission is granted.
-  Permission onGrantedCallback(VoidCallback? callback) {
+  Permission onGrantedCallback(FutureOr<void>? Function()? callback) {
     onGranted = callback;
     return this;
   }
 
   /// Method to set a callback for when permission is permanently denied.
-  Permission onPermanentlyDeniedCallback(VoidCallback? callback) {
+  Permission onPermanentlyDeniedCallback(FutureOr<void>? Function()? callback) {
     onPermanentlyDenied = callback;
     return this;
   }
 
   /// Method to set a callback for when permission is restricted.
-  Permission onRestrictedCallback(VoidCallback? callback) {
+  Permission onRestrictedCallback(FutureOr<void>? Function()? callback) {
     onRestricted = callback;
     return this;
   }
 
   /// Method to set a callback for when permission is limited.
-  Permission onLimitedCallback(VoidCallback? callback) {
+  Permission onLimitedCallback(FutureOr<void>? Function()? callback) {
     onLimited = callback;
     return this;
   }
 
   /// Method to set a callback for when permission is provisional.
-  Permission onProvisionalCallback(VoidCallback? callback) {
+  Permission onProvisionalCallback(FutureOr<void>? Function()? callback) {
     onProvisional = callback;
     return this;
   }
 
   /// Request the user for access to this [Permission], if access hasn't already
-  /// been grant access before.
+  /// been granted before.
   ///
   /// Returns the new [PermissionStatus].
   Future<PermissionStatus> ask() async {

--- a/permission_handler/lib/permission_handler.dart
+++ b/permission_handler/lib/permission_handler.dart
@@ -21,36 +21,6 @@ PermissionHandlerPlatform get _handler => PermissionHandlerPlatform.instance;
 /// Returns [true] if the app settings page could be opened, otherwise [false].
 Future<bool> openAppSettings() => _handler.openAppSettings();
 
-/// Shortcuts for checking the [status] of a [Permission].
-extension PermissionCheckShortcuts on Permission {
-  /// If the user granted this permission.
-  Future<bool> get isGranted => status.isGranted;
-
-  /// If the user denied this permission.
-  Future<bool> get isDenied => status.isDenied;
-
-  /// If the OS denied this permission. The user cannot change the status,
-  /// possibly due to active restrictions such as parental controls being in
-  /// place.
-  /// *Only supported on iOS.*
-  Future<bool> get isRestricted => status.isRestricted;
-
-  /// User has authorized this application for limited photo library access.
-  /// *Only supported on iOS.(iOS14+)*
-  Future<bool> get isLimited => status.isLimited;
-
-  /// Returns `true` when permissions are denied permanently.
-  ///
-  /// When permissions are denied permanently, no new permission dialog will
-  /// be showed to the user. Consuming Apps should redirect the user to the
-  /// App settings to change permissions.
-  Future<bool> get isPermanentlyDenied => status.isPermanentlyDenied;
-
-  /// If the application is provisionally authorized to post noninterruptive user notifications.
-  /// *Only supported on iOS.*
-  Future<bool> get isProvisional => status.isProvisional;
-}
-
 /// Actions that can be executed on a permission.
 extension PermissionActions on Permission {
   /// Callback for when permission is denied.
@@ -154,6 +124,36 @@ extension PermissionActions on Permission {
 
     return permissionStatus;
   }
+}
+
+/// Shortcuts for checking the [status] of a [Permission].
+extension PermissionCheckShortcuts on Permission {
+  /// If the user granted this permission.
+  Future<bool> get isGranted => status.isGranted;
+
+  /// If the user denied this permission.
+  Future<bool> get isDenied => status.isDenied;
+
+  /// If the OS denied this permission. The user cannot change the status,
+  /// possibly due to active restrictions such as parental controls being in
+  /// place.
+  /// *Only supported on iOS.*
+  Future<bool> get isRestricted => status.isRestricted;
+
+  /// User has authorized this application for limited photo library access.
+  /// *Only supported on iOS.(iOS14+)*
+  Future<bool> get isLimited => status.isLimited;
+
+  /// Returns `true` when permissions are denied permanently.
+  ///
+  /// When permissions are denied permanently, no new permission dialog will
+  /// be showed to the user. Consuming Apps should redirect the user to the
+  /// App settings to change permissions.
+  Future<bool> get isPermanentlyDenied => status.isPermanentlyDenied;
+
+  /// If the application is provisionally authorized to post noninterruptive user notifications.
+  /// *Only supported on iOS.*
+  Future<bool> get isProvisional => status.isProvisional;
 }
 
 /// Actions that apply only to permissions that have an associated service.

--- a/permission_handler/lib/permission_handler.dart
+++ b/permission_handler/lib/permission_handler.dart
@@ -84,6 +84,83 @@ extension PermissionCheckShortcuts on Permission {
   Future<bool> get isProvisional => status.isProvisional;
 }
 
+/// Define an extension named PermissionCallbacks for adding callback handlers to Permission objects.
+extension PermissionCallbacks on Permission {
+  /// Callback for when permission is denied.
+  static late VoidCallback? onDenied;
+
+  /// Callback for when permission is granted.
+  static late VoidCallback? onGranted;
+
+  /// Callback for when permission is permanently denied.
+  static late VoidCallback? onPermanentlyDenied;
+
+  /// Callback for when permission is permanently restricted.
+  static late VoidCallback? onRestricted;
+
+  /// Callback for when permission is limited.
+  static late VoidCallback? onLimited;
+
+  /// Callback for when permission is Provisional.
+  static late VoidCallback? onProvisional;
+
+  /// Method to set a callback for when permission is denied.
+  Permission onDeniedCallback(VoidCallback? callback) {
+    onDenied = callback;
+    return this;
+  }
+
+  /// Method to set a callback for when permission is granted.
+  Permission onGrantedCallback(VoidCallback? callback) {
+    onGranted = callback;
+    return this;
+  }
+
+  /// Method to set a callback for when permission is permanently denied.
+  Permission onPermanentlyDeniedCallback(VoidCallback? callback) {
+    onPermanentlyDenied = callback;
+    return this;
+  }
+
+  /// Method to set a callback for when permission is restricted.
+  Permission onRestrictedCallback(VoidCallback? callback) {
+    onRestricted = callback;
+    return this;
+  }
+
+  /// Method to set a callback for when permission is limited.
+  Permission onLimitedCallback(VoidCallback? callback) {
+    onLimited = callback;
+    return this;
+  }
+
+  /// Method to set a callback for when permission is provisional.
+  Permission onProvisionalCallback(VoidCallback? callback) {
+    onProvisional = callback;
+    return this;
+  }
+
+  Future<PermissionStatus> ask() async {
+    final permissionStatus = await request();
+
+    if (permissionStatus.isDenied) {
+      onDenied?.call();
+    } else if (permissionStatus.isGranted) {
+      onGranted?.call();
+    } else if (permissionStatus.isPermanentlyDenied) {
+      onPermanentlyDenied?.call();
+    } else if (permissionStatus.isRestricted) {
+      onRestricted?.call();
+    } else if (permissionStatus.isLimited) {
+      onLimited?.call();
+    } else if (permissionStatus.isProvisional) {
+      onProvisional?.call();
+    }
+
+    return permissionStatus;
+  }
+}
+
 /// Actions that apply only to permissions that have an associated service.
 extension ServicePermissionActions on PermissionWithService {
   /// Checks the current status of the service associated with the given

--- a/permission_handler/lib/permission_handler.dart
+++ b/permission_handler/lib/permission_handler.dart
@@ -140,6 +140,10 @@ extension PermissionCallbacks on Permission {
     return this;
   }
 
+  /// Request the user for access to this [Permission], if access hasn't already
+  /// been grant access before.
+  ///
+  /// Returns the new [PermissionStatus].
   Future<PermissionStatus> ask() async {
     final permissionStatus = await request();
 

--- a/permission_handler/lib/permission_handler.dart
+++ b/permission_handler/lib/permission_handler.dart
@@ -24,56 +24,56 @@ Future<bool> openAppSettings() => _handler.openAppSettings();
 /// Actions that can be executed on a permission.
 extension PermissionActions on Permission {
   /// Callback for when permission is denied.
-  static FutureOr<void>? Function()? onDenied;
+  static FutureOr<void>? Function()? _onDenied;
 
   /// Callback for when permission is granted.
-  static FutureOr<void>? Function()? onGranted;
+  static FutureOr<void>? Function()? _onGranted;
 
   /// Callback for when permission is permanently denied.
-  static FutureOr<void>? Function()? onPermanentlyDenied;
+  static FutureOr<void>? Function()? _onPermanentlyDenied;
 
   /// Callback for when permission is restricted.
-  static FutureOr<void>? Function()? onRestricted;
+  static FutureOr<void>? Function()? _onRestricted;
 
   /// Callback for when permission is limited.
-  static FutureOr<void>? Function()? onLimited;
+  static FutureOr<void>? Function()? _onLimited;
 
   /// Callback for when permission is Provisional.
-  static FutureOr<void>? Function()? onProvisional;
+  static FutureOr<void>? Function()? _onProvisional;
 
   /// Method to set a callback for when permission is denied.
   Permission onDeniedCallback(FutureOr<void>? Function()? callback) {
-    onDenied = callback;
+    _onDenied = callback;
     return this;
   }
 
   /// Method to set a callback for when permission is granted.
   Permission onGrantedCallback(FutureOr<void>? Function()? callback) {
-    onGranted = callback;
+    _onGranted = callback;
     return this;
   }
 
   /// Method to set a callback for when permission is permanently denied.
   Permission onPermanentlyDeniedCallback(FutureOr<void>? Function()? callback) {
-    onPermanentlyDenied = callback;
+    _onPermanentlyDenied = callback;
     return this;
   }
 
   /// Method to set a callback for when permission is restricted.
   Permission onRestrictedCallback(FutureOr<void>? Function()? callback) {
-    onRestricted = callback;
+    _onRestricted = callback;
     return this;
   }
 
   /// Method to set a callback for when permission is limited.
   Permission onLimitedCallback(FutureOr<void>? Function()? callback) {
-    onLimited = callback;
+    _onLimited = callback;
     return this;
   }
 
   /// Method to set a callback for when permission is provisional.
   Permission onProvisionalCallback(FutureOr<void>? Function()? callback) {
-    onProvisional = callback;
+    _onProvisional = callback;
     return this;
   }
 
@@ -109,17 +109,17 @@ extension PermissionActions on Permission {
         (await [this].request())[this] ?? PermissionStatus.denied;
 
     if (permissionStatus.isDenied) {
-      onDenied?.call();
+      _onDenied?.call();
     } else if (permissionStatus.isGranted) {
-      onGranted?.call();
+      _onGranted?.call();
     } else if (permissionStatus.isPermanentlyDenied) {
-      onPermanentlyDenied?.call();
+      _onPermanentlyDenied?.call();
     } else if (permissionStatus.isRestricted) {
-      onRestricted?.call();
+      _onRestricted?.call();
     } else if (permissionStatus.isLimited) {
-      onLimited?.call();
+      _onLimited?.call();
     } else if (permissionStatus.isProvisional) {
-      onProvisional?.call();
+      _onProvisional?.call();
     }
 
     return permissionStatus;

--- a/permission_handler/lib/permission_handler.dart
+++ b/permission_handler/lib/permission_handler.dart
@@ -21,41 +21,6 @@ PermissionHandlerPlatform get _handler => PermissionHandlerPlatform.instance;
 /// Returns [true] if the app settings page could be opened, otherwise [false].
 Future<bool> openAppSettings() => _handler.openAppSettings();
 
-/// Actions that can be executed on a permission.
-extension PermissionActions on Permission {
-  /// Checks the current status of the given [Permission].
-  ///
-  /// Notes about specific permissions:
-  /// - **[Permission.bluetooth]**
-  ///   - iOS 13.0 only:
-  ///     - The method will **always** return [PermissionStatus.denied],
-  ///       regardless of the actual status. For the actual permission state,
-  ///       use [Permission.bluetooth.request]. Note that this will show a
-  ///       permission dialog if the permission was not yet requested.
-  Future<PermissionStatus> get status => _handler.checkPermissionStatus(this);
-
-  /// If you should show a rationale for requesting permission.
-  ///
-  /// This is only implemented on Android, calling this on iOS always returns
-  /// [false].
-  Future<bool> get shouldShowRequestRationale async {
-    if (defaultTargetPlatform != TargetPlatform.android) {
-      return false;
-    }
-
-    return _handler.shouldShowRequestPermissionRationale(this);
-  }
-
-  /// Request the user for access to this [Permission], if access hasn't already
-  /// been grant access before.
-  ///
-  /// Returns the new [PermissionStatus].
-  Future<PermissionStatus> request() async {
-    final permissionStatus = (await [this].request())[this];
-    return permissionStatus ?? PermissionStatus.denied;
-  }
-}
-
 /// Shortcuts for checking the [status] of a [Permission].
 extension PermissionCheckShortcuts on Permission {
   /// If the user granted this permission.
@@ -86,8 +51,8 @@ extension PermissionCheckShortcuts on Permission {
   Future<bool> get isProvisional => status.isProvisional;
 }
 
-/// Define an extension named PermissionCallbacks for adding callback handlers to Permission objects.
-extension PermissionCallbacks on Permission {
+/// Actions that can be executed on a permission.
+extension PermissionActions on Permission {
   /// Callback for when permission is denied.
   static FutureOr<void>? Function()? onDenied;
 
@@ -142,12 +107,36 @@ extension PermissionCallbacks on Permission {
     return this;
   }
 
+  /// Checks the current status of the given [Permission].
+  ///
+  /// Notes about specific permissions:
+  /// - **[Permission.bluetooth]**
+  ///   - iOS 13.0 only:
+  ///     - The method will **always** return [PermissionStatus.denied],
+  ///       regardless of the actual status. For the actual permission state,
+  ///       use [Permission.bluetooth.request]. Note that this will show a
+  ///       permission dialog if the permission was not yet requested.
+  Future<PermissionStatus> get status => _handler.checkPermissionStatus(this);
+
+  /// If you should show a rationale for requesting permission.
+  ///
+  /// This is only implemented on Android, calling this on iOS always returns
+  /// [false].
+  Future<bool> get shouldShowRequestRationale async {
+    if (defaultTargetPlatform != TargetPlatform.android) {
+      return false;
+    }
+
+    return _handler.shouldShowRequestPermissionRationale(this);
+  }
+
   /// Request the user for access to this [Permission], if access hasn't already
-  /// been granted before.
+  /// been grant access before.
   ///
   /// Returns the new [PermissionStatus].
-  Future<PermissionStatus> ask() async {
-    final permissionStatus = await request();
+  Future<PermissionStatus> request() async {
+    final permissionStatus =
+        (await [this].request())[this] ?? PermissionStatus.denied;
 
     if (permissionStatus.isDenied) {
       onDenied?.call();

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -2,7 +2,7 @@ name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
 repository: https://github.com/baseflow/flutter-permission-handler
 issue_tracker: https://github.com/Baseflow/flutter-permission-handler/issues
-version: 11.0.0
+version: 11.0.1
 
 environment:
   sdk: ">=2.15.0 <4.0.0"

--- a/permission_handler/test/permission_handler_test.dart
+++ b/permission_handler/test/permission_handler_test.dart
@@ -9,6 +9,7 @@ void main() {
     setUp(() {
       PermissionHandlerPlatform.instance = MockPermissionHandlerPlatform();
     });
+
     test('openAppSettings', () async {
       final hasOpened = await openAppSettings();
 
@@ -94,61 +95,69 @@ void main() {
       expect(permissionMap, isA<Map<Permission, PermissionStatus>>());
     });
 
-    test('onDeniedCallback sets onDenied', () {
-      callback() => true;
-      const permission = Permission.camera;
-      permission.onDeniedCallback(callback);
-      expect(PermissionActions.onDenied, callback);
+    test('onDeniedCallback sets onDenied', () async {
+      bool callbackCalled = false;
+      callback() => callbackCalled = true;
+      await Permission.location.onDeniedCallback(callback).request();
+      expect(callbackCalled, isTrue);
     });
 
-    test('onGrantedCallback sets onGranted', () {
-      callback() => true;
-      const permission = Permission.camera;
-      permission.onGrantedCallback(callback);
-      expect(PermissionActions.onGranted, callback);
+    test('onGrantedCallback sets onGranted', () async {
+      bool callbackCalled = false;
+      callback() => callbackCalled = true;
+      await Permission.location.onGrantedCallback(callback).request();
+      expect(callbackCalled, isFalse);
     });
 
-    test('onPermanentlyDeniedCallback sets onPermanentlyDenied', () {
-      callback() => true;
-      const permission = Permission.camera;
-      permission.onPermanentlyDeniedCallback(callback);
-      expect(PermissionActions.onPermanentlyDenied, callback);
+    test('onPermanentlyDeniedCallback sets onPermanentlyDenied', () async {
+      bool callbackCalled = false;
+      callback() => callbackCalled = true;
+      await Permission.location.onPermanentlyDeniedCallback(callback).request();
+      expect(callbackCalled, isFalse);
     });
 
-    test('onRestrictedCallback sets onRestricted', () {
-      callback() => true;
-      const permission = Permission.camera;
-      permission.onRestrictedCallback(callback);
-      expect(PermissionActions.onRestricted, callback);
+    test('onRestrictedCallback sets onRestricted', () async {
+      bool callbackCalled = false;
+      callback() => callbackCalled = true;
+      await Permission.location.onRestrictedCallback(callback).request();
+      expect(callbackCalled, isFalse);
     });
 
-    test('onLimitedCallback sets onLimited', () {
-      const permission = Permission.camera;
-      callback() => true;
-      permission.onLimitedCallback(callback);
-      expect(PermissionActions.onLimited, callback);
+    test('onLimitedCallback sets onLimited', () async {
+      bool callbackCalled = false;
+      callback() => callbackCalled = true;
+      await Permission.location.onLimitedCallback(callback).request();
+      expect(callbackCalled, isFalse);
     });
 
-    test('onProvisionalCallback sets onProvisional', () {
-      callback() => true;
-      const permission = Permission.camera;
-      permission.onProvisionalCallback(callback);
-      expect(PermissionActions.onProvisional, callback);
+    test('onProvisionalCallback sets onProvisional', () async {
+      bool callbackCalled = false;
+      callback() => callbackCalled = true;
+      await Permission.location.onProvisionalCallback(callback).request();
+      expect(callbackCalled, isFalse);
+    });
+
+    test('onGrantedCallback sets onGranted', () async {
+      bool callbackCalled = false;
+      callback() => callbackCalled = true;
+      await Permission.location.onGrantedCallback(callback).request();
+      expect(callbackCalled, isFalse);
     });
 
     test('ask calls the appropriate callback', () async {
-      callback() => true;
+      List<String> callbackCalled = [];
 
-      final status = Permission.camera
-          .onDeniedCallback(callback)
-          .onGrantedCallback(callback)
-          .onPermanentlyDeniedCallback(callback)
-          .onRestrictedCallback(callback)
-          .onLimitedCallback(callback)
-          .onProvisionalCallback(callback)
+      await Permission.camera
+          .onDeniedCallback(() => callbackCalled.add('Denied'))
+          .onGrantedCallback(() => callbackCalled.add('Granted'))
+          .onPermanentlyDeniedCallback(
+              () => callbackCalled.add('PermanentlyDenied'))
+          .onRestrictedCallback(() => callbackCalled.add('Restricted'))
+          .onLimitedCallback(() => callbackCalled.add('Limited'))
+          .onProvisionalCallback(() => callbackCalled.add('Provisional'))
           .request();
 
-      expect(status, isA<Future<PermissionStatus>>());
+      expect(callbackCalled, ['Denied']);
     });
   });
 }

--- a/permission_handler/test/permission_handler_test.dart
+++ b/permission_handler/test/permission_handler_test.dart
@@ -95,6 +95,72 @@ void main() {
       expect(permissionMap, isA<Map<Permission, PermissionStatus>>());
     });
   });
+
+  group('PermissionCallbacks', () {
+    setUp(() {
+      PermissionHandlerPlatform.instance = MockPermissionHandlerPlatform();
+    });
+
+    test('onDeniedCallback sets onDenied', () {
+      final permission = Permission.camera;
+      final callback = () => print('Permission denied');
+      permission.onDeniedCallback(callback);
+      expect(PermissionCallbacks.onDenied, equals(callback));
+    });
+
+    test('onGrantedCallback sets onGranted', () {
+      final permission = Permission.camera;
+      final callback = () => print('Permission granted');
+      permission.onGrantedCallback(callback);
+      expect(PermissionCallbacks.onGranted, equals(callback));
+    });
+
+    test('onPermanentlyDeniedCallback sets onPermanentlyDenied', () {
+      final permission = Permission.camera;
+      final callback = () => print('Permission permanently denied');
+      permission.onPermanentlyDeniedCallback(callback);
+      expect(PermissionCallbacks.onPermanentlyDenied, equals(callback));
+    });
+
+    test('onRestrictedCallback sets onRestricted', () {
+      final permission = Permission.camera;
+      final callback = () => print('Permission restricted');
+      permission.onRestrictedCallback(callback);
+      expect(PermissionCallbacks.onRestricted, equals(callback));
+    });
+
+    test('onLimitedCallback sets onLimited', () {
+      final permission = Permission.camera;
+      final callback = () => print('Permission limited');
+      permission.onLimitedCallback(callback);
+      expect(PermissionCallbacks.onLimited, equals(callback));
+    });
+
+    test('onProvisionalCallback sets onProvisional', () {
+      final permission = Permission.camera;
+      final callback = () => print('Permission provisional');
+      permission.onProvisionalCallback(callback);
+      expect(PermissionCallbacks.onProvisional, equals(callback));
+    });
+
+    test('ask calls the appropriate callback', () async {
+      final status = Permission.camera.onDeniedCallback(() {
+        print('Permission denied');
+      }).onGrantedCallback(() {
+        print('Permission granted');
+      }).onPermanentlyDeniedCallback(() {
+        print('Permission permanently denied');
+      }).onRestrictedCallback(() {
+        print('Permission restricted');
+      }).onLimitedCallback(() {
+        print('Permission limited');
+      }).onProvisionalCallback(() {
+        print('Permission provisional');
+      }).ask();
+
+      expect(status, isA<Future<PermissionStatus>>());
+    });
+  });
 }
 
 class MockPermissionHandlerPlatform extends Mock

--- a/permission_handler/test/permission_handler_test.dart
+++ b/permission_handler/test/permission_handler_test.dart
@@ -5,10 +5,10 @@ import 'package:permission_handler_platform_interface/permission_handler_platfor
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 void main() {
-  setUp(() {
-    PermissionHandlerPlatform.instance = MockPermissionHandlerPlatform();
-  });
   group('PermissionHandler', () {
+    setUp(() {
+      PermissionHandlerPlatform.instance = MockPermissionHandlerPlatform();
+    });
     test('openAppSettings', () async {
       final hasOpened = await openAppSettings();
 
@@ -93,63 +93,63 @@ void main() {
 
       expect(permissionMap, isA<Map<Permission, PermissionStatus>>());
     });
-  });
 
-  test('onDeniedCallback sets onDenied', () {
-    callback() => true;
-    const permission = Permission.camera;
-    permission.onDeniedCallback(callback);
-    expect(PermissionActions.onDenied, callback);
-  });
+    test('onDeniedCallback sets onDenied', () {
+      callback() => true;
+      const permission = Permission.camera;
+      permission.onDeniedCallback(callback);
+      expect(PermissionActions.onDenied, callback);
+    });
 
-  test('onGrantedCallback sets onGranted', () {
-    callback() => true;
-    const permission = Permission.camera;
-    permission.onGrantedCallback(callback);
-    expect(PermissionActions.onGranted, callback);
-  });
+    test('onGrantedCallback sets onGranted', () {
+      callback() => true;
+      const permission = Permission.camera;
+      permission.onGrantedCallback(callback);
+      expect(PermissionActions.onGranted, callback);
+    });
 
-  test('onPermanentlyDeniedCallback sets onPermanentlyDenied', () {
-    callback() => true;
-    const permission = Permission.camera;
-    permission.onPermanentlyDeniedCallback(callback);
-    expect(PermissionActions.onPermanentlyDenied, callback);
-  });
+    test('onPermanentlyDeniedCallback sets onPermanentlyDenied', () {
+      callback() => true;
+      const permission = Permission.camera;
+      permission.onPermanentlyDeniedCallback(callback);
+      expect(PermissionActions.onPermanentlyDenied, callback);
+    });
 
-  test('onRestrictedCallback sets onRestricted', () {
-    callback() => true;
-    const permission = Permission.camera;
-    permission.onRestrictedCallback(callback);
-    expect(PermissionActions.onRestricted, callback);
-  });
+    test('onRestrictedCallback sets onRestricted', () {
+      callback() => true;
+      const permission = Permission.camera;
+      permission.onRestrictedCallback(callback);
+      expect(PermissionActions.onRestricted, callback);
+    });
 
-  test('onLimitedCallback sets onLimited', () {
-    const permission = Permission.camera;
-    callback() => true;
-    permission.onLimitedCallback(callback);
-    expect(PermissionActions.onLimited, callback);
-  });
+    test('onLimitedCallback sets onLimited', () {
+      const permission = Permission.camera;
+      callback() => true;
+      permission.onLimitedCallback(callback);
+      expect(PermissionActions.onLimited, callback);
+    });
 
-  test('onProvisionalCallback sets onProvisional', () {
-    callback() => true;
-    const permission = Permission.camera;
-    permission.onProvisionalCallback(callback);
-    expect(PermissionActions.onProvisional, callback);
-  });
+    test('onProvisionalCallback sets onProvisional', () {
+      callback() => true;
+      const permission = Permission.camera;
+      permission.onProvisionalCallback(callback);
+      expect(PermissionActions.onProvisional, callback);
+    });
 
-  test('ask calls the appropriate callback', () async {
-    callback() => true;
+    test('ask calls the appropriate callback', () async {
+      callback() => true;
 
-    final status = Permission.camera
-        .onDeniedCallback(callback)
-        .onGrantedCallback(callback)
-        .onPermanentlyDeniedCallback(callback)
-        .onRestrictedCallback(callback)
-        .onLimitedCallback(callback)
-        .onProvisionalCallback(callback)
-        .request();
+      final status = Permission.camera
+          .onDeniedCallback(callback)
+          .onGrantedCallback(callback)
+          .onPermanentlyDeniedCallback(callback)
+          .onRestrictedCallback(callback)
+          .onLimitedCallback(callback)
+          .onProvisionalCallback(callback)
+          .request();
 
-    expect(status, isA<Future<PermissionStatus>>());
+      expect(status, isA<Future<PermissionStatus>>());
+    });
   });
 }
 

--- a/permission_handler/test/permission_handler_test.dart
+++ b/permission_handler/test/permission_handler_test.dart
@@ -102,60 +102,60 @@ void main() {
     });
 
     test('onDeniedCallback sets onDenied', () {
-      final permission = Permission.camera;
-      final callback = () => print('Permission denied');
+      const permission = Permission.camera;
+      callback() => true;
       permission.onDeniedCallback(callback);
       expect(PermissionCallbacks.onDenied, equals(callback));
     });
 
     test('onGrantedCallback sets onGranted', () {
-      final permission = Permission.camera;
-      final callback = () => print('Permission granted');
+      const permission = Permission.camera;
+      callback() => true;
       permission.onGrantedCallback(callback);
       expect(PermissionCallbacks.onGranted, equals(callback));
     });
 
     test('onPermanentlyDeniedCallback sets onPermanentlyDenied', () {
-      final permission = Permission.camera;
-      final callback = () => print('Permission permanently denied');
+      const permission = Permission.camera;
+      callback() => true;
       permission.onPermanentlyDeniedCallback(callback);
       expect(PermissionCallbacks.onPermanentlyDenied, equals(callback));
     });
 
     test('onRestrictedCallback sets onRestricted', () {
-      final permission = Permission.camera;
-      final callback = () => print('Permission restricted');
+      const permission = Permission.camera;
+      callback() => true;
       permission.onRestrictedCallback(callback);
       expect(PermissionCallbacks.onRestricted, equals(callback));
     });
 
     test('onLimitedCallback sets onLimited', () {
-      final permission = Permission.camera;
-      final callback = () => print('Permission limited');
+      const permission = Permission.camera;
+      callback() => true;
       permission.onLimitedCallback(callback);
       expect(PermissionCallbacks.onLimited, equals(callback));
     });
 
     test('onProvisionalCallback sets onProvisional', () {
-      final permission = Permission.camera;
-      final callback = () => print('Permission provisional');
+      const permission = Permission.camera;
+      callback() => true;
       permission.onProvisionalCallback(callback);
       expect(PermissionCallbacks.onProvisional, equals(callback));
     });
 
     test('ask calls the appropriate callback', () async {
       final status = Permission.camera.onDeniedCallback(() {
-        print('Permission denied');
+        // Your code.
       }).onGrantedCallback(() {
-        print('Permission granted');
+        // Your code.
       }).onPermanentlyDeniedCallback(() {
-        print('Permission permanently denied');
+        // Your code.
       }).onRestrictedCallback(() {
-        print('Permission restricted');
+        // Your code.
       }).onLimitedCallback(() {
-        print('Permission limited');
+        // Your code.
       }).onProvisionalCallback(() {
-        print('Permission provisional');
+        // Your code.
       }).ask();
 
       expect(status, isA<Future<PermissionStatus>>());

--- a/permission_handler/test/permission_handler_test.dart
+++ b/permission_handler/test/permission_handler_test.dart
@@ -5,11 +5,10 @@ import 'package:permission_handler_platform_interface/permission_handler_platfor
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 void main() {
+  setUp(() {
+    PermissionHandlerPlatform.instance = MockPermissionHandlerPlatform();
+  });
   group('PermissionHandler', () {
-    setUp(() {
-      PermissionHandlerPlatform.instance = MockPermissionHandlerPlatform();
-    });
-
     test('openAppSettings', () async {
       final hasOpened = await openAppSettings();
 
@@ -97,66 +96,59 @@ void main() {
   });
 
   group('PermissionCallbacks', () {
-    setUp(() {
-      PermissionHandlerPlatform.instance = MockPermissionHandlerPlatform();
-    });
-
     test('onDeniedCallback sets onDenied', () {
-      const permission = Permission.camera;
       callback() => true;
+      const permission = Permission.camera;
       permission.onDeniedCallback(callback);
-      expect(PermissionCallbacks.onDenied, equals(callback));
+      expect(PermissionCallbacks.onDenied, callback);
     });
 
     test('onGrantedCallback sets onGranted', () {
-      const permission = Permission.camera;
       callback() => true;
+      const permission = Permission.camera;
       permission.onGrantedCallback(callback);
-      expect(PermissionCallbacks.onGranted, equals(callback));
+      expect(PermissionCallbacks.onGranted, callback);
     });
 
     test('onPermanentlyDeniedCallback sets onPermanentlyDenied', () {
-      const permission = Permission.camera;
       callback() => true;
+      const permission = Permission.camera;
       permission.onPermanentlyDeniedCallback(callback);
-      expect(PermissionCallbacks.onPermanentlyDenied, equals(callback));
+      expect(PermissionCallbacks.onPermanentlyDenied, callback);
     });
 
     test('onRestrictedCallback sets onRestricted', () {
-      const permission = Permission.camera;
       callback() => true;
+      const permission = Permission.camera;
       permission.onRestrictedCallback(callback);
-      expect(PermissionCallbacks.onRestricted, equals(callback));
+      expect(PermissionCallbacks.onRestricted, callback);
     });
 
     test('onLimitedCallback sets onLimited', () {
       const permission = Permission.camera;
       callback() => true;
       permission.onLimitedCallback(callback);
-      expect(PermissionCallbacks.onLimited, equals(callback));
+      expect(PermissionCallbacks.onLimited, callback);
     });
 
     test('onProvisionalCallback sets onProvisional', () {
-      const permission = Permission.camera;
       callback() => true;
+      const permission = Permission.camera;
       permission.onProvisionalCallback(callback);
-      expect(PermissionCallbacks.onProvisional, equals(callback));
+      expect(PermissionCallbacks.onProvisional, callback);
     });
 
     test('ask calls the appropriate callback', () async {
-      final status = Permission.camera.onDeniedCallback(() {
-        // Your code.
-      }).onGrantedCallback(() {
-        // Your code.
-      }).onPermanentlyDeniedCallback(() {
-        // Your code.
-      }).onRestrictedCallback(() {
-        // Your code.
-      }).onLimitedCallback(() {
-        // Your code.
-      }).onProvisionalCallback(() {
-        // Your code.
-      }).ask();
+      callback() => true;
+
+      final status = Permission.camera
+          .onDeniedCallback(callback)
+          .onGrantedCallback(callback)
+          .onPermanentlyDeniedCallback(callback)
+          .onRestrictedCallback(callback)
+          .onLimitedCallback(callback)
+          .onProvisionalCallback(callback)
+          .ask();
 
       expect(status, isA<Future<PermissionStatus>>());
     });

--- a/permission_handler/test/permission_handler_test.dart
+++ b/permission_handler/test/permission_handler_test.dart
@@ -95,63 +95,61 @@ void main() {
     });
   });
 
-  group('PermissionCallbacks', () {
-    test('onDeniedCallback sets onDenied', () {
-      callback() => true;
-      const permission = Permission.camera;
-      permission.onDeniedCallback(callback);
-      expect(PermissionCallbacks.onDenied, callback);
-    });
+  test('onDeniedCallback sets onDenied', () {
+    callback() => true;
+    const permission = Permission.camera;
+    permission.onDeniedCallback(callback);
+    expect(PermissionActions.onDenied, callback);
+  });
 
-    test('onGrantedCallback sets onGranted', () {
-      callback() => true;
-      const permission = Permission.camera;
-      permission.onGrantedCallback(callback);
-      expect(PermissionCallbacks.onGranted, callback);
-    });
+  test('onGrantedCallback sets onGranted', () {
+    callback() => true;
+    const permission = Permission.camera;
+    permission.onGrantedCallback(callback);
+    expect(PermissionActions.onGranted, callback);
+  });
 
-    test('onPermanentlyDeniedCallback sets onPermanentlyDenied', () {
-      callback() => true;
-      const permission = Permission.camera;
-      permission.onPermanentlyDeniedCallback(callback);
-      expect(PermissionCallbacks.onPermanentlyDenied, callback);
-    });
+  test('onPermanentlyDeniedCallback sets onPermanentlyDenied', () {
+    callback() => true;
+    const permission = Permission.camera;
+    permission.onPermanentlyDeniedCallback(callback);
+    expect(PermissionActions.onPermanentlyDenied, callback);
+  });
 
-    test('onRestrictedCallback sets onRestricted', () {
-      callback() => true;
-      const permission = Permission.camera;
-      permission.onRestrictedCallback(callback);
-      expect(PermissionCallbacks.onRestricted, callback);
-    });
+  test('onRestrictedCallback sets onRestricted', () {
+    callback() => true;
+    const permission = Permission.camera;
+    permission.onRestrictedCallback(callback);
+    expect(PermissionActions.onRestricted, callback);
+  });
 
-    test('onLimitedCallback sets onLimited', () {
-      const permission = Permission.camera;
-      callback() => true;
-      permission.onLimitedCallback(callback);
-      expect(PermissionCallbacks.onLimited, callback);
-    });
+  test('onLimitedCallback sets onLimited', () {
+    const permission = Permission.camera;
+    callback() => true;
+    permission.onLimitedCallback(callback);
+    expect(PermissionActions.onLimited, callback);
+  });
 
-    test('onProvisionalCallback sets onProvisional', () {
-      callback() => true;
-      const permission = Permission.camera;
-      permission.onProvisionalCallback(callback);
-      expect(PermissionCallbacks.onProvisional, callback);
-    });
+  test('onProvisionalCallback sets onProvisional', () {
+    callback() => true;
+    const permission = Permission.camera;
+    permission.onProvisionalCallback(callback);
+    expect(PermissionActions.onProvisional, callback);
+  });
 
-    test('ask calls the appropriate callback', () async {
-      callback() => true;
+  test('ask calls the appropriate callback', () async {
+    callback() => true;
 
-      final status = Permission.camera
-          .onDeniedCallback(callback)
-          .onGrantedCallback(callback)
-          .onPermanentlyDeniedCallback(callback)
-          .onRestrictedCallback(callback)
-          .onLimitedCallback(callback)
-          .onProvisionalCallback(callback)
-          .ask();
+    final status = Permission.camera
+        .onDeniedCallback(callback)
+        .onGrantedCallback(callback)
+        .onPermanentlyDeniedCallback(callback)
+        .onRestrictedCallback(callback)
+        .onLimitedCallback(callback)
+        .onProvisionalCallback(callback)
+        .request();
 
-      expect(status, isA<Future<PermissionStatus>>());
-    });
+    expect(status, isA<Future<PermissionStatus>>());
   });
 }
 


### PR DESCRIPTION
This PR introduces a new style for checking permission status.

Before:

```dart
Future<bool> askPermission() async {
  PermissionStatus status = await Permission.contacts.request();
  if (status.isDenied) {
    // Your code
  } else if (status.isGranted) {
    // Your code
  } else if (status.isRestricted) {
    // Your code
  }
}
```

After:

```dart
Future<bool> askPermission() async {
  await Permission.contacts
    .onDeniedCallback(() {
      // Your code
    })
    .onGrantedCallback(() {
      // Your code
    })
    .onRestrictedCallback(() {
      // Your code
    })
    .request();
}
```

In this updated code, the permission status checks have been replaced with a more concise style that leverages the `PermissionCallbacks` extension. This change simplifies the code and makes it more readable.

## Pre-launch Checklist

- [X] I made sure the project builds.
- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I rebased onto `main`.
- [X] I added new tests to check the change I am making, or this PR does not need tests.
- [X] I made sure all existing and new tests are passing.
- [X] I ran `dart format .` and committed any changes.
- [X] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
