### PR TITLE
Update logic to handle calendar WRITE/FULL_ACCESS instead of READ/FULL_ACCESS

### DIFF
--- a/permission_handler_android/CHANGELOG.md
+++ b/permission_handler_android/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 12.0.0
+
+* **BREAKING CHANGES:**
+  * Adds `Permission.calendarWriteOnly`.
+  * Removes `Permission.calendarReadOnly`.
+
 ## 11.1.0
 
 * Implements the `Permission.calendarReadOnly` and `PermissionCalendarFullAccess` permissions.

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionConstants.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionConstants.java
@@ -20,7 +20,7 @@ final class PermissionConstants {
 
     // PERMISSION_GROUP
 
-    // Deprecated in favor of PERMISSION_GROUP_CALENDAR_READ_ONLY and
+    // Deprecated in favor of PERMISSION_GROUP_CALENDAR_WRITE_ONLY and
     // PERMISSION_GROUP_CALENDAR_FULL_ACCESS.
     static final int PERMISSION_GROUP_CALENDAR = 0;
     static final int PERMISSION_GROUP_CAMERA = 1;
@@ -58,7 +58,7 @@ final class PermissionConstants {
     static final int PERMISSION_GROUP_AUDIO = 33;
     static final int PERMISSION_GROUP_SCHEDULE_EXACT_ALARM = 34;
     static final int PERMISSION_GROUP_SENSORS_ALWAYS = 35;
-    static final int PERMISSION_GROUP_CALENDAR_READ_ONLY = 36;
+    static final int PERMISSION_GROUP_CALENDAR_WRITE_ONLY = 36;
     static final int PERMISSION_GROUP_CALENDAR_FULL_ACCESS = 37;
 
     @Retention(RetentionPolicy.SOURCE)
@@ -96,7 +96,7 @@ final class PermissionConstants {
             PERMISSION_GROUP_VIDEOS,
             PERMISSION_GROUP_AUDIO,
             PERMISSION_GROUP_SCHEDULE_EXACT_ALARM,
-            PERMISSION_GROUP_CALENDAR_READ_ONLY,
+            PERMISSION_GROUP_CALENDAR_WRITE_ONLY,
             PERMISSION_GROUP_CALENDAR_FULL_ACCESS
     })
     @interface PermissionGroup {

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
@@ -166,24 +166,24 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
             return false;
         }
 
-        // Calendar permissions are split between READ and WRITE in Android, and split between READ
+        // Calendar permissions are split between WRITE and READ in Android, and split between WRITE
         // and FULL ACCESS in the plugin. We need special logic for this translation.
         final List<String> permissionList = Arrays.asList(permissions);
-        final int calendarReadIndex = permissionList.indexOf(Manifest.permission.READ_CALENDAR);
         final int calendarWriteIndex = permissionList.indexOf(Manifest.permission.WRITE_CALENDAR);
-        // READ -> READ.
-        if (calendarReadIndex >= 0) {
-            final int readGrantResult = grantResults[calendarReadIndex];
-            final @PermissionConstants.PermissionStatus int readStatus =
-                PermissionUtils.toPermissionStatus(this.activity, Manifest.permission.READ_CALENDAR, readGrantResult);
-            requestResults.put(PermissionConstants.PERMISSION_GROUP_CALENDAR_READ_ONLY, readStatus);
+        // WRITE -> WRITE.
+        if (calendarWriteIndex >= 0) {
+            final int writeGrantResult = grantResults[calendarWriteIndex];
+            final @PermissionConstants.PermissionStatus int writeStatus =
+                PermissionUtils.toPermissionStatus(this.activity, Manifest.permission.WRITE_CALENDAR, writeGrantResult);
+            requestResults.put(PermissionConstants.PERMISSION_GROUP_CALENDAR_WRITE_ONLY, writeStatus);
 
-            // READ + WRITE -> FULL ACCESS.
-            if (calendarWriteIndex >= 0) {
-                final int writeGrantResult = grantResults[calendarWriteIndex];
-                final @PermissionConstants.PermissionStatus int writeStatus =
-                    PermissionUtils.toPermissionStatus(this.activity, Manifest.permission.WRITE_CALENDAR, writeGrantResult);
-                final @PermissionConstants.PermissionStatus int fullAccessStatus = strictestStatus(readStatus, writeStatus);
+            // WRITE + READ -> FULL ACCESS.
+            final int calendarReadIndex = permissionList.indexOf(Manifest.permission.READ_CALENDAR);
+            if (calendarReadIndex >= 0) {
+                final int readGrantResult = grantResults[calendarReadIndex];
+                final @PermissionConstants.PermissionStatus int readStatus =
+                    PermissionUtils.toPermissionStatus(this.activity, Manifest.permission.READ_CALENDAR, readGrantResult);
+                final @PermissionConstants.PermissionStatus int fullAccessStatus = strictestStatus(writeStatus, readStatus);
                 requestResults.put(PermissionConstants.PERMISSION_GROUP_CALENDAR_FULL_ACCESS, fullAccessStatus);
                 // Support deprecated CALENDAR permission.
                 requestResults.put(PermissionConstants.PERMISSION_GROUP_CALENDAR, fullAccessStatus);
@@ -193,8 +193,8 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
         for (int i = 0; i < permissions.length; i++) {
             final String permissionName = permissions[i];
 
-            // READ_CALENDAR and WRITE_CALENDAR permission results have already been handled.
-            if (permissionName.equals(Manifest.permission.READ_CALENDAR) || permissionName.equals(Manifest.permission.WRITE_CALENDAR)) {
+            // WRITE_CALENDAR and READ_CALENDAR permission results have already been handled.
+            if (permissionName.equals(Manifest.permission.WRITE_CALENDAR) || permissionName.equals(Manifest.permission.READ_CALENDAR)) {
                 continue;
             }
 
@@ -409,12 +409,12 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
                     Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM,
                     PermissionConstants.PERMISSION_CODE_SCHEDULE_EXACT_ALARM);
             } else if (permission == PermissionConstants.PERMISSION_GROUP_CALENDAR_FULL_ACCESS || permission == PermissionConstants.PERMISSION_GROUP_CALENDAR) {
-                // Deny CALENDAR_FULL_ACCESS permission if manifest is not listing both read- and write permissions.
-                // Otherwise, we will only ask for READ permission and think full access is granted.
+                // Deny CALENDAR_FULL_ACCESS permission if manifest is not listing both write- and read permissions.
+                // Otherwise, we will only ask for WRITE permission and think full access is granted.
                 final boolean isValidManifest = isValidManifestForCalendarFullAccess();
                 if (isValidManifest) {
-                    permissionsToRequest.add(Manifest.permission.READ_CALENDAR);
                     permissionsToRequest.add(Manifest.permission.WRITE_CALENDAR);
+                    permissionsToRequest.add(Manifest.permission.READ_CALENDAR);
                     pendingRequestCount += 2;
                 } else {
                     requestResults.put(permission, PermissionConstants.PERMISSION_STATUS_DENIED);
@@ -650,19 +650,19 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
     }
 
     /**
-     * Checks if the manifest contains both {@link Manifest.permission#READ_CALENDAR} and
-     * {@link Manifest.permission#WRITE_CALENDAR} permission declarations.
+     * Checks if the manifest contains both {@link Manifest.permission#WRITE_CALENDAR} and
+     * {@link Manifest.permission#READ_CALENDAR} permission declarations.
      */
     private boolean isValidManifestForCalendarFullAccess() {
         List<String> names = PermissionUtils.getManifestNames(context, PermissionConstants.PERMISSION_GROUP_CALENDAR_FULL_ACCESS);
-        final boolean readInManifest = names != null && names.contains(Manifest.permission.READ_CALENDAR);
         final boolean writeInManifest = names != null && names.contains(Manifest.permission.WRITE_CALENDAR);
-        final boolean validManifest = readInManifest && writeInManifest;
+        final boolean readInManifest = names != null && names.contains(Manifest.permission.READ_CALENDAR);
+        final boolean validManifest = writeInManifest && readInManifest;
         if (!validManifest) {
-            if (!readInManifest)
-                Log.d(PermissionConstants.LOG_TAG, Manifest.permission.READ_CALENDAR + " missing in manifest");
             if (!writeInManifest)
                 Log.d(PermissionConstants.LOG_TAG, Manifest.permission.WRITE_CALENDAR + " missing in manifest");
+            if (!readInManifest)
+                Log.d(PermissionConstants.LOG_TAG, Manifest.permission.READ_CALENDAR + " missing in manifest");
             return false;
         }
         return true;

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
@@ -410,7 +410,6 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
                     PermissionConstants.PERMISSION_CODE_SCHEDULE_EXACT_ALARM);
             } else if (permission == PermissionConstants.PERMISSION_GROUP_CALENDAR_FULL_ACCESS || permission == PermissionConstants.PERMISSION_GROUP_CALENDAR) {
                 // Deny CALENDAR_FULL_ACCESS permission if manifest is not listing both write- and read permissions.
-                // Otherwise, we will only ask for WRITE permission and think full access is granted.
                 final boolean isValidManifest = isValidManifestForCalendarFullAccess();
                 if (isValidManifest) {
                     permissionsToRequest.add(Manifest.permission.WRITE_CALENDAR);

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java
@@ -27,8 +27,8 @@ public class PermissionUtils {
     @PermissionConstants.PermissionGroup
     static int parseManifestName(String permission) {
         switch (permission) {
-            case Manifest.permission.READ_CALENDAR:
             case Manifest.permission.WRITE_CALENDAR:
+            case Manifest.permission.READ_CALENDAR:
                 return PermissionConstants.PERMISSION_GROUP_CALENDAR;
             case Manifest.permission.CAMERA:
                 return PermissionConstants.PERMISSION_GROUP_CAMERA;
@@ -103,17 +103,17 @@ public class PermissionUtils {
         final ArrayList<String> permissionNames = new ArrayList<>();
 
         switch (permission) {
-            case PermissionConstants.PERMISSION_GROUP_CALENDAR_READ_ONLY:
-                if (hasPermissionInManifest(context, permissionNames, Manifest.permission.READ_CALENDAR))
-                    permissionNames.add(Manifest.permission.READ_CALENDAR);
+            case PermissionConstants.PERMISSION_GROUP_CALENDAR_WRITE_ONLY:
+                if (hasPermissionInManifest(context, permissionNames, Manifest.permission.WRITE_CALENDAR))
+                    permissionNames.add(Manifest.permission.WRITE_CALENDAR);
                 break;
 
             case PermissionConstants.PERMISSION_GROUP_CALENDAR_FULL_ACCESS:
             case PermissionConstants.PERMISSION_GROUP_CALENDAR:
-                if (hasPermissionInManifest(context, permissionNames, Manifest.permission.READ_CALENDAR))
-                    permissionNames.add(Manifest.permission.READ_CALENDAR);
                 if (hasPermissionInManifest(context, permissionNames, Manifest.permission.WRITE_CALENDAR))
                     permissionNames.add(Manifest.permission.WRITE_CALENDAR);
+                if (hasPermissionInManifest(context, permissionNames, Manifest.permission.READ_CALENDAR))
+                    permissionNames.add(Manifest.permission.READ_CALENDAR);
                 break;
 
             case PermissionConstants.PERMISSION_GROUP_CAMERA:

--- a/permission_handler_android/pubspec.yaml
+++ b/permission_handler_android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: permission_handler_android
 description: Permission plugin for Flutter. This plugin provides the Android API to request and check permissions.
 homepage: https://github.com/baseflow/flutter-permission-handler
-version: 11.1.0
+version: 12.0.0
 
 environment:
   sdk: ">=2.15.0 <4.0.0"
@@ -18,7 +18,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  permission_handler_platform_interface: ^3.12.0
+  permission_handler_platform_interface: ^4.0.0
 
 dev_dependencies:
   flutter_lints: ^1.0.4


### PR DESCRIPTION
The calendar permission has been split into read-only and full access, as this split can be facilitated by Android's read/write split and iOS's read/full-access split. However, it turns out that iOS's calendar permissions are split in write/full-access instead. Therefore, the new calendar split for the app-facing package will be write-only and full access.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
