### PR TITLE
Implement `Permission.calendarReadOnly` and `Permission.calendarFullAccess`

### DIFF
--- a/permission_handler_android/CHANGELOG.md
+++ b/permission_handler_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 11.1.0
+
+* Implements the `Permission.calendarReadOnly` and `PermissionCalendarFullAccess` permissions.
+
 ## 11.0.5
 
 * Removes the obsolete `updatePermissionShouldShowStatus` method from the Java code base.

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionConstants.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionConstants.java
@@ -17,7 +17,11 @@ final class PermissionConstants {
     static final int PERMISSION_CODE_ACCESS_NOTIFICATION_POLICY = 213;
     static final int PERMISSION_CODE_SCHEDULE_EXACT_ALARM = 214;
 
-    //PERMISSION_GROUP
+
+    // PERMISSION_GROUP
+
+    // Deprecated in favor of PERMISSION_GROUP_CALENDAR_READ_ONLY and
+    // PERMISSION_GROUP_CALENDAR_FULL_ACCESS.
     static final int PERMISSION_GROUP_CALENDAR = 0;
     static final int PERMISSION_GROUP_CAMERA = 1;
     static final int PERMISSION_GROUP_CONTACTS = 2;
@@ -54,6 +58,8 @@ final class PermissionConstants {
     static final int PERMISSION_GROUP_AUDIO = 33;
     static final int PERMISSION_GROUP_SCHEDULE_EXACT_ALARM = 34;
     static final int PERMISSION_GROUP_SENSORS_ALWAYS = 35;
+    static final int PERMISSION_GROUP_CALENDAR_READ_ONLY = 36;
+    static final int PERMISSION_GROUP_CALENDAR_FULL_ACCESS = 37;
 
     @Retention(RetentionPolicy.SOURCE)
     @IntDef({
@@ -89,7 +95,9 @@ final class PermissionConstants {
             PERMISSION_GROUP_NEARBY_WIFI_DEVICES,
             PERMISSION_GROUP_VIDEOS,
             PERMISSION_GROUP_AUDIO,
-            PERMISSION_GROUP_SCHEDULE_EXACT_ALARM
+            PERMISSION_GROUP_SCHEDULE_EXACT_ALARM,
+            PERMISSION_GROUP_CALENDAR_READ_ONLY,
+            PERMISSION_GROUP_CALENDAR_FULL_ACCESS
     })
     @interface PermissionGroup {
     }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
@@ -103,6 +103,12 @@ public class PermissionUtils {
         final ArrayList<String> permissionNames = new ArrayList<>();
 
         switch (permission) {
+            case PermissionConstants.PERMISSION_GROUP_CALENDAR_READ_ONLY:
+                if (hasPermissionInManifest(context, permissionNames, Manifest.permission.READ_CALENDAR))
+                    permissionNames.add(Manifest.permission.READ_CALENDAR);
+                break;
+
+            case PermissionConstants.PERMISSION_GROUP_CALENDAR_FULL_ACCESS:
             case PermissionConstants.PERMISSION_GROUP_CALENDAR:
                 if (hasPermissionInManifest(context, permissionNames, Manifest.permission.READ_CALENDAR))
                     permissionNames.add(Manifest.permission.READ_CALENDAR);

--- a/permission_handler_android/example/android/app/src/main/AndroidManifest.xml
+++ b/permission_handler_android/example/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,13 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.baseflow.permissionhandler.example">
 
+    <uses-feature
+        android:name="android.hardware.telephony"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
+
     <!--
     Internet permissions do not affect the `permission_handler` plugin, but are required if your app needs access to
     the internet.

--- a/permission_handler_android/pubspec.yaml
+++ b/permission_handler_android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: permission_handler_android
 description: Permission plugin for Flutter. This plugin provides the Android API to request and check permissions.
 homepage: https://github.com/baseflow/flutter-permission-handler
-version: 11.0.5
+version: 11.1.0
 
 environment:
   sdk: ">=2.15.0 <4.0.0"
@@ -18,7 +18,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  permission_handler_platform_interface: ^3.11.2
+  permission_handler_platform_interface: ^3.12.0
 
 dev_dependencies:
   flutter_lints: ^1.0.4


### PR DESCRIPTION
Implements the `Permission.calendarReadOnly` and `Permission.calendarFullAccess` permissions.

The current architecture does not support the way Android deals with calendar permissions very well. As a refactor that removes almost all Java code is in the works, we decided not to care too much about the code quality.

Closes #1182.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
