### PR TITLE
Platform Interface: Deprecates `calendar`, introduces `calendarReadOnly` and `calendarFullAccess`

### DIFF
--- a/permission_handler_platform_interface/CHANGELOG.md
+++ b/permission_handler_platform_interface/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.12.0
+
+* Adds `Permission.calendarReadOnly` and `Permission.calendarFullAccess`.
+* Deprecates `Permission.calendar`. Developers should use `Permission.calendarReadOnly` and `Permission.calendarFullAccess` instead.
+
 ## 3.11.5
 
 * Updates the mentions of Android versions throughout the plugin, now following a format of 'Android {name} (API {number})'. For example: 'Android 13 (API 33)'.

--- a/permission_handler_platform_interface/lib/src/permissions.dart
+++ b/permission_handler_platform_interface/lib/src/permissions.dart
@@ -29,6 +29,7 @@ class Permission {
   ///
   /// Android: Calendar
   /// iOS: Calendar (Events)
+  @Deprecated('Use [calendarReadOnly] and [calendarFullAccess].')
   static const calendar = Permission._(0);
 
   /// Permission for accessing the device's camera.
@@ -296,8 +297,17 @@ class Permission {
   /// Android 13+ (API 33+)
   static const sensorsAlways = Permission._(35);
 
+  /// Permission for reading the device's calendar.
+  ///
+  /// On iOS 16 and lower, this permission is identical to [Permission.calendarFullAccess].
+  static const calendarReadOnly = Permission._(36);
+
+  /// Permission for reading from and writing to the device's calendar.
+  static const calendarFullAccess = Permission._(37);
+
   /// Returns a list of all possible [PermissionGroup] values.
   static const List<Permission> values = <Permission>[
+    // ignore: deprecated_member_use_from_same_package
     calendar,
     camera,
     contacts,
@@ -334,6 +344,8 @@ class Permission {
     audio,
     scheduleExactAlarm,
     sensorsAlways,
+    calendarReadOnly,
+    calendarFullAccess,
   ];
 
   static const List<String> _names = <String>[
@@ -373,6 +385,8 @@ class Permission {
     'audio',
     'scheduleExactAlarm',
     'sensorsAlways',
+    'calendarReadOnly',
+    'calendarFullAccess',
   ];
 
   @override

--- a/permission_handler_platform_interface/pubspec.yaml
+++ b/permission_handler_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the permission_handler plugin.
 homepage: https://github.com/baseflow/flutter-permission-handler/tree/master/permission_handler_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 3.11.5
+version: 3.12.0
 
 dependencies:
   flutter:

--- a/permission_handler_platform_interface/test/src/method_channel/method_channel_permission_handler_test.dart
+++ b/permission_handler_platform_interface/test/src/method_channel/method_channel_permission_handler_test.dart
@@ -3,8 +3,11 @@ import 'package:permission_handler_platform_interface/permission_handler_platfor
 import 'package:permission_handler_platform_interface/src/method_channel/method_channel_permission_handler.dart';
 import 'method_channel_mock.dart';
 
-List<Permission> get mockPermissions => List.of(
-    <Permission>{Permission.calendar, Permission.camera, Permission.contacts});
+List<Permission> get mockPermissions => List.of(<Permission>{
+      Permission.contacts,
+      Permission.camera,
+      Permission.calendarReadOnly,
+    });
 
 Map<Permission, PermissionStatus> get mockPermissionMap => {};
 
@@ -21,7 +24,7 @@ void main() {
       );
 
       final permissionStatus = await MethodChannelPermissionHandler()
-          .checkPermissionStatus(Permission.calendar);
+          .checkPermissionStatus(Permission.contacts);
 
       expect(permissionStatus, PermissionStatus.denied);
     });
@@ -35,7 +38,7 @@ void main() {
       );
 
       final permissionStatus = await MethodChannelPermissionHandler()
-          .checkPermissionStatus(Permission.calendar);
+          .checkPermissionStatus(Permission.contacts);
 
       expect(permissionStatus, PermissionStatus.denied);
     });
@@ -51,7 +54,7 @@ void main() {
       );
 
       final permissionStatus = await MethodChannelPermissionHandler()
-          .checkPermissionStatus(Permission.calendar);
+          .checkPermissionStatus(Permission.contacts);
 
       expect(permissionStatus, PermissionStatus.restricted);
     });
@@ -67,7 +70,7 @@ void main() {
       );
 
       final permissionStatus = await MethodChannelPermissionHandler()
-          .checkPermissionStatus(Permission.calendar);
+          .checkPermissionStatus(Permission.contacts);
 
       expect(permissionStatus, PermissionStatus.limited);
     });
@@ -83,7 +86,7 @@ void main() {
       );
 
       final permissionStatus = await MethodChannelPermissionHandler()
-          .checkPermissionStatus(Permission.calendar);
+          .checkPermissionStatus(Permission.contacts);
 
       expect(permissionStatus, PermissionStatus.permanentlyDenied);
     });
@@ -101,7 +104,7 @@ void main() {
       );
 
       final serviceStatus = await MethodChannelPermissionHandler()
-          .checkServiceStatus(Permission.calendar);
+          .checkServiceStatus(Permission.contacts);
 
       expect(serviceStatus, ServiceStatus.disabled);
     });
@@ -115,7 +118,7 @@ void main() {
       );
 
       final serviceStatus = await MethodChannelPermissionHandler()
-          .checkServiceStatus(Permission.calendar);
+          .checkServiceStatus(Permission.contacts);
 
       expect(serviceStatus, ServiceStatus.enabled);
     });
@@ -131,7 +134,7 @@ void main() {
       );
 
       final serviceStatus = await MethodChannelPermissionHandler()
-          .checkServiceStatus(Permission.calendar);
+          .checkServiceStatus(Permission.contacts);
 
       expect(serviceStatus, ServiceStatus.notApplicable);
     });

--- a/permission_handler_platform_interface/test/src/permissions_test.dart
+++ b/permission_handler_platform_interface/test/src/permissions_test.dart
@@ -6,7 +6,7 @@ void main() {
       () {
     const values = Permission.values;
 
-    expect(values.length, 36);
+    expect(values.length, 38);
   });
 
   test('check if byValue returns corresponding PermissionGroup value', () {


### PR DESCRIPTION
Closes #1181.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
