### PR TITLE
`checkPermissionStatus` for normal permissions

### DIFF
--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ActivityCompatHostApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ActivityCompatHostApiImpl.java
@@ -40,9 +40,8 @@ public class ActivityCompatHostApiImpl implements ActivityCompatHostApi {
         this.instanceManager = instanceManager;
     }
 
-    @NonNull
     @Override
-    public Boolean shouldShowRequestPermissionRationale(
+    @NonNull public Boolean shouldShowRequestPermissionRationale(
         @NonNull String activityInstanceId,
         @NonNull String permission
     ) {
@@ -52,5 +51,18 @@ public class ActivityCompatHostApiImpl implements ActivityCompatHostApi {
             throw new ActivityNotFoundException();
         }
         return ActivityCompat.shouldShowRequestPermissionRationale(activity, permission);
+    }
+
+    @Override
+    @NonNull public Long checkSelfPermission(
+        @NonNull String activityInstanceId,
+        @NonNull String permission
+    ) {
+        final UUID activityInstanceUuid = UUID.fromString(activityInstanceId);
+        final Activity activity = instanceManager.getInstance(activityInstanceUuid);
+        if (activity == null) {
+            throw new ActivityNotFoundException();
+        }
+        return (long) ActivityCompat.checkSelfPermission(activity, permission);
     }
 }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPigeon.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPigeon.java
