### PR TITLE
Refactor: Port `PackageManager.canRequestPackageInstalls` (Android)

### DIFF
--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ActivityHostApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ActivityHostApiImpl.java
@@ -3,6 +3,7 @@ package com.baseflow.permissionhandler;
 import android.app.Activity;
 import android.app.AlarmManager;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.os.PowerManager;
 
 import androidx.annotation.NonNull;
@@ -59,6 +60,8 @@ public class ActivityHostApiImpl implements
 
     private final AlarmManagerFlutterApiImpl alarmManagerFlutterApi;
 
+    private final PackageManagerFlutterApiImpl packageManagerFlutterApi;
+
     /**
      * Callbacks to complete a pending permission request.
      * <p>
@@ -84,11 +87,13 @@ public class ActivityHostApiImpl implements
     public ActivityHostApiImpl(
         @NonNull PowerManagerFlutterApiImpl powerManagerFlutterApi,
         @NonNull AlarmManagerFlutterApiImpl alarmManagerFlutterApi,
+        @NonNull PackageManagerFlutterApiImpl packageManagerFlutterApi,
         @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
-        this.alarmManagerFlutterApi = alarmManagerFlutterApi;
         this.powerManagerFlutterApi = powerManagerFlutterApi;
+        this.alarmManagerFlutterApi = alarmManagerFlutterApi;
+        this.packageManagerFlutterApi = packageManagerFlutterApi;
         this.binaryMessenger = binaryMessenger;
         this.instanceManager = instanceManager;
     }
@@ -248,5 +253,20 @@ public class ActivityHostApiImpl implements
 
         final UUID systemServiceUuid = instanceManager.getIdentifierForStrongReference(systemService);
         return systemServiceUuid.toString();
+    }
+
+    @Override
+    @NonNull public String getPackageManager(
+        @NonNull String instanceId
+    ) {
+        final UUID instanceUuid = UUID.fromString(instanceId);
+        final Activity activity = instanceManager.getInstance(instanceUuid);
+
+        final PackageManager packageManager = activity.getPackageManager();
+
+        packageManagerFlutterApi.create(packageManager);
+
+        final UUID packageManagerUuid = instanceManager.getIdentifierForStrongReference(packageManager);
+        return packageManagerUuid.toString();
     }
 }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ContextHostApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ContextHostApiImpl.java
@@ -3,6 +3,7 @@ package com.baseflow.permissionhandler;
 import android.app.AlarmManager;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.os.PowerManager;
 
 import androidx.annotation.NonNull;
@@ -32,6 +33,8 @@ public class ContextHostApiImpl implements ContextHostApi {
 
     private final AlarmManagerFlutterApiImpl alarmManagerFlutterApi;
 
+    private final PackageManagerFlutterApiImpl packageManagerFlutterApi;
+
     /**
      * Constructs an {@link ContextHostApiImpl}.
      *
@@ -41,11 +44,13 @@ public class ContextHostApiImpl implements ContextHostApi {
     public ContextHostApiImpl(
         @NonNull PowerManagerFlutterApiImpl powerManagerFlutterApi,
         @NonNull AlarmManagerFlutterApiImpl alarmManagerFlutterApi,
+        @NonNull PackageManagerFlutterApiImpl packageManagerFlutterApi,
         @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
         this.powerManagerFlutterApi = powerManagerFlutterApi;
         this.alarmManagerFlutterApi = alarmManagerFlutterApi;
+        this.packageManagerFlutterApi = packageManagerFlutterApi;
         this.binaryMessenger = binaryMessenger;
         this.instanceManager = instanceManager;
     }
@@ -103,5 +108,20 @@ public class ContextHostApiImpl implements ContextHostApi {
 
         final UUID systemServiceUuid = instanceManager.getIdentifierForStrongReference(systemService);
         return systemServiceUuid.toString();
+    }
+
+    @Override
+    @NonNull public String getPackageManager(
+        @NonNull String instanceId
+    ) {
+        final UUID instanceUuid = UUID.fromString(instanceId);
+        final Context context = instanceManager.getInstance(instanceUuid);
+
+        final PackageManager packageManager = context.getPackageManager();
+
+        packageManagerFlutterApi.create(packageManager);
+
+        final UUID packageManagerUuid = instanceManager.getIdentifierForStrongReference(packageManager);
+        return packageManagerUuid.toString();
     }
 }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PackageManagerFlutterApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PackageManagerFlutterApiImpl.java
@@ -1,0 +1,66 @@
+package com.baseflow.permissionhandler;
+
+import android.content.pm.PackageManager;
+
+import androidx.annotation.NonNull;
+
+import com.baseflow.instancemanager.InstanceManager;
+import com.baseflow.permissionhandler.PermissionHandlerPigeon.PackageManagerFlutterApi;
+
+import java.util.UUID;
+
+import io.flutter.plugin.common.BinaryMessenger;
+
+/**
+ * Flutter API implementation for `PackageManager`.
+ *
+ * <p>This class may handle adding native instances that are attached to a Dart instance or passing
+ * arguments of callbacks methods to a Dart instance.
+ */
+public class PackageManagerFlutterApiImpl {
+    // To ease adding additional methods, this value is added prematurely.
+    @SuppressWarnings({"unused", "FieldCanBeLocal"})
+    private final BinaryMessenger binaryMessenger;
+
+    private final InstanceManager instanceManager;
+
+    private final PackageManagerFlutterApi api;
+
+    /**
+     * Constructs a {@link PackageManagerFlutterApiImpl}.
+     *
+     * @param binaryMessenger used to communicate with Dart over asynchronous messages
+     * @param instanceManager maintains instances stored to communicate with attached Dart objects
+     */
+    public PackageManagerFlutterApiImpl(
+        @NonNull BinaryMessenger binaryMessenger,
+        @NonNull InstanceManager instanceManager
+    ) {
+        this.binaryMessenger = binaryMessenger;
+        this.instanceManager = instanceManager;
+        api = new PackageManagerFlutterApi(binaryMessenger);
+    }
+
+    /**
+     * Stores the `PackageManager` instance and notifies Dart to create and store a new
+     * `PackageManager` instance that is attached to this one. If `instance` has already been added,
+     * this method does nothing.
+     */
+    public void create(@NonNull PackageManager instance) {
+        if (!instanceManager.containsInstance(instance)) {
+            final UUID packageManagerInstanceUuid = instanceManager.addHostCreatedInstance(instance);
+            api.create(packageManagerInstanceUuid.toString(), reply -> {});
+        }
+    }
+
+    /**
+     * Disposes of the `PackageManager` instance in the instance manager and notifies Dart to do the
+     * same. If `instance` was already disposed, this method does nothing.
+     */
+    public void dispose(PackageManager instance) {
+        final UUID packageManagerInstanceUuid = instanceManager.getIdentifierForStrongReference(instance);
+        if (packageManagerInstanceUuid != null) {
+            api.dispose(packageManagerInstanceUuid.toString(), reply -> {});
+        }
+    }
+}

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PackageManagerHostApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PackageManagerHostApiImpl.java
@@ -1,0 +1,52 @@
+package com.baseflow.permissionhandler;
+
+import android.content.pm.PackageManager;
+import android.os.Build;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+
+import com.baseflow.instancemanager.InstanceManager;
+import com.baseflow.permissionhandler.PermissionHandlerPigeon.PackageManagerHostApi;
+
+import java.util.UUID;
+
+import io.flutter.plugin.common.BinaryMessenger;
+
+/**
+ * Host API implementation for `PackageManager`.
+ *
+ * <p>This class may handle instantiating and adding native object instances that are attached to a
+ * Dart instance or handle method calls on the associated native class or an instance of the class.
+ */
+public class PackageManagerHostApiImpl implements PackageManagerHostApi {
+    // To ease adding additional methods, this value is added prematurely.
+    @SuppressWarnings({"unused", "FieldCanBeLocal"})
+    private final BinaryMessenger binaryMessenger;
+
+    private final InstanceManager instanceManager;
+
+    /**
+     * Constructs an {@link PackageManagerHostApiImpl}.
+     *
+     * @param binaryMessenger used to communicate with Dart over asynchronous messages
+     * @param instanceManager maintains instances stored to communicate with attached Dart objects
+     */
+    public PackageManagerHostApiImpl(
+        @NonNull BinaryMessenger binaryMessenger,
+        @NonNull InstanceManager instanceManager
+    ) {
+        this.binaryMessenger = binaryMessenger;
+        this.instanceManager = instanceManager;
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    @NonNull
+    @Override
+    public Boolean canRequestPackageInstalls(@NonNull String instanceId) {
+        final UUID instanceUuid = UUID.fromString(instanceId);
+        final PackageManager packageManager = instanceManager.getInstance(instanceUuid);
+
+        return packageManager.canRequestPackageInstalls();
+    }
+}

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPigeon.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPigeon.java
@@ -357,6 +357,13 @@ public class PermissionHandlerPigeon {
      * See https://developer.android.com/reference/android/app/Activity#startActivityForResult(android.content.Intent,%20int).
      */
     void startActivityForResult(@NonNull String instanceId, @NonNull String intentInstanceId, @Nullable Long requestCode, @NonNull Result<ActivityResultPigeon> result);
+    /**
+     * Returns the instance ID of a PackageManager instance to find global package information.
+     *
+     * See https://developer.android.com/reference/android/content/Context#getPackageManager().
+     */
+    @NonNull 
+    String getPackageManager(@NonNull String instanceId);
 
     /** The codec used by ActivityHostApi. */
     static @NonNull MessageCodec<Object> getCodec() {
@@ -550,6 +557,30 @@ public class PermissionHandlerPigeon {
           channel.setMessageHandler(null);
         }
       }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(
+                binaryMessenger, "dev.flutter.pigeon.permission_handler_android.ActivityHostApi.getPackageManager", getCodec());
+        if (api != null) {
+          channel.setMessageHandler(
+              (message, reply) -> {
+                ArrayList<Object> wrapped = new ArrayList<Object>();
+                ArrayList<Object> args = (ArrayList<Object>) message;
+                String instanceIdArg = (String) args.get(0);
+                try {
+                  String output = api.getPackageManager(instanceIdArg);
+                  wrapped.add(0, output);
+                }
+ catch (Throwable exception) {
+                  ArrayList<Object> wrappedError = wrapError(exception);
+                  wrapped = wrappedError;
+                }
+                reply.reply(wrapped);
+              });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
     }
   }
   /**
@@ -641,6 +672,13 @@ public class PermissionHandlerPigeon {
      */
     @NonNull 
     String getSystemService(@NonNull String instanceId, @NonNull String name);
+    /**
+     * Returns the instance ID of a PackageManager instance to find global package information.
+     *
+     * See https://developer.android.com/reference/android/content/Context#getPackageManager().
+     */
+    @NonNull 
+    String getPackageManager(@NonNull String instanceId);
 
     /** The codec used by ContextHostApi. */
     static @NonNull MessageCodec<Object> getCodec() {
@@ -735,6 +773,30 @@ public class PermissionHandlerPigeon {
                 String nameArg = (String) args.get(1);
                 try {
                   String output = api.getSystemService(instanceIdArg, nameArg);
+                  wrapped.add(0, output);
+                }
+ catch (Throwable exception) {
+                  ArrayList<Object> wrappedError = wrapError(exception);
+                  wrapped = wrappedError;
+                }
+                reply.reply(wrapped);
+              });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(
+                binaryMessenger, "dev.flutter.pigeon.permission_handler_android.ContextHostApi.getPackageManager", getCodec());
+        if (api != null) {
+          channel.setMessageHandler(
+              (message, reply) -> {
+                ArrayList<Object> wrapped = new ArrayList<Object>();
+                ArrayList<Object> args = (ArrayList<Object>) message;
+                String instanceIdArg = (String) args.get(0);
+                try {
+                  String output = api.getPackageManager(instanceIdArg);
                   wrapped.add(0, output);
                 }
  catch (Throwable exception) {
@@ -1318,6 +1380,104 @@ public class PermissionHandlerPigeon {
       BasicMessageChannel<Object> channel =
           new BasicMessageChannel<>(
               binaryMessenger, "dev.flutter.pigeon.permission_handler_android.AlarmManagerFlutterApi.dispose", getCodec());
+      channel.send(
+          new ArrayList<Object>(Collections.singletonList(instanceIdArg)),
+          channelReply -> callback.reply(null));
+    }
+  }
+  /**
+   * Host API for `PackageManager`.
+   *
+   * This class may handle instantiating and adding native object instances that
+   * are attached to a Dart instance or handle method calls on the associated
+   * native class or an instance of the class.
+   *
+   * See https://developer.android.com/reference/kotlin/android/content/pm/PackageManager.
+   *
+   * Generated interface from Pigeon that represents a handler of messages from Flutter.
+   */
+  public interface PackageManagerHostApi {
+    /**
+     * Checks whether the calling package is allowed to request package installs through package installer.
+     *
+     * See https://developer.android.com/reference/android/content/pm/PackageManager#canRequestPackageInstalls().
+     */
+    @NonNull 
+    Boolean canRequestPackageInstalls(@NonNull String instanceId);
+
+    /** The codec used by PackageManagerHostApi. */
+    static @NonNull MessageCodec<Object> getCodec() {
+      return new StandardMessageCodec();
+    }
+    /**Sets up an instance of `PackageManagerHostApi` to handle messages through the `binaryMessenger`. */
+    static void setup(@NonNull BinaryMessenger binaryMessenger, @Nullable PackageManagerHostApi api) {
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(
+                binaryMessenger, "dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.canRequestPackageInstalls", getCodec());
+        if (api != null) {
+          channel.setMessageHandler(
+              (message, reply) -> {
+                ArrayList<Object> wrapped = new ArrayList<Object>();
+                ArrayList<Object> args = (ArrayList<Object>) message;
+                String instanceIdArg = (String) args.get(0);
+                try {
+                  Boolean output = api.canRequestPackageInstalls(instanceIdArg);
+                  wrapped.add(0, output);
+                }
+ catch (Throwable exception) {
+                  ArrayList<Object> wrappedError = wrapError(exception);
+                  wrapped = wrappedError;
+                }
+                reply.reply(wrapped);
+              });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+    }
+  }
+  /**
+   * Flutter API for `PackageManager`.
+   *
+   * This class may handle instantiating and adding Dart instances that are
+   * attached to a native instance or receiving callback methods from an
+   * overridden native class.
+   *
+   * See https://developer.android.com/reference/kotlin/android/content/pm/PackageManager.
+   *
+   * Generated class from Pigeon that represents Flutter messages that can be called from Java.
+   */
+  public static class PackageManagerFlutterApi {
+    private final @NonNull BinaryMessenger binaryMessenger;
+
+    public PackageManagerFlutterApi(@NonNull BinaryMessenger argBinaryMessenger) {
+      this.binaryMessenger = argBinaryMessenger;
+    }
+
+    /** Public interface for sending reply. */ 
+    @SuppressWarnings("UnknownNullness")
+    public interface Reply<T> {
+      void reply(T reply);
+    }
+    /** The codec used by PackageManagerFlutterApi. */
+    static @NonNull MessageCodec<Object> getCodec() {
+      return new StandardMessageCodec();
+    }
+    /** Create a new Dart instance and add it to the `InstanceManager`. */
+    public void create(@NonNull String instanceIdArg, @NonNull Reply<Void> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(
+              binaryMessenger, "dev.flutter.pigeon.permission_handler_android.PackageManagerFlutterApi.create", getCodec());
+      channel.send(
+          new ArrayList<Object>(Collections.singletonList(instanceIdArg)),
+          channelReply -> callback.reply(null));
+    }
+    /** Dispose of the Dart instance and remove it from the `InstanceManager`. */
+    public void dispose(@NonNull String instanceIdArg, @NonNull Reply<Void> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(
+              binaryMessenger, "dev.flutter.pigeon.permission_handler_android.PackageManagerFlutterApi.dispose", getCodec());
       channel.send(
           new ArrayList<Object>(Collections.singletonList(instanceIdArg)),
           channelReply -> callback.reply(null));

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
@@ -15,6 +15,7 @@ import com.baseflow.permissionhandler.PermissionHandlerPigeon.AlarmManagerHostAp
 import com.baseflow.permissionhandler.PermissionHandlerPigeon.BuildVersionHostApi;
 import com.baseflow.permissionhandler.PermissionHandlerPigeon.ContextHostApi;
 import com.baseflow.permissionhandler.PermissionHandlerPigeon.IntentHostApi;
+import com.baseflow.permissionhandler.PermissionHandlerPigeon.PackageManagerHostApi;
 import com.baseflow.permissionhandler.PermissionHandlerPigeon.PowerManagerHostApi;
 import com.baseflow.permissionhandler.PermissionHandlerPigeon.UriHostApi;
 
@@ -67,10 +68,15 @@ public final class PermissionHandlerPlugin implements FlutterPlugin, ActivityAwa
         final AlarmManagerHostApi alarmManagerHostApi = new AlarmManagerHostApiImpl(binaryMessenger, instanceManager);
         AlarmManagerHostApi.setup(binaryMessenger, alarmManagerHostApi);
 
+        final PackageManagerFlutterApiImpl packageManagerFlutterApi = new PackageManagerFlutterApiImpl(binaryMessenger, instanceManager);
+        final PackageManagerHostApi packageManagerHostApi = new PackageManagerHostApiImpl(binaryMessenger, instanceManager);
+        PackageManagerHostApi.setup(binaryMessenger, packageManagerHostApi);
+
         activityFlutterApi = new ActivityFlutterApiImpl(binaryMessenger, instanceManager);
         activityHostApi = new ActivityHostApiImpl(
             powerManagerFlutterApi,
             alarmManagerFlutterApi,
+            packageManagerFlutterApi,
             binaryMessenger,
             instanceManager
         );
@@ -80,6 +86,7 @@ public final class PermissionHandlerPlugin implements FlutterPlugin, ActivityAwa
         final ContextHostApiImpl contextHostApi = new ContextHostApiImpl(
             powerManagerFlutterApi,
             alarmManagerFlutterApi,
+            packageManagerFlutterApi,
             binaryMessenger,
             instanceManager
         );

--- a/permission_handler_android/lib/src/android_object_mirrors/activity.dart
+++ b/permission_handler_android/lib/src/android_object_mirrors/activity.dart
@@ -81,9 +81,9 @@ class Activity extends JavaObject {
   /// and
   /// https://developer.android.com/reference/androidx/core/app/ActivityCompat.OnRequestPermissionsResultCallback.
   Future<PermissionRequestResult> requestPermissions(
-    List<String> permissions, [
+    List<String> permissions, {
     int? requestCode,
-  ]) {
+  }) {
     return _hostApi.requestPermissionsFromInstance(
       this,
       permissions,
@@ -116,9 +116,9 @@ class Activity extends JavaObject {
   ///
   /// See https://developer.android.com/reference/android/app/Activity#startActivityForResult(android.content.Intent,%20int).
   Future<ActivityResult> startActivityForResult(
-    Intent intent, [
+    Intent intent, {
     int? requestCode,
-  ]) {
+  }) {
     return _hostApi.startActivityForResultFromInstance(
       this,
       intent,

--- a/permission_handler_android/lib/src/android_object_mirrors/activity.dart
+++ b/permission_handler_android/lib/src/android_object_mirrors/activity.dart
@@ -62,7 +62,7 @@ class Activity extends JavaObject {
     );
   }
 
-  /// Determine whether the application has been granted a particular permission.
+  /// Determines whether the application has been granted a particular permission.
   ///
   /// See https://developer.android.com/reference/android/content/ContextWrapper#checkSelfPermission(java.lang.String).
   Future<int> checkSelfPermission(
@@ -81,9 +81,9 @@ class Activity extends JavaObject {
   /// and
   /// https://developer.android.com/reference/androidx/core/app/ActivityCompat.OnRequestPermissionsResultCallback.
   Future<PermissionRequestResult> requestPermissions(
-    List<String> permissions,
+    List<String> permissions, [
     int? requestCode,
-  ) {
+  ]) {
     return _hostApi.requestPermissionsFromInstance(
       this,
       permissions,
@@ -91,7 +91,7 @@ class Activity extends JavaObject {
     );
   }
 
-  /// Launch a new activity.
+  /// Launches a new activity.
   ///
   /// See https://developer.android.com/reference/android/content/Context#startActivity(android.content.Intent).
   Future<void> startActivity(
@@ -116,9 +116,9 @@ class Activity extends JavaObject {
   ///
   /// See https://developer.android.com/reference/android/app/Activity#startActivityForResult(android.content.Intent,%20int).
   Future<ActivityResult> startActivityForResult(
-    Intent intent,
+    Intent intent, [
     int? requestCode,
-  ) {
+  ]) {
     return _hostApi.startActivityForResultFromInstance(
       this,
       intent,
@@ -126,7 +126,7 @@ class Activity extends JavaObject {
     );
   }
 
-  /// Return the handle to a system-level service by name.
+  /// Returns the handle to a system-level service by name.
   ///
   /// The class of the returned object varies by the requested name.
   ///
@@ -139,6 +139,15 @@ class Activity extends JavaObject {
     return _hostApi.getSystemServiceFromInstance(
       this,
       name,
+    );
+  }
+
+  /// Returns a PackageManager instance to find global package information.
+  ///
+  /// See https://developer.android.com/reference/android/content/Context#getPackageManager().
+  Future<PackageManager> getPackageManager() {
+    return _hostApi.getPackageManagerFromInstance(
+      this,
     );
   }
 }

--- a/permission_handler_android/lib/src/android_object_mirrors/context.dart
+++ b/permission_handler_android/lib/src/android_object_mirrors/context.dart
@@ -38,7 +38,7 @@ class Context extends JavaObject {
   /// receiving intents at a time of your choosing.
   static const String alarmService = 'alarm';
 
-  /// Determine whether the application has been granted a particular permission.
+  /// Determines whether the application has been granted a particular permission.
   ///
   /// See https://developer.android.com/reference/android/content/Context#checkSelfPermission(java.lang.String).
   Future<int> checkSelfPermission(
@@ -50,7 +50,7 @@ class Context extends JavaObject {
     );
   }
 
-  /// Launch a new activity.
+  /// Launches a new activity.
   ///
   /// See https://developer.android.com/reference/android/content/Context#startActivity(android.content.Intent).
   Future<void> startActivity(
@@ -71,7 +71,7 @@ class Context extends JavaObject {
     );
   }
 
-  /// Return the handle to a system-level service by name.
+  /// Returns the handle to a system-level service by name.
   ///
   /// The class of the returned object varies by the requested name.
   ///
@@ -82,6 +82,15 @@ class Context extends JavaObject {
     return _hostApi.getSystemServiceFromInstance(
       this,
       name,
+    );
+  }
+
+  /// Returns a PackageManager instance to find global package information.
+  ///
+  /// See https://developer.android.com/reference/android/content/Context#getPackageManager().
+  Future<PackageManager> getPackageManager() {
+    return _hostApi.getPackageManagerFromInstance(
+      this,
     );
   }
 }

--- a/permission_handler_android/lib/src/android_object_mirrors/package_manager.dart
+++ b/permission_handler_android/lib/src/android_object_mirrors/package_manager.dart
@@ -1,10 +1,26 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_instance_manager/flutter_instance_manager.dart';
+
+import '../android_permission_handler_api_impls.dart';
+
 /// Class for retrieving various kinds of information related to the application
 /// packages that are currently installed on the device. You can find this class
 /// through Context#getPackageManager.
 ///
 /// See https://developer.android.com/reference/android/content/pm/PackageManager.
-class PackageManager {
-  const PackageManager._();
+class PackageManager extends JavaObject {
+  /// Instantiates an [PackageManager] without creating and attaching to an
+  /// instance of the associated native class.
+  PackageManager.detached({
+    BinaryMessenger? binaryMessenger,
+    InstanceManager? instanceManager,
+  })  : _hostApi = PackageManagerHostApiImpl(
+          binaryMessenger: binaryMessenger,
+          instanceManager: instanceManager,
+        ),
+        super.detached();
+
+  final PackageManagerHostApiImpl _hostApi;
 
   /// Permission check result: this is returned by checkPermission(String, String) if the permission has not been granted to the given package.
   ///
@@ -15,4 +31,11 @@ class PackageManager {
   ///
   /// Constant Value: 0 (0x00000000)
   static const int permissionGranted = 0;
+
+  /// Checks whether the calling package is allowed to request package installs through package installer.
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager#canRequestPackageInstalls().
+  Future<bool> canRequestPackageInstalls() {
+    return _hostApi.canRequestPackageInstallsFromInstance(this);
+  }
 }

--- a/permission_handler_android/lib/src/permission_handler.pigeon.dart
+++ b/permission_handler_android/lib/src/permission_handler.pigeon.dart
@@ -348,6 +348,37 @@ class ActivityHostApi {
       return (replyList[0] as ActivityResultPigeon?)!;
     }
   }
+
+  /// Returns the instance ID of a PackageManager instance to find global package information.
+  ///
+  /// See https://developer.android.com/reference/android/content/Context#getPackageManager().
+  Future<String> getPackageManager(String arg_instanceId) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.permission_handler_android.ActivityHostApi.getPackageManager',
+        codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList =
+        await channel.send(<Object?>[arg_instanceId]) as List<Object?>?;
+    if (replyList == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyList.length > 1) {
+      throw PlatformException(
+        code: replyList[0]! as String,
+        message: replyList[1] as String?,
+        details: replyList[2],
+      );
+    } else if (replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (replyList[0] as String?)!;
+    }
+  }
 }
 
 /// Flutter API for `Activity`.
@@ -534,6 +565,37 @@ class ContextHostApi {
         binaryMessenger: _binaryMessenger);
     final List<Object?>? replyList = await channel
         .send(<Object?>[arg_instanceId, arg_name]) as List<Object?>?;
+    if (replyList == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyList.length > 1) {
+      throw PlatformException(
+        code: replyList[0]! as String,
+        message: replyList[1] as String?,
+        details: replyList[2],
+      );
+    } else if (replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (replyList[0] as String?)!;
+    }
+  }
+
+  /// Returns the instance ID of a PackageManager instance to find global package information.
+  ///
+  /// See https://developer.android.com/reference/android/content/Context#getPackageManager().
+  Future<String> getPackageManager(String arg_instanceId) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.permission_handler_android.ContextHostApi.getPackageManager',
+        codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList =
+        await channel.send(<Object?>[arg_instanceId]) as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
         code: 'channel-error',
@@ -1123,6 +1185,116 @@ abstract class AlarmManagerFlutterApi {
           final String? arg_instanceId = (args[0] as String?);
           assert(arg_instanceId != null,
               'Argument for dev.flutter.pigeon.permission_handler_android.AlarmManagerFlutterApi.dispose was null, expected non-null String.');
+          api.dispose(arg_instanceId!);
+          return;
+        });
+      }
+    }
+  }
+}
+
+/// Host API for `PackageManager`.
+///
+/// This class may handle instantiating and adding native object instances that
+/// are attached to a Dart instance or handle method calls on the associated
+/// native class or an instance of the class.
+///
+/// See https://developer.android.com/reference/kotlin/android/content/pm/PackageManager.
+class PackageManagerHostApi {
+  /// Constructor for [PackageManagerHostApi].  The [binaryMessenger] named argument is
+  /// available for dependency injection.  If it is left null, the default
+  /// BinaryMessenger will be used which routes to the host platform.
+  PackageManagerHostApi({BinaryMessenger? binaryMessenger})
+      : _binaryMessenger = binaryMessenger;
+  final BinaryMessenger? _binaryMessenger;
+
+  static const MessageCodec<Object?> codec = StandardMessageCodec();
+
+  /// Checks whether the calling package is allowed to request package installs through package installer.
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager#canRequestPackageInstalls().
+  Future<bool> canRequestPackageInstalls(String arg_instanceId) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.canRequestPackageInstalls',
+        codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList =
+        await channel.send(<Object?>[arg_instanceId]) as List<Object?>?;
+    if (replyList == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyList.length > 1) {
+      throw PlatformException(
+        code: replyList[0]! as String,
+        message: replyList[1] as String?,
+        details: replyList[2],
+      );
+    } else if (replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (replyList[0] as bool?)!;
+    }
+  }
+}
+
+/// Flutter API for `PackageManager`.
+///
+/// This class may handle instantiating and adding Dart instances that are
+/// attached to a native instance or receiving callback methods from an
+/// overridden native class.
+///
+/// See https://developer.android.com/reference/kotlin/android/content/pm/PackageManager.
+abstract class PackageManagerFlutterApi {
+  static const MessageCodec<Object?> codec = StandardMessageCodec();
+
+  /// Create a new Dart instance and add it to the `InstanceManager`.
+  void create(String instanceId);
+
+  /// Dispose of the Dart instance and remove it from the `InstanceManager`.
+  void dispose(String instanceId);
+
+  static void setup(PackageManagerFlutterApi? api,
+      {BinaryMessenger? binaryMessenger}) {
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.PackageManagerFlutterApi.create',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        channel.setMessageHandler(null);
+      } else {
+        channel.setMessageHandler((Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageManagerFlutterApi.create was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_instanceId = (args[0] as String?);
+          assert(arg_instanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageManagerFlutterApi.create was null, expected non-null String.');
+          api.create(arg_instanceId!);
+          return;
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.PackageManagerFlutterApi.dispose',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        channel.setMessageHandler(null);
+      } else {
+        channel.setMessageHandler((Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageManagerFlutterApi.dispose was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_instanceId = (args[0] as String?);
+          assert(arg_instanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageManagerFlutterApi.dispose was null, expected non-null String.');
           api.dispose(arg_instanceId!);
           return;
         });

--- a/permission_handler_android/lib/src/permission_handler_android.dart
+++ b/permission_handler_android/lib/src/permission_handler_android.dart
@@ -109,7 +109,7 @@ class PermissionHandlerAndroid extends PermissionHandlerPlatform {
   }) async {
     final PermissionRequestResult result = await activity.requestPermissions(
       permission.manifestStrings,
-      requestCode,
+      requestCode: requestCode,
     );
 
     final List<String> permissions =
@@ -143,7 +143,7 @@ class PermissionHandlerAndroid extends PermissionHandlerPlatform {
             'package:${await _activityManager.applicationContext.getPackageName()}',
           ),
         ),
-      requestCode,
+      requestCode: requestCode,
     );
   }
 

--- a/permission_handler_android/pigeons/android_permission_handler.dart
+++ b/permission_handler_android/pigeons/android_permission_handler.dart
@@ -121,6 +121,13 @@ abstract class ActivityHostApi {
     String intentInstanceId,
     int? requestCode,
   );
+
+  /// Returns the instance ID of a PackageManager instance to find global package information.
+  ///
+  /// See https://developer.android.com/reference/android/content/Context#getPackageManager().
+  String getPackageManager(
+    String instanceId,
+  );
 }
 
 /// Flutter API for `Activity`.
@@ -181,6 +188,13 @@ abstract class ContextHostApi {
   String getSystemService(
     String instanceId,
     String name,
+  );
+
+  /// Returns the instance ID of a PackageManager instance to find global package information.
+  ///
+  /// See https://developer.android.com/reference/android/content/Context#getPackageManager().
+  String getPackageManager(
+    String instanceId,
   );
 }
 
@@ -370,6 +384,37 @@ abstract class AlarmManagerHostApi {
 /// See https://developer.android.com/reference/android/app/AlarmManager.
 @FlutterApi()
 abstract class AlarmManagerFlutterApi {
+  /// Create a new Dart instance and add it to the `InstanceManager`.
+  void create(String instanceId);
+
+  /// Dispose of the Dart instance and remove it from the `InstanceManager`.
+  void dispose(String instanceId);
+}
+
+/// Host API for `PackageManager`.
+///
+/// This class may handle instantiating and adding native object instances that
+/// are attached to a Dart instance or handle method calls on the associated
+/// native class or an instance of the class.
+///
+/// See https://developer.android.com/reference/kotlin/android/content/pm/PackageManager.
+@HostApi(dartHostTestHandler: 'PackageManagerTestHostApi')
+abstract class PackageManagerHostApi {
+  /// Checks whether the calling package is allowed to request package installs through package installer.
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager#canRequestPackageInstalls().
+  bool canRequestPackageInstalls(String instanceId);
+}
+
+/// Flutter API for `PackageManager`.
+///
+/// This class may handle instantiating and adding Dart instances that are
+/// attached to a native instance or receiving callback methods from an
+/// overridden native class.
+///
+/// See https://developer.android.com/reference/kotlin/android/content/pm/PackageManager.
+@FlutterApi()
+abstract class PackageManagerFlutterApi {
   /// Create a new Dart instance and add it to the `InstanceManager`.
   void create(String instanceId);
 

--- a/permission_handler_android/test/test_permission_handler.pigeon.dart
+++ b/permission_handler_android/test/test_permission_handler.pigeon.dart
@@ -95,6 +95,11 @@ abstract class ActivityTestHostApi {
   Future<ActivityResultPigeon> startActivityForResult(
       String instanceId, String intentInstanceId, int? requestCode);
 
+  /// Returns the instance ID of a PackageManager instance to find global package information.
+  ///
+  /// See https://developer.android.com/reference/android/content/Context#getPackageManager().
+  String getPackageManager(String instanceId);
+
   static void setup(ActivityTestHostApi? api,
       {BinaryMessenger? binaryMessenger}) {
     {
@@ -284,6 +289,29 @@ abstract class ActivityTestHostApi {
         });
       }
     }
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.ActivityHostApi.getPackageManager',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel,
+                (Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.ActivityHostApi.getPackageManager was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_instanceId = (args[0] as String?);
+          assert(arg_instanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.ActivityHostApi.getPackageManager was null, expected non-null String.');
+          final String output = api.getPackageManager(arg_instanceId!);
+          return <Object?>[output];
+        });
+      }
+    }
   }
 }
 
@@ -322,6 +350,11 @@ abstract class ContextTestHostApi {
   ///
   /// See https://developer.android.com/reference/android/content/Context#getSystemService(java.lang.String).
   String getSystemService(String instanceId, String name);
+
+  /// Returns the instance ID of a PackageManager instance to find global package information.
+  ///
+  /// See https://developer.android.com/reference/android/content/Context#getPackageManager().
+  String getPackageManager(String instanceId);
 
   static void setup(ContextTestHostApi? api,
       {BinaryMessenger? binaryMessenger}) {
@@ -424,6 +457,29 @@ abstract class ContextTestHostApi {
               'Argument for dev.flutter.pigeon.permission_handler_android.ContextHostApi.getSystemService was null, expected non-null String.');
           final String output =
               api.getSystemService(arg_instanceId!, arg_name!);
+          return <Object?>[output];
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.ContextHostApi.getPackageManager',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel,
+                (Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.ContextHostApi.getPackageManager was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_instanceId = (args[0] as String?);
+          assert(arg_instanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.ContextHostApi.getPackageManager was null, expected non-null String.');
+          final String output = api.getPackageManager(arg_instanceId!);
           return <Object?>[output];
         });
       }
@@ -825,6 +881,51 @@ abstract class AlarmManagerTestHostApi {
           assert(arg_instanceId != null,
               'Argument for dev.flutter.pigeon.permission_handler_android.AlarmManagerHostApi.canScheduleExactAlarms was null, expected non-null String.');
           final bool output = api.canScheduleExactAlarms(arg_instanceId!);
+          return <Object?>[output];
+        });
+      }
+    }
+  }
+}
+
+/// Host API for `PackageManager`.
+///
+/// This class may handle instantiating and adding native object instances that
+/// are attached to a Dart instance or handle method calls on the associated
+/// native class or an instance of the class.
+///
+/// See https://developer.android.com/reference/kotlin/android/content/pm/PackageManager.
+abstract class PackageManagerTestHostApi {
+  static TestDefaultBinaryMessengerBinding? get _testBinaryMessengerBinding =>
+      TestDefaultBinaryMessengerBinding.instance;
+  static const MessageCodec<Object?> codec = StandardMessageCodec();
+
+  /// Checks whether the calling package is allowed to request package installs through package installer.
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager#canRequestPackageInstalls().
+  bool canRequestPackageInstalls(String instanceId);
+
+  static void setup(PackageManagerTestHostApi? api,
+      {BinaryMessenger? binaryMessenger}) {
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.canRequestPackageInstalls',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel,
+                (Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.canRequestPackageInstalls was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_instanceId = (args[0] as String?);
+          assert(arg_instanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.canRequestPackageInstalls was null, expected non-null String.');
+          final bool output = api.canRequestPackageInstalls(arg_instanceId!);
           return <Object?>[output];
         });
       }


### PR DESCRIPTION
Ports the necessary Android SDK bits for checking whether an application can request package installs.

Closes https://github.com/orgs/Baseflow/projects/9/views/1?pane=issue&itemId=39927253.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `next`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
