### PR TITLE
Updates documentation for Permission.photos on Android

### DIFF
--- a/permission_handler_platform_interface/CHANGELOG.md
+++ b/permission_handler_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.0
+
+* Updates Android documentation on how to use `permission.photo` on Android 12 (API 32) and below and Android 13 (API 33) and above.
+
 ## 4.0.0
 
 * **BREAKING CHANGE**: Replaces `Permission.calendarReadOnly` with `Permission.calendarWriteOnly`.

--- a/permission_handler_platform_interface/CHANGELOG.md
+++ b/permission_handler_platform_interface/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.1.0
+## 4.0.1
 
 * Updates Android documentation on how to use `permission.photo` on Android 12 (API 32) and below and Android 13 (API 33) and above.
 

--- a/permission_handler_platform_interface/lib/src/permissions.dart
+++ b/permission_handler_platform_interface/lib/src/permissions.dart
@@ -94,13 +94,27 @@ class Permission {
   /// Depending on the platform and version, the requirements are slightly
   /// different:
   ///
-  /// **Android:**
-  /// - When running on Android 13 (API 33) and above: Read image files from
-  /// external storage
-  /// - When running below Android 13 (API 33): Nothing
-  ///
   /// **iOS:**
   /// - When running Photos (iOS 14+ read & write access level)
+  ///
+  /// **Android:**
+  /// - Devices running Android 13 (API level 33) use [Permissions.storage].
+  /// - Devices running Android 12L (API level 32) or lower: Should use [Permissions.photos].
+  ///
+  /// EXAMPLE: in Manifest:
+  /// <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32"/>
+  /// <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
+  ///
+  /// In Flutter to check the status:
+  ///
+  /// if (Platform.isAndroid) {
+  ///   final androidInfo = await DeviceInfoPlugin().androidInfo;
+  ///   if (androidInfo.version.sdkInt <= 32) {
+  ///     use [Permissions.storage.status]
+  ///   }  else {
+  ///     use [Permissions.photos.status]
+  ///   }
+  /// }
   static const photos = Permission._(9);
 
   /// Permission for adding photos to the device's photo library (iOS only).

--- a/permission_handler_platform_interface/lib/src/permissions.dart
+++ b/permission_handler_platform_interface/lib/src/permissions.dart
@@ -98,8 +98,8 @@ class Permission {
   /// - When running Photos (iOS 14+ read & write access level)
   ///
   /// **Android:**
-  /// - Devices running Android 13 (API level 33) use [Permissions.storage].
-  /// - Devices running Android 12L (API level 32) or lower: Should use [Permissions.photos].
+  /// - Devices running Android 13 (API level 33) and above: use [Permissions.storage].
+  /// - Devices running Android 12 (API level 32) or lower: Should use [Permissions.photos].
   ///
   /// EXAMPLE: in Manifest:
   /// <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32"/>

--- a/permission_handler_platform_interface/lib/src/permissions.dart
+++ b/permission_handler_platform_interface/lib/src/permissions.dart
@@ -98,8 +98,8 @@ class Permission {
   /// - When running Photos (iOS 14+ read & write access level)
   ///
   /// **Android:**
-  /// - Devices running Android 13 (API level 33) and above: use [Permissions.storage].
-  /// - Devices running Android 12 (API level 32) or lower: Should use [Permissions.photos].
+  /// - Devices running Android 12 (API level 32) or lower: use [Permissions.storage].
+  /// - Devices running Android 13 (API level 33) and above: Should use [Permissions.photos].
   ///
   /// EXAMPLE: in Manifest:
   /// <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32"/>

--- a/permission_handler_platform_interface/pubspec.yaml
+++ b/permission_handler_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the permission_handler plugin.
 homepage: https://github.com/baseflow/flutter-permission-handler/tree/master/permission_handler_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 4.0.0
+version: 4.1.0
 
 dependencies:
   flutter:

--- a/permission_handler_platform_interface/pubspec.yaml
+++ b/permission_handler_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the permission_handler plugin.
 homepage: https://github.com/baseflow/flutter-permission-handler/tree/master/permission_handler_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 4.1.0
+version: 4.0.1
 
 dependencies:
   flutter:


### PR DESCRIPTION
Documentation is updated that resolves: [#944](https://github.com/Baseflow/flutter-permission-handler/issues/944). It was unclear how to use photo permission on Android on api 32 (Android 12) and below and api 33 (Android 13) and above.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
