### PR TITLE
Support a permissive default implementation of permission_handler for linux.

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 11.0.1
+
+* Add linux platform support with `permission_handler_default`.
+
 ## 11.0.0
 
 * **BREAKING CHANGE:** Updates `permission_handler_android` dependency to version 11.0.0.

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -17,6 +17,8 @@ flutter:
         default_package: permission_handler_apple
       windows:
         default_package: permission_handler_windows
+      linux:
+        default_package: permission_handler_default
 
 dependencies:
   flutter:
@@ -25,6 +27,7 @@ dependencies:
   permission_handler_android: ^11.0.0
   permission_handler_apple: ^9.1.4
   permission_handler_windows: ^0.1.3
+  permission_handler_default: ^0.0.1
   permission_handler_platform_interface: ^3.11.5
 
 dev_dependencies:

--- a/permission_handler_default/LICENSE
+++ b/permission_handler_default/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Baseflow
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/permission_handler_default/README.md
+++ b/permission_handler_default/README.md
@@ -1,0 +1,23 @@
+# permission_handler_web
+
+[![pub package](https://img.shields.io/pub/v/permission_handler_default.svg)](https://pub.dartlang.org/packages/permission_handler_default) ![Build status](https://github.com/Baseflow/flutter-permission-handler/workflows/permission_handler_default/badge.svg?branch=master) [![style: flutter lints](https://img.shields.io/badge/style-flutter_lints-40c4ff.svg)](https://pub.dev/packages/flutter_lints)
+
+The official default implementation of the [permission_handler](https://pub.dev/packages/permission_handler) plugin by [Baseflow](https://baseflow.com).
+
+## Usage
+
+This is the officially endorsed default implementation of the permission_handler plugin. This means it will automatically be added to your dependencies when you depend on `permission_handler` in your applications pubspec.yaml.
+
+More detailed instructions on using the API can be found in the [README.md](../permission_handler/README.md) of the [permission_handler](https://pub.dev/packages/permission_handler) package.
+
+## Issues
+
+Please file any issues, bugs or feature requests as an issue on our [GitHub](https://github.com/Baseflow/flutter-permission-handler/issues) page. Commercial support is available, you can contact us at <hello@baseflow.com>.
+
+## Want to contribute
+
+If you would like to contribute to the plugin (e.g. by improving the documentation, solving a bug or adding a cool new feature), please carefully review our [contribution guide](../CONTRIBUTING.md) and send us your [pull request](https://github.com/Baseflow/flutter-permission-handler/pulls).
+
+## Author
+
+This permission_handler plugin for Flutter is developed by [Patrick Northon](northon_patrick3@yahoo.ca).

--- a/permission_handler_default/lib/permission_handler_default.dart
+++ b/permission_handler_default/lib/permission_handler_default.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/foundation.dart';
+import 'package:permission_handler_platform_interface/permission_handler_platform_interface.dart';
+
+/// Platform implementation of the permission_handler Flutter plugin.
+class DefaultPermissionHandler extends PermissionHandlerPlatform {
+  /// Registers the default plugin implementation.
+  static void registerWith() {
+    PermissionHandlerPlatform.instance = DefaultPermissionHandler();
+  }
+
+  @override
+  Future<Map<Permission, PermissionStatus>> requestPermissions(
+      List<Permission> permissions) async {
+    final Map<Permission, PermissionStatus> permissionStatusMap = {};
+
+    for (final permission in permissions) {
+      permissionStatusMap[permission] = PermissionStatus.granted;
+    }
+
+    return SynchronousFuture(permissionStatusMap);
+  }
+
+  @override
+  Future<PermissionStatus> checkPermissionStatus(Permission permission) async {
+    return SynchronousFuture(PermissionStatus.granted);
+  }
+
+  @override
+  Future<ServiceStatus> checkServiceStatus(Permission permission) async {
+    return SynchronousFuture(ServiceStatus.enabled);
+  }
+
+  @override
+  Future<bool> shouldShowRequestPermissionRationale(
+      Permission permission) async {
+    return SynchronousFuture(false);
+  }
+
+  @override
+  Future<bool> openAppSettings() {
+    return SynchronousFuture(false);
+  }
+}

--- a/permission_handler_default/pubspec.yaml
+++ b/permission_handler_default/pubspec.yaml
@@ -1,0 +1,33 @@
+name: permission_handler_default
+description: Permission handler for platforms that don't have specific support. It assume that all permissions are granted.
+version: 0.0.1
+homepage:
+
+environment:
+  sdk: '>=3.0.5 <4.0.0'
+  flutter: ">=3.3.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  permission_handler_platform_interface: ^3.7.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^2.0.0
+  build_runner: ^2.1.2
+  test: ^1.24.4
+
+# For information on the generic Dart part of this file, see the
+# following page: https://dart.dev/tools/pub/pubspec
+
+# The following section is specific to Flutter packages.
+flutter:
+
+  plugin:
+    implements: permission_handler
+    platforms:
+      linux:
+        dartPluginClass: DefaultPermissionHandler
+        fileName: permission_handler_default.dart

--- a/permission_handler_default/test/permission_handler_default_test.dart
+++ b/permission_handler_default/test/permission_handler_default_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:permission_handler_platform_interface/permission_handler_platform_interface.dart';
+import 'package:permission_handler_default/permission_handler_default.dart';
+
+void main() {
+  final List<Permission> testPermissions = [
+    Permission.camera,
+    Permission.contacts,
+    Permission.location,
+    Permission.microphone,
+    Permission.notification,
+  ];
+
+  final plugin = DefaultPermissionHandler();
+
+  test('check permissions are all granted', () async {
+    final permissions = await plugin.requestPermissions(testPermissions);
+
+    for (final status in permissions.values) {
+      expect(status, PermissionStatus.granted);
+    }
+  });
+
+  test('check services are all enabled.', () async {
+    for (final permission in testPermissions) {
+      final serviceStatus = await plugin.checkServiceStatus(permission);
+      expect(serviceStatus, ServiceStatus.enabled);
+    }
+  });
+
+  test('never show unsupported permission rational.', () async {
+    for (final permission in testPermissions) {
+      final shouldIt =
+          await plugin.shouldShowRequestPermissionRationale(permission);
+      expect(shouldIt, false);
+    }
+  });
+
+  test('never show unsupported app settings.', () async {
+    final appSettings = await plugin.openAppSettings();
+    expect(appSettings, false);
+  });
+}


### PR DESCRIPTION
* Assume that all permissions are granted.
* Assume that all services are enabled.
* Assume that there is no "app settings" and permission requests.
* Make it the default for linux platform.

This will enable support for the linux platform. Linux has plenty of ways to sandbox an application but no singular way. Later I could look into flatpak and snaps and see if it can be integrated. For now this plugin should at least make apps work for linux. I named it the "default" plugin but I can always rename it if preferred.

It should fix issue #631

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
