### PR TITLE
Replace `calendarReadOnly` with `calendarWriteOnly`

### DIFF
--- a/permission_handler_platform_interface/CHANGELOG.md
+++ b/permission_handler_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.0
+
+* **BREAKING CHANGE**: Replaces `Permission.calendarReadOnly` with `Permission.calendarWriteOnly`.
+
 ## 3.12.0
 
 * Adds `Permission.calendarReadOnly` and `Permission.calendarFullAccess`.

--- a/permission_handler_platform_interface/lib/src/permissions.dart
+++ b/permission_handler_platform_interface/lib/src/permissions.dart
@@ -29,7 +29,7 @@ class Permission {
   ///
   /// Android: Calendar
   /// iOS: Calendar (Events)
-  @Deprecated('Use [calendarReadOnly] and [calendarFullAccess].')
+  @Deprecated('Use [calendarWriteOnly] and [calendarFullAccess].')
   static const calendar = Permission._(0);
 
   /// Permission for accessing the device's camera.
@@ -297,10 +297,10 @@ class Permission {
   /// Android 13+ (API 33+)
   static const sensorsAlways = Permission._(35);
 
-  /// Permission for reading the device's calendar.
+  /// Permission for writing to the device's calendar.
   ///
   /// On iOS 16 and lower, this permission is identical to [Permission.calendarFullAccess].
-  static const calendarReadOnly = Permission._(36);
+  static const calendarWriteOnly = Permission._(36);
 
   /// Permission for reading from and writing to the device's calendar.
   static const calendarFullAccess = Permission._(37);
@@ -344,7 +344,7 @@ class Permission {
     audio,
     scheduleExactAlarm,
     sensorsAlways,
-    calendarReadOnly,
+    calendarWriteOnly,
     calendarFullAccess,
   ];
 
@@ -385,7 +385,7 @@ class Permission {
     'audio',
     'scheduleExactAlarm',
     'sensorsAlways',
-    'calendarReadOnly',
+    'calendarWriteOnly',
     'calendarFullAccess',
   ];
 

--- a/permission_handler_platform_interface/pubspec.yaml
+++ b/permission_handler_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the permission_handler plugin.
 homepage: https://github.com/baseflow/flutter-permission-handler/tree/master/permission_handler_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 3.12.0
+version: 4.0.0
 
 dependencies:
   flutter:

--- a/permission_handler_platform_interface/test/src/method_channel/method_channel_permission_handler_test.dart
+++ b/permission_handler_platform_interface/test/src/method_channel/method_channel_permission_handler_test.dart
@@ -6,7 +6,7 @@ import 'method_channel_mock.dart';
 List<Permission> get mockPermissions => List.of(<Permission>{
       Permission.contacts,
       Permission.camera,
-      Permission.calendarReadOnly,
+      Permission.calendarWriteOnly,
     });
 
 Map<Permission, PermissionStatus> get mockPermissionMap => {};


### PR DESCRIPTION
The calendar permission has been split into read-only and full access, as this split can be facilitated by Android's read/write split and iOS's read/full-access split. However, it turns out that iOS's calendar permissions are split in write/full-access instead. Therefore, the new calendar split for the app-facing package will be write-only and full access.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
