### PR TITLE
Fixes bug where special permission's status would always be 'denied'

### DIFF
--- a/permission_handler_android/CHANGELOG.md
+++ b/permission_handler_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 11.0.4
+
+* Fixes a bug where the status of special permissions would incorrectly be reported as `denied`.
+
 ## 11.0.3
 
 * Fixes a bug where `Permission.notification.status` would never return `permanentlyDenied` on Android.

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
@@ -477,9 +477,7 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
                     } else {
                         permissionStatuses.add(PermissionConstants.PERMISSION_STATUS_RESTRICTED);
                     }
-                }
-
-                if (permission == PermissionConstants.PERMISSION_GROUP_MANAGE_EXTERNAL_STORAGE) {
+                } else if (permission == PermissionConstants.PERMISSION_GROUP_MANAGE_EXTERNAL_STORAGE) {
                     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
                         permissionStatuses.add(PermissionConstants.PERMISSION_STATUS_RESTRICTED);
                     }
@@ -488,27 +486,21 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
                         ? PermissionConstants.PERMISSION_STATUS_GRANTED
                         : PermissionConstants.PERMISSION_STATUS_DENIED;
                     permissionStatuses.add(status);
-                }
-
-                if (permission == PermissionConstants.PERMISSION_GROUP_SYSTEM_ALERT_WINDOW) {
+                } else if (permission == PermissionConstants.PERMISSION_GROUP_SYSTEM_ALERT_WINDOW) {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                         int status = Settings.canDrawOverlays(context)
                             ? PermissionConstants.PERMISSION_STATUS_GRANTED
                             : PermissionConstants.PERMISSION_STATUS_DENIED;
                         permissionStatuses.add(status);
                     }
-                }
-
-                if (permission == PermissionConstants.PERMISSION_GROUP_REQUEST_INSTALL_PACKAGES) {
+                } else if (permission == PermissionConstants.PERMISSION_GROUP_REQUEST_INSTALL_PACKAGES) {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                         int status = context.getPackageManager().canRequestPackageInstalls()
                             ? PermissionConstants.PERMISSION_STATUS_GRANTED
                             : PermissionConstants.PERMISSION_STATUS_DENIED;
                         permissionStatuses.add(status);
                     }
-                }
-
-                if (permission == PermissionConstants.PERMISSION_GROUP_ACCESS_NOTIFICATION_POLICY) {
+                } else if (permission == PermissionConstants.PERMISSION_GROUP_ACCESS_NOTIFICATION_POLICY) {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                         NotificationManager notificationManager = (NotificationManager) context.getSystemService(Application.NOTIFICATION_SERVICE);
                         int status = notificationManager.isNotificationPolicyAccessGranted()
@@ -516,9 +508,7 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
                             : PermissionConstants.PERMISSION_STATUS_DENIED;
                         permissionStatuses.add(status);
                     }
-                }
-
-                if (permission == PermissionConstants.PERMISSION_GROUP_SCHEDULE_EXACT_ALARM) {
+                } else if (permission == PermissionConstants.PERMISSION_GROUP_SCHEDULE_EXACT_ALARM) {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                         AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
                         int status = alarmManager.canScheduleExactAlarms()
@@ -528,11 +518,11 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
                     } else {
                         permissionStatuses.add(PermissionConstants.PERMISSION_STATUS_GRANTED);
                     }
-                }
-
-                final int permissionStatus = ContextCompat.checkSelfPermission(context, name);
-                if (permissionStatus != PackageManager.PERMISSION_GRANTED) {
-                    permissionStatuses.add(PermissionUtils.determineDeniedVariant(activity, name));
+                } else {
+                    final int permissionStatus = ContextCompat.checkSelfPermission(context, name);
+                    if (permissionStatus != PackageManager.PERMISSION_GRANTED) {
+                        permissionStatuses.add(PermissionUtils.determineDeniedVariant(activity, name));
+                    }
                 }
             }
         }

--- a/permission_handler_android/pubspec.yaml
+++ b/permission_handler_android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: permission_handler_android
 description: Permission plugin for Flutter. This plugin provides the Android API to request and check permissions.
 homepage: https://github.com/baseflow/flutter-permission-handler
-version: 11.0.3
+version: 11.0.4
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
During the changes in #1157, an oversight unintentionally changed the behavior of the business logic for checking permission statuses. Special permissions were now always reported as 'denied'. This was caused because the logic at the end of the for loop is now always fired, where it was previously escaped for these special permissions.

Fixes #1165.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [ ] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