@@ -71,6 +71,9 @@ public class PermissionHandlerPigeon {
     /** Gets whether you should show UI with rationale before requesting a permission. */
     @NonNull 
     Boolean shouldShowRequestPermissionRationale(@NonNull String activityInstanceId, @NonNull String permission);
+    /** Determine whether you have been granted a particular permission. */
+    @NonNull 
+    Long checkSelfPermission(@NonNull String activityInstanceId, @NonNull String permission);
 
     /** The codec used by ActivityCompatHostApi. */
     static @NonNull MessageCodec<Object> getCodec() {
@@ -91,6 +94,31 @@ public class PermissionHandlerPigeon {
                 String permissionArg = (String) args.get(1);
                 try {
                   Boolean output = api.shouldShowRequestPermissionRationale(activityInstanceIdArg, permissionArg);
+                  wrapped.add(0, output);
+                }
+ catch (Throwable exception) {
+                  ArrayList<Object> wrappedError = wrapError(exception);
+                  wrapped = wrappedError;
+                }
+                reply.reply(wrapped);
+              });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(
+                binaryMessenger, "dev.flutter.pigeon.permission_handler_android.ActivityCompatHostApi.checkSelfPermission", getCodec());
+        if (api != null) {
+          channel.setMessageHandler(
+              (message, reply) -> {
+                ArrayList<Object> wrapped = new ArrayList<Object>();
+                ArrayList<Object> args = (ArrayList<Object>) message;
+                String activityInstanceIdArg = (String) args.get(0);
+                String permissionArg = (String) args.get(1);
+                try {
+                  Long output = api.checkSelfPermission(activityInstanceIdArg, permissionArg);
                   wrapped.add(0, output);
                 }
  catch (Throwable exception) {

--- a/permission_handler_android/lib/permission_handler_android.dart
+++ b/permission_handler_android/lib/permission_handler_android.dart
@@ -1,6 +1,8 @@
 export 'src/android_object_mirrors/activity.dart';
 export 'src/android_object_mirrors/activity_compat.dart';
 export 'src/android_object_mirrors/manifest.dart';
+export 'src/extensions.dart';
+export 'src/missing_android_activity_exception.dart';
 
 export 'src/android.dart';
 export 'src/permission_handler_android.dart';

--- a/permission_handler_android/lib/src/android_object_mirrors/activity_compat.dart
+++ b/permission_handler_android/lib/src/android_object_mirrors/activity_compat.dart
@@ -7,6 +7,8 @@ import 'activity.dart';
 ///
 /// See https://developer.android.com/reference/androidx/core/app/ActivityCompat.
 class ActivityCompat {
+  const ActivityCompat._();
+
   static ActivityCompatHostApiImpl _api = ActivityCompatHostApiImpl();
 
   @visibleForTesting
@@ -18,6 +20,17 @@ class ActivityCompat {
     String permission,
   ) {
     return _api.shouldShowRequestPermissionRationaleFromInstance(
+      activity,
+      permission,
+    );
+  }
+
+  /// Gets whether the app has been granted the given permission.
+  static Future<int> checkSelfPermission(
+    Activity activity,
+    String permission,
+  ) {
+    return _api.checkSelfPermissionFromInstance(
       activity,
       permission,
     );

--- a/permission_handler_android/lib/src/android_object_mirrors/package_manager.dart
+++ b/permission_handler_android/lib/src/android_object_mirrors/package_manager.dart
@@ -1,0 +1,18 @@
+/// Class for retrieving various kinds of information related to the application
+/// packages that are currently installed on the device. You can find this class
+/// through Context#getPackageManager.
+///
+/// See https://developer.android.com/reference/android/content/pm/PackageManager.
+class PackageManager {
+  const PackageManager._();
+
+  /// Permission check result: this is returned by checkPermission(String, String) if the permission has not been granted to the given package.
+  ///
+  /// Constant Value: -1 (0xffffffff)
+  static const int permissionDenied = -1;
+
+  /// Permission check result: this is returned by checkPermission(String, String) if the permission has been granted to the given package.
+  ///
+  /// Constant Value: 0 (0x00000000)
+  static const int permissionGranted = 0;
+}

--- a/permission_handler_android/lib/src/android_permission_handler_api_impls.dart
+++ b/permission_handler_android/lib/src/android_permission_handler_api_impls.dart
@@ -35,6 +35,19 @@ class ActivityCompatHostApiImpl extends ActivityCompatHostApi {
       permission,
     );
   }
+
+  /// Determine whether you have been granted a particular permission.
+  Future<int> checkSelfPermissionFromInstance(
+    Activity activity,
+    String permission,
+  ) async {
+    final String activityInstanceId = instanceManager.getIdentifier(activity)!;
+
+    return checkSelfPermission(
+      activityInstanceId,
+      permission,
+    );
+  }
 }
 
 /// Flutter API implementation of Activity.

--- a/permission_handler_android/lib/src/extensions.dart
+++ b/permission_handler_android/lib/src/extensions.dart
@@ -1,0 +1,28 @@
+import 'package:permission_handler_platform_interface/permission_handler_platform_interface.dart';
+
+import 'android_object_mirrors/manifest.dart';
+
+/// An extension on [Permission] that provides a [manifestStrings] getter.
+extension ManifestStringExtension on Permission {
+  /// Returns the matching Manifest.permission strings for this permission.
+  ///
+  /// TODO(jweener): translate all permissions that will be universally
+  /// available.
+  List<String> get manifestStrings {
+    // ignore: deprecated_member_use
+    if (this == Permission.calendarFullAccess || this == Permission.calendar) {
+      return [
+        Manifest.permission.readCalendar,
+        Manifest.permission.writeCalendar,
+      ];
+    } else if (this == Permission.calendarWriteOnly) {
+      return [Manifest.permission.writeCalendar];
+    } else if (this == Permission.camera) {
+      return [Manifest.permission.camera];
+    }
+
+    throw UnimplementedError(
+      'There is no matching Manifest.permission string for $this',
+    );
+  }
+}

--- a/permission_handler_android/lib/src/extensions.dart
+++ b/permission_handler_android/lib/src/extensions.dart
@@ -3,7 +3,7 @@ import 'package:permission_handler_platform_interface/permission_handler_platfor
 import 'android_object_mirrors/manifest.dart';
 
 /// An extension on [Permission] that provides a [manifestStrings] getter.
-extension ManifestStringExtension on Permission {
+extension PermissionToManifestStrings on Permission {
   /// Returns the matching Manifest.permission strings for this permission.
   ///
   /// TODO(jweener): translate all permissions that will be universally

--- a/permission_handler_android/lib/src/permission_handler.pigeon.dart
+++ b/permission_handler_android/lib/src/permission_handler.pigeon.dart
@@ -26,12 +26,15 @@ class ActivityCompatHostApi {
   static const MessageCodec<Object?> codec = StandardMessageCodec();
 
   /// Gets whether you should show UI with rationale before requesting a permission.
-  Future<bool> shouldShowRequestPermissionRationale(String arg_activityInstanceId, String arg_permission) async {
+  Future<bool> shouldShowRequestPermissionRationale(
+      String arg_activityInstanceId, String arg_permission) async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.permission_handler_android.ActivityCompatHostApi.shouldShowRequestPermissionRationale', codec,
+        'dev.flutter.pigeon.permission_handler_android.ActivityCompatHostApi.shouldShowRequestPermissionRationale',
+        codec,
         binaryMessenger: _binaryMessenger);
     final List<Object?>? replyList =
-        await channel.send(<Object?>[arg_activityInstanceId, arg_permission]) as List<Object?>?;
+        await channel.send(<Object?>[arg_activityInstanceId, arg_permission])
+            as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
         code: 'channel-error',
@@ -54,12 +57,15 @@ class ActivityCompatHostApi {
   }
 
   /// Determine whether you have been granted a particular permission.
-  Future<int> checkSelfPermission(String arg_activityInstanceId, String arg_permission) async {
+  Future<int> checkSelfPermission(
+      String arg_activityInstanceId, String arg_permission) async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.permission_handler_android.ActivityCompatHostApi.checkSelfPermission', codec,
+        'dev.flutter.pigeon.permission_handler_android.ActivityCompatHostApi.checkSelfPermission',
+        codec,
         binaryMessenger: _binaryMessenger);
     final List<Object?>? replyList =
-        await channel.send(<Object?>[arg_activityInstanceId, arg_permission]) as List<Object?>?;
+        await channel.send(<Object?>[arg_activityInstanceId, arg_permission])
+            as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
         code: 'channel-error',
@@ -98,17 +104,19 @@ abstract class ActivityFlutterApi {
   /// Dispose of the Dart instance and remove it from the `InstanceManager`.
   void dispose(String instanceId);
 
-  static void setup(ActivityFlutterApi? api, {BinaryMessenger? binaryMessenger}) {
+  static void setup(ActivityFlutterApi? api,
+      {BinaryMessenger? binaryMessenger}) {
     {
       final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.permission_handler_android.ActivityFlutterApi.create', codec,
+          'dev.flutter.pigeon.permission_handler_android.ActivityFlutterApi.create',
+          codec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         channel.setMessageHandler(null);
       } else {
         channel.setMessageHandler((Object? message) async {
           assert(message != null,
-          'Argument for dev.flutter.pigeon.permission_handler_android.ActivityFlutterApi.create was null.');
+              'Argument for dev.flutter.pigeon.permission_handler_android.ActivityFlutterApi.create was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_instanceId = (args[0] as String?);
           assert(arg_instanceId != null,
@@ -120,14 +128,15 @@ abstract class ActivityFlutterApi {
     }
     {
       final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.permission_handler_android.ActivityFlutterApi.dispose', codec,
+          'dev.flutter.pigeon.permission_handler_android.ActivityFlutterApi.dispose',
+          codec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         channel.setMessageHandler(null);
       } else {
         channel.setMessageHandler((Object? message) async {
           assert(message != null,
-          'Argument for dev.flutter.pigeon.permission_handler_android.ActivityFlutterApi.dispose was null.');
+              'Argument for dev.flutter.pigeon.permission_handler_android.ActivityFlutterApi.dispose was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_instanceId = (args[0] as String?);
           assert(arg_instanceId != null,

--- a/permission_handler_android/lib/src/permission_handler.pigeon.dart
+++ b/permission_handler_android/lib/src/permission_handler.pigeon.dart
@@ -26,15 +26,12 @@ class ActivityCompatHostApi {
   static const MessageCodec<Object?> codec = StandardMessageCodec();
 
   /// Gets whether you should show UI with rationale before requesting a permission.
-  Future<bool> shouldShowRequestPermissionRationale(
-      String arg_activityInstanceId, String arg_permission) async {
+  Future<bool> shouldShowRequestPermissionRationale(String arg_activityInstanceId, String arg_permission) async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.permission_handler_android.ActivityCompatHostApi.shouldShowRequestPermissionRationale',
-        codec,
+        'dev.flutter.pigeon.permission_handler_android.ActivityCompatHostApi.shouldShowRequestPermissionRationale', codec,
         binaryMessenger: _binaryMessenger);
     final List<Object?>? replyList =
-        await channel.send(<Object?>[arg_activityInstanceId, arg_permission])
-            as List<Object?>?;
+        await channel.send(<Object?>[arg_activityInstanceId, arg_permission]) as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
         code: 'channel-error',
@@ -55,6 +52,34 @@ class ActivityCompatHostApi {
       return (replyList[0] as bool?)!;
     }
   }
+
+  /// Determine whether you have been granted a particular permission.
+  Future<int> checkSelfPermission(String arg_activityInstanceId, String arg_permission) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.permission_handler_android.ActivityCompatHostApi.checkSelfPermission', codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList =
+        await channel.send(<Object?>[arg_activityInstanceId, arg_permission]) as List<Object?>?;
+    if (replyList == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyList.length > 1) {
+      throw PlatformException(
+        code: replyList[0]! as String,
+        message: replyList[1] as String?,
+        details: replyList[2],
+      );
+    } else if (replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (replyList[0] as int?)!;
+    }
+  }
 }
 
 /// Flutter API for `Activity`.
@@ -73,19 +98,17 @@ abstract class ActivityFlutterApi {
   /// Dispose of the Dart instance and remove it from the `InstanceManager`.
   void dispose(String instanceId);
 
-  static void setup(ActivityFlutterApi? api,
-      {BinaryMessenger? binaryMessenger}) {
+  static void setup(ActivityFlutterApi? api, {BinaryMessenger? binaryMessenger}) {
     {
       final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.permission_handler_android.ActivityFlutterApi.create',
-          codec,
+          'dev.flutter.pigeon.permission_handler_android.ActivityFlutterApi.create', codec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         channel.setMessageHandler(null);
       } else {
         channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.permission_handler_android.ActivityFlutterApi.create was null.');
+          'Argument for dev.flutter.pigeon.permission_handler_android.ActivityFlutterApi.create was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_instanceId = (args[0] as String?);
           assert(arg_instanceId != null,
@@ -97,15 +120,14 @@ abstract class ActivityFlutterApi {
     }
     {
       final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.permission_handler_android.ActivityFlutterApi.dispose',
-          codec,
+          'dev.flutter.pigeon.permission_handler_android.ActivityFlutterApi.dispose', codec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         channel.setMessageHandler(null);
       } else {
         channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.permission_handler_android.ActivityFlutterApi.dispose was null.');
+          'Argument for dev.flutter.pigeon.permission_handler_android.ActivityFlutterApi.dispose was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_instanceId = (args[0] as String?);
           assert(arg_instanceId != null,

--- a/permission_handler_android/lib/src/permission_handler_android.dart
+++ b/permission_handler_android/lib/src/permission_handler_android.dart
@@ -57,7 +57,7 @@ class PermissionHandlerAndroid extends PermissionHandlerPlatform {
             manifestString,
           );
 
-          final PermissionStatus status = await translateManifestGrantResult(
+          final PermissionStatus status = await grantResultToPermissionStatus(
             _activity!,
             manifestString,
             grantResult,

--- a/permission_handler_android/lib/src/permission_handler_android.dart
+++ b/permission_handler_android/lib/src/permission_handler_android.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/foundation.dart';
+import 'package:permission_handler_android/src/extensions.dart';
+import 'package:permission_handler_android/src/utils.dart';
 import 'package:permission_handler_platform_interface/permission_handler_platform_interface.dart';
 
 import 'android_object_mirrors/activity.dart';
@@ -40,10 +42,33 @@ class PermissionHandlerAndroid extends PermissionHandlerPlatform {
     );
   }
 
-  /// TODO(jweener): implement this method.
+  /// TODO(jweener): handle special permissions.
   @override
-  Future<PermissionStatus> checkPermissionStatus(Permission permission) {
-    return Future(() => PermissionStatus.denied);
+  Future<PermissionStatus> checkPermissionStatus(Permission permission) async {
+    if (_activity == null) {
+      throw const MissingAndroidActivityException();
+    }
+
+    final Iterable<PermissionStatus> statuses = await Future.wait(
+      permission.manifestStrings.map(
+        (String manifestString) async {
+          final int grantResult = await ActivityCompat.checkSelfPermission(
+            _activity!,
+            manifestString,
+          );
+
+          final PermissionStatus status = await translateManifestGrantResult(
+            _activity!,
+            manifestString,
+            grantResult,
+          );
+
+          return status;
+        },
+      ),
+    );
+
+    return statuses.strictest;
   }
 
   /// TODO(jweener): implement this method.
@@ -54,16 +79,24 @@ class PermissionHandlerAndroid extends PermissionHandlerPlatform {
   }
 
   @override
-  Future<bool> shouldShowRequestPermissionRationale(Permission permission) {
+  Future<bool> shouldShowRequestPermissionRationale(
+    Permission permission,
+  ) async {
     if (_activity == null) {
       throw const MissingAndroidActivityException();
     }
 
-    return ActivityCompat.shouldShowRequestPermissionRationale(
-      _activity!,
-      // TODO(jweener): replace with Android manifest name for permission once
-      // they have been ported over.
-      'android.permission.READ_CONTACTS',
+    final Iterable<bool> shouldShowRationales = await Future.wait(
+      permission.manifestStrings.map(
+        (String manifestString) {
+          return ActivityCompat.shouldShowRequestPermissionRationale(
+            _activity!,
+            manifestString,
+          );
+        },
+      ),
     );
+
+    return shouldShowRationales.any((bool shouldShow) => shouldShow);
   }
 }

--- a/permission_handler_android/lib/src/utils.dart
+++ b/permission_handler_android/lib/src/utils.dart
@@ -1,0 +1,110 @@
+import 'package:permission_handler_platform_interface/permission_handler_platform_interface.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'android_object_mirrors/activity.dart';
+import 'android_object_mirrors/activity_compat.dart';
+import 'android_object_mirrors/package_manager.dart';
+
+/// A class that provides methods for setting and getting whether a manifest
+/// permission was denied before.
+class ManifestPersistenceStorage {
+  const ManifestPersistenceStorage._();
+
+  /// Writes to shared preferences that the permission was denied before.
+  static Future<void> setDeniedBefore(String manifestString) async {
+    final sp = await SharedPreferences.getInstance();
+    sp.setBool(manifestString, true);
+  }
+
+  /// Reads from shared preferences if the permission was denied before.
+  static Future<bool> wasDeniedBefore(String manifestString) async {
+    final sp = await SharedPreferences.getInstance();
+    return sp.getBool(manifestString) ?? false;
+  }
+}
+
+/// Returns a [PermissionStatus] for a given manifest permission.
+///
+/// Note: This method has side-effects as it will store whether the permission
+/// was denied before in persistent memory.
+///
+/// When [PackageManager.permissionDenied] is received, we do not know if the
+/// permission was denied permanently. The OS does not tell us whether the
+/// user dismissed the dialog or pressed 'deny'. Therefore, we need a more
+/// sophisticated (read: hacky) approach to determine whether the permission
+/// status is [PermissionStatus.denied] or
+/// [PermissionStatus.permanentlyDenied].
+///
+/// The OS behavior has been researched experimentally and is displayed in the
+/// following diagrams:
+///
+/// **State machine diagram:**
+///
+/// Dismissed
+///    ┌┐
+/// ┌──┘▼─────┐  Granted ┌───────┐
+/// │Not asked├──────────►Granted│
+/// └─┬───────┘          └─▲─────┘
+///   │           Granted  │
+///   │Denied  ┌───────────┘
+///   │        │
+/// ┌─▼────────┴┐        ┌────────────────────────────────┐
+/// │Denied once├────────►Denied twice(permanently denied)│
+/// └──▲┌───────┘ Denied └────────────────────────────────┘
+///    └┘
+/// Dismissed
+///
+/// **Scenario table listing output of
+/// [ActivityCompat.shouldShowRequestPermissionRationale]:**
+///
+/// ┌────────────┬────────────────┬─────────┬───────────────────────────────────┬─────────────────────────┐
+/// │ Scenario # │ Previous state │ Action  │ New state                         │ 'Show rationale' output │
+/// ├────────────┼────────────────┼─────────┼───────────────────────────────────┼─────────────────────────┤
+/// │ 1.         │ Not asked      │ Dismiss │ Not asked                         │ false                   │
+/// │ 2.         │ Not asked      │ Deny    │ Denied once                       │ true                    │
+/// │ 3.         │ Denied once    │ Dismiss │ Denied once                       │ true                    │
+/// │ 4.         │ Denied once    │ Deny    │ Denied twice (permanently denied) │ false                   │
+/// └────────────┴────────────────┴─────────┴───────────────────────────────────┴─────────────────────────┘
+///
+/// To distinguish between scenarios, we can use
+/// [ActivityCompat.shouldShowRequestPermissionRationale]. If it returns true,
+/// we can safely return [PermissionStatus.denied]. To distinguish between
+/// scenarios 1 and 4, however, we need an extra mechanism. We opt to store a
+/// boolean stating whether permission has been requested before. Using a
+/// combination of checking for showing the permission rationale and the
+/// boolean, we can distinguish all scenarios and return the appropriate
+/// permission status.
+///
+/// Changing permissions via the app info screen, so outside of the
+/// application, changes the permission state to 'Granted' if the permission
+/// is allowed, or 'Denied once' if denied. This behavior should not require
+/// any additional logic.
+Future<PermissionStatus> translateManifestGrantResult(
+  Activity activity,
+  String manifestString,
+  int grantResult,
+) async {
+  if (grantResult == PackageManager.permissionGranted) {
+    return PermissionStatus.granted;
+  }
+
+  final bool wasDeniedBefore =
+      await ManifestPersistenceStorage.wasDeniedBefore(manifestString);
+  final bool shouldShowRationale =
+      await ActivityCompat.shouldShowRequestPermissionRationale(
+    activity,
+    manifestString,
+  );
+
+  final bool isDeniedNow =
+      wasDeniedBefore ? !shouldShowRationale : shouldShowRationale;
+
+  if (!wasDeniedBefore && isDeniedNow) {
+    ManifestPersistenceStorage.setDeniedBefore(manifestString);
+  }
+
+  if (wasDeniedBefore && isDeniedNow) {
+    return PermissionStatus.permanentlyDenied;
+  }
+  return PermissionStatus.denied;
+}

--- a/permission_handler_android/lib/src/utils.dart
+++ b/permission_handler_android/lib/src/utils.dart
@@ -7,8 +7,8 @@ import 'android_object_mirrors/package_manager.dart';
 
 /// A class that provides methods for setting and getting whether a manifest
 /// permission was denied before.
-class ManifestPersistenceStorage {
-  const ManifestPersistenceStorage._();
+class ManifestPersistentStorage {
+  const ManifestPersistentStorage._();
 
   /// Writes to shared preferences that the permission was denied before.
   static Future<void> setDeniedBefore(String manifestString) async {
@@ -75,11 +75,11 @@ class ManifestPersistenceStorage {
 /// boolean, we can distinguish all scenarios and return the appropriate
 /// permission status.
 ///
-/// Changing permissions via the app info screen, so outside of the
-/// application, changes the permission state to 'Granted' if the permission
-/// is allowed, or 'Denied once' if denied. This behavior should not require
-/// any additional logic.
-Future<PermissionStatus> translateManifestGrantResult(
+/// Changing permissions via the app info screen (so outside of the application)
+/// changes the permission state to 'Granted' if the permission is allowed, or
+/// 'Denied once' if denied. This behavior should not require any additional
+/// logic.
+Future<PermissionStatus> grantResultToPermissionStatus(
   Activity activity,
   String manifestString,
   int grantResult,
@@ -89,7 +89,7 @@ Future<PermissionStatus> translateManifestGrantResult(
   }
 
   final bool wasDeniedBefore =
-      await ManifestPersistenceStorage.wasDeniedBefore(manifestString);
+      await ManifestPersistentStorage.wasDeniedBefore(manifestString);
   final bool shouldShowRationale =
       await ActivityCompat.shouldShowRequestPermissionRationale(
     activity,
@@ -100,7 +100,7 @@ Future<PermissionStatus> translateManifestGrantResult(
       wasDeniedBefore ? !shouldShowRationale : shouldShowRationale;
 
   if (!wasDeniedBefore && isDeniedNow) {
-    ManifestPersistenceStorage.setDeniedBefore(manifestString);
+    ManifestPersistentStorage.setDeniedBefore(manifestString);
   }
 
   if (wasDeniedBefore && isDeniedNow) {

--- a/permission_handler_android/pigeons/android_permission_handler.dart
+++ b/permission_handler_android/pigeons/android_permission_handler.dart
@@ -31,6 +31,12 @@ abstract class ActivityCompatHostApi {
     String activityInstanceId,
     String permission,
   );
+
+  /// Determine whether you have been granted a particular permission.
+  int checkSelfPermission(
+    String activityInstanceId,
+    String permission,
+  );
 }
 
 /// Flutter API for `Activity`.

--- a/permission_handler_android/pubspec.yaml
+++ b/permission_handler_android/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   flutter_instance_manager:
     path: ../../flutter_instance_manager
   permission_handler_platform_interface: ^4.0.0
+  shared_preferences: ^2.2.2
 
 dev_dependencies:
   flutter_lints: ^1.0.4

--- a/permission_handler_android/test/activity_compat_test.dart
+++ b/permission_handler_android/test/activity_compat_test.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_instance_manager/flutter_instance_manager.dart';
+import 'package:flutter_instance_manager/test/test_instance_manager.pigeon.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:permission_handler_android/permission_handler_android.dart';
+import 'package:permission_handler_android/src/android_object_mirrors/package_manager.dart';
+import 'package:permission_handler_android/src/android_permission_handler_api_impls.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late List<List<Object?>> requestLog;
+  late final MockTestInstanceManagerHostApi mockInstanceManagerHostApi;
+
+  setUpAll(() {
+    mockInstanceManagerHostApi = MockTestInstanceManagerHostApi();
+    TestInstanceManagerHostApi.setup(mockInstanceManagerHostApi);
+  });
+
+  setUp(() {
+    requestLog = <List<Object?>>[];
+  });
+
+  tearDown(() {
+    TestInstanceManagerHostApi.setup(null);
+  });
+
+  group('shouldShowRationale', () {
+    setUpAll(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMessageHandler(
+        'dev.flutter.pigeon.permission_handler_android.ActivityCompatHostApi.shouldShowRequestPermissionRationale',
+        (ByteData? message) async {
+          const MessageCodec codec = StandardMessageCodec();
+
+          final List<Object?> request = codec.decodeMessage(message);
+          requestLog.add(request);
+
+          final response = [true];
+          return codec.encodeMessage(response);
+        },
+      );
+    });
+
+    test('returns properly', () async {
+      // > Arrange
+      final instanceManager = InstanceManager(
+        onWeakReferenceRemoved: (_) {},
+      );
+      ActivityCompat.api = ActivityCompatHostApiImpl(
+        instanceManager: instanceManager,
+      );
+      final activity = Activity.detached();
+      instanceManager.addHostCreatedInstance(
+        activity,
+        'activity_instance_id',
+      );
+
+      // > Act
+      final shouldShowRequestPermissionRationale =
+          await ActivityCompat.shouldShowRequestPermissionRationale(
+        activity,
+        Manifest.permission.readCalendar,
+      );
+
+      // > Assert
+      expect(
+        requestLog,
+        [
+          [
+            'activity_instance_id',
+            'android.permission.READ_CALENDAR',
+          ],
+        ],
+      );
+      expect(shouldShowRequestPermissionRationale, isTrue);
+    });
+  });
+
+  group('checkPermissionStatus', () {
+    setUpAll(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMessageHandler(
+        'dev.flutter.pigeon.permission_handler_android.ActivityCompatHostApi.checkSelfPermission',
+        (ByteData? message) async {
+          const MessageCodec codec = StandardMessageCodec();
+
+          final List<Object?> request = codec.decodeMessage(message);
+          requestLog.add(request);
+
+          final response = [PackageManager.permissionGranted];
+          return codec.encodeMessage(response);
+        },
+      );
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMessageHandler(
+        'dev.flutter.pigeon.permission_handler_android.ActivityCompatHostApi.shouldShowRequestPermissionRationale',
+        (ByteData? message) async {
+          const MessageCodec codec = StandardMessageCodec();
+
+          final response = [true];
+          return codec.encodeMessage(response);
+        },
+      );
+    });
+
+    test('returns properly', () async {
+      // > Arrange
+      final instanceManager = InstanceManager(
+        onWeakReferenceRemoved: (_) {},
+      );
+      ActivityCompat.api = ActivityCompatHostApiImpl(
+        instanceManager: instanceManager,
+      );
+      final activity = Activity.detached();
+      instanceManager.addHostCreatedInstance(
+        activity,
+        'activity_instance_id',
+      );
+
+      SharedPreferences.setMockInitialValues({
+        Manifest.permission.readCalendar: true,
+      });
+
+      // > Act
+      final permissionStatus = await ActivityCompat.checkSelfPermission(
+        activity,
+        Manifest.permission.readCalendar,
+      );
+
+      // > Assert
+      expect(
+        requestLog,
+        [
+          [
+            'activity_instance_id',
+            'android.permission.READ_CALENDAR',
+          ],
+        ],
+      );
+      expect(permissionStatus, PackageManager.permissionGranted);
+    });
+  });
+}

--- a/permission_handler_android/test/permission_handler_test.dart
+++ b/permission_handler_android/test/permission_handler_test.dart
@@ -5,9 +5,10 @@ import 'package:flutter_instance_manager/flutter_instance_manager.dart';
 import 'package:flutter_instance_manager/test/test_instance_manager.pigeon.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:permission_handler_android/permission_handler_android.dart';
+import 'package:permission_handler_android/src/android_object_mirrors/package_manager.dart';
 import 'package:permission_handler_android/src/android_permission_handler_api_impls.dart';
-import 'package:permission_handler_android/src/missing_android_activity_exception.dart';
 import 'package:permission_handler_platform_interface/permission_handler_platform_interface.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -105,8 +106,9 @@ void main() {
         final permissionHandler = PermissionHandlerAndroid();
 
         // > Act
-        shouldShowRequestPermissionRationale() async => await permissionHandler
-            .shouldShowRequestPermissionRationale(Permission.contacts);
+        shouldShowRequestPermissionRationale() async =>
+            await permissionHandler.shouldShowRequestPermissionRationale(
+                Permission.calendarFullAccess);
 
         // > Assert
         expect(
@@ -133,8 +135,9 @@ void main() {
         permissionHandler.activity = activity;
 
         // > Act
-        final shouldShowRequestPermissionRationale = await permissionHandler
-            .shouldShowRequestPermissionRationale(Permission.contacts);
+        final shouldShowRequestPermissionRationale =
+            await permissionHandler.shouldShowRequestPermissionRationale(
+                Permission.calendarFullAccess);
 
         // > Assert
         expect(
@@ -142,11 +145,116 @@ void main() {
           [
             [
               'activity_instance_id',
-              'android.permission.READ_CONTACTS',
+              'android.permission.READ_CALENDAR',
+            ],
+            [
+              'activity_instance_id',
+              'android.permission.WRITE_CALENDAR',
             ],
           ],
         );
         expect(shouldShowRequestPermissionRationale, isTrue);
+      });
+    });
+
+    group('checkPermissionStatus', () {
+      setUpAll(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMessageHandler(
+          'dev.flutter.pigeon.permission_handler_android.ActivityCompatHostApi.checkSelfPermission',
+          (ByteData? message) async {
+            const MessageCodec codec = StandardMessageCodec();
+
+            final List<Object?> request = codec.decodeMessage(message);
+            requestLog.add(request);
+
+            final response = [PackageManager.permissionGranted];
+            return codec.encodeMessage(response);
+          },
+        );
+
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMessageHandler(
+          'dev.flutter.pigeon.permission_handler_android.ActivityCompatHostApi.shouldShowRequestPermissionRationale',
+          (ByteData? message) async {
+            const MessageCodec codec = StandardMessageCodec();
+
+            final response = [true];
+            return codec.encodeMessage(response);
+          },
+        );
+      });
+
+      test(
+          'throws `MissingAndroidActivityException` if no activity is attached',
+          () async {
+        // > Arrange
+        final instanceManager = InstanceManager(
+          onWeakReferenceRemoved: (_) {},
+        );
+        ActivityCompat.api = ActivityCompatHostApiImpl(
+          instanceManager: instanceManager,
+        );
+
+        final activity = Activity.detached();
+        instanceManager.addHostCreatedInstance(
+          activity,
+          'activity_instance_id',
+        );
+
+        final permissionHandler = PermissionHandlerAndroid();
+
+        // > Act
+        checkPermissionStatus() async => await permissionHandler
+            .checkPermissionStatus(Permission.calendarFullAccess);
+
+        // > Assert
+        expect(
+          checkPermissionStatus(),
+          throwsA(isA<MissingAndroidActivityException>()),
+        );
+      });
+
+      test('returns properly', () async {
+        // > Arrange
+        final instanceManager = InstanceManager(
+          onWeakReferenceRemoved: (_) {},
+        );
+        ActivityCompat.api = ActivityCompatHostApiImpl(
+          instanceManager: instanceManager,
+        );
+        final activity = Activity.detached();
+        instanceManager.addHostCreatedInstance(
+          activity,
+          'activity_instance_id',
+        );
+
+        final permissionHandler = PermissionHandlerAndroid();
+        permissionHandler.activity = activity;
+        SharedPreferences.setMockInitialValues({
+          Manifest.permission.readCalendar: true,
+          Manifest.permission.writeCalendar: true,
+        });
+
+        // > Act
+        final permissionStatus = await permissionHandler
+            .checkPermissionStatus(Permission.calendarFullAccess);
+
+        // > Assert
+        expect(
+          requestLog,
+          [
+            [
+              'activity_instance_id',
+              'android.permission.READ_CALENDAR',
+            ],
+            [
+              'activity_instance_id',
+              'android.permission.WRITE_CALENDAR',
+            ],
+          ],
+        );
+        expect(permissionStatus, PermissionStatus.granted);
       });
     });
   });

--- a/permission_handler_android/test/test_permission_handler.pigeon.dart
+++ b/permission_handler_android/test/test_permission_handler.pigeon.dart
@@ -18,30 +18,26 @@ import 'package:permission_handler_android/src/permission_handler.pigeon.dart';
 ///
 /// See https://developer.android.com/reference/androidx/core/app/ActivityCompat.
 abstract class ActivityCompatTestHostApi {
-  static TestDefaultBinaryMessengerBinding? get _testBinaryMessengerBinding =>
-      TestDefaultBinaryMessengerBinding.instance;
+  static TestDefaultBinaryMessengerBinding? get _testBinaryMessengerBinding => TestDefaultBinaryMessengerBinding.instance;
   static const MessageCodec<Object?> codec = StandardMessageCodec();
 
   /// Gets whether you should show UI with rationale before requesting a permission.
-  bool shouldShowRequestPermissionRationale(
-      String activityInstanceId, String permission);
+  bool shouldShowRequestPermissionRationale(String activityInstanceId, String permission);
 
-  static void setup(ActivityCompatTestHostApi? api,
-      {BinaryMessenger? binaryMessenger}) {
+  /// Determine whether you have been granted a particular permission.
+  int checkSelfPermission(String activityInstanceId, String permission);
+
+  static void setup(ActivityCompatTestHostApi? api, {BinaryMessenger? binaryMessenger}) {
     {
       final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.permission_handler_android.ActivityCompatHostApi.shouldShowRequestPermissionRationale',
-          codec,
+          'dev.flutter.pigeon.permission_handler_android.ActivityCompatHostApi.shouldShowRequestPermissionRationale', codec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger
-            .setMockDecodedMessageHandler<Object?>(channel, null);
+        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, null);
       } else {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger
-            .setMockDecodedMessageHandler<Object?>(channel,
-                (Object? message) async {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, (Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.permission_handler_android.ActivityCompatHostApi.shouldShowRequestPermissionRationale was null.');
+          'Argument for dev.flutter.pigeon.permission_handler_android.ActivityCompatHostApi.shouldShowRequestPermissionRationale was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_activityInstanceId = (args[0] as String?);
           assert(arg_activityInstanceId != null,
@@ -49,8 +45,29 @@ abstract class ActivityCompatTestHostApi {
           final String? arg_permission = (args[1] as String?);
           assert(arg_permission != null,
               'Argument for dev.flutter.pigeon.permission_handler_android.ActivityCompatHostApi.shouldShowRequestPermissionRationale was null, expected non-null String.');
-          final bool output = api.shouldShowRequestPermissionRationale(
-              arg_activityInstanceId!, arg_permission!);
+          final bool output = api.shouldShowRequestPermissionRationale(arg_activityInstanceId!, arg_permission!);
+          return <Object?>[output];
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.ActivityCompatHostApi.checkSelfPermission', codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, (Object? message) async {
+          assert(message != null,
+          'Argument for dev.flutter.pigeon.permission_handler_android.ActivityCompatHostApi.checkSelfPermission was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_activityInstanceId = (args[0] as String?);
+          assert(arg_activityInstanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.ActivityCompatHostApi.checkSelfPermission was null, expected non-null String.');
+          final String? arg_permission = (args[1] as String?);
+          assert(arg_permission != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.ActivityCompatHostApi.checkSelfPermission was null, expected non-null String.');
+          final int output = api.checkSelfPermission(arg_activityInstanceId!, arg_permission!);
           return <Object?>[output];
         });
       }

--- a/permission_handler_android/test/test_permission_handler.pigeon.dart
+++ b/permission_handler_android/test/test_permission_handler.pigeon.dart
@@ -18,26 +18,33 @@ import 'package:permission_handler_android/src/permission_handler.pigeon.dart';
 ///
 /// See https://developer.android.com/reference/androidx/core/app/ActivityCompat.
 abstract class ActivityCompatTestHostApi {
-  static TestDefaultBinaryMessengerBinding? get _testBinaryMessengerBinding => TestDefaultBinaryMessengerBinding.instance;
+  static TestDefaultBinaryMessengerBinding? get _testBinaryMessengerBinding =>
+      TestDefaultBinaryMessengerBinding.instance;
   static const MessageCodec<Object?> codec = StandardMessageCodec();
 
   /// Gets whether you should show UI with rationale before requesting a permission.
-  bool shouldShowRequestPermissionRationale(String activityInstanceId, String permission);
+  bool shouldShowRequestPermissionRationale(
+      String activityInstanceId, String permission);
 
   /// Determine whether you have been granted a particular permission.
   int checkSelfPermission(String activityInstanceId, String permission);
 
-  static void setup(ActivityCompatTestHostApi? api, {BinaryMessenger? binaryMessenger}) {
+  static void setup(ActivityCompatTestHostApi? api,
+      {BinaryMessenger? binaryMessenger}) {
     {
       final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.permission_handler_android.ActivityCompatHostApi.shouldShowRequestPermissionRationale', codec,
+          'dev.flutter.pigeon.permission_handler_android.ActivityCompatHostApi.shouldShowRequestPermissionRationale',
+          codec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, null);
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel, null);
       } else {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, (Object? message) async {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel,
+                (Object? message) async {
           assert(message != null,
-          'Argument for dev.flutter.pigeon.permission_handler_android.ActivityCompatHostApi.shouldShowRequestPermissionRationale was null.');
+              'Argument for dev.flutter.pigeon.permission_handler_android.ActivityCompatHostApi.shouldShowRequestPermissionRationale was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_activityInstanceId = (args[0] as String?);
           assert(arg_activityInstanceId != null,
@@ -45,21 +52,26 @@ abstract class ActivityCompatTestHostApi {
           final String? arg_permission = (args[1] as String?);
           assert(arg_permission != null,
               'Argument for dev.flutter.pigeon.permission_handler_android.ActivityCompatHostApi.shouldShowRequestPermissionRationale was null, expected non-null String.');
-          final bool output = api.shouldShowRequestPermissionRationale(arg_activityInstanceId!, arg_permission!);
+          final bool output = api.shouldShowRequestPermissionRationale(
+              arg_activityInstanceId!, arg_permission!);
           return <Object?>[output];
         });
       }
     }
     {
       final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.permission_handler_android.ActivityCompatHostApi.checkSelfPermission', codec,
+          'dev.flutter.pigeon.permission_handler_android.ActivityCompatHostApi.checkSelfPermission',
+          codec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, null);
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel, null);
       } else {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, (Object? message) async {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel,
+                (Object? message) async {
           assert(message != null,
-          'Argument for dev.flutter.pigeon.permission_handler_android.ActivityCompatHostApi.checkSelfPermission was null.');
+              'Argument for dev.flutter.pigeon.permission_handler_android.ActivityCompatHostApi.checkSelfPermission was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_activityInstanceId = (args[0] as String?);
           assert(arg_activityInstanceId != null,
@@ -67,7 +79,8 @@ abstract class ActivityCompatTestHostApi {
           final String? arg_permission = (args[1] as String?);
           assert(arg_permission != null,
               'Argument for dev.flutter.pigeon.permission_handler_android.ActivityCompatHostApi.checkSelfPermission was null, expected non-null String.');
-          final int output = api.checkSelfPermission(arg_activityInstanceId!, arg_permission!);
+          final int output =
+              api.checkSelfPermission(arg_activityInstanceId!, arg_permission!);
           return <Object?>[output];
         });
       }

--- a/permission_handler_platform_interface/lib/src/permission_status.dart
+++ b/permission_handler_platform_interface/lib/src/permission_status.dart
@@ -141,3 +141,19 @@ extension FuturePermissionStatusGetters on Future<PermissionStatus> {
   /// *Only supported on iOS.*
   Future<bool> get isProvisional async => (await this).isProvisional;
 }
+
+/// An extension on the [Iterable] of [PermissionStatus] that provides a method
+/// to get the [strictest] status.
+extension StrictestPermissionInIterable on Iterable<PermissionStatus> {
+  /// Returns the strictest [PermissionStatus] in this iterable.
+  ///
+  /// TODO(jweener): consider other values for [PermissionStatus].
+  PermissionStatus get strictest {
+    if (contains(PermissionStatus.permanentlyDenied)) {
+      return PermissionStatus.permanentlyDenied;
+    } else if (contains(PermissionStatus.denied)) {
+      return PermissionStatus.denied;
+    }
+    return PermissionStatus.granted;
+  }
+}

--- a/permission_handler_platform_interface/test/src/permission_status_test.dart
+++ b/permission_handler_platform_interface/test/src/permission_status_test.dart
@@ -94,5 +94,17 @@ void main() {
     });
   });
 
-  test('test', () {});
+  group('StrictestPermissionInIterable', () {
+    test('Getter for strictest should return the strictest status', () {
+      final statuses = [
+        PermissionStatus.granted,
+        PermissionStatus.denied,
+        PermissionStatus.permanentlyDenied,
+      ];
+
+      final strictestStatus = statuses.strictest;
+
+      expect(strictestStatus, PermissionStatus.permanentlyDenied);
+    });
+  });
 }


### PR DESCRIPTION
Implements `checkPermissionStatus` for normal permissions.

This PR also includes:
- Clone of `PackageManager`
- Mapping of package `Permission`s to a list of Android permissions as listed in the manifest
- Dart implementation to determine the strictest `PermissionStatus`

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
