### PR TITLE
Refactor: Port `NotificationManager` (Android)

### DIFF
--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ContextHostApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ContextHostApiImpl.java
@@ -1,6 +1,7 @@
 package com.baseflow.permissionhandler;
 
 import android.app.AlarmManager;
+import android.app.NotificationManager;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -35,6 +36,8 @@ public class ContextHostApiImpl implements ContextHostApi {
 
     private final PackageManagerFlutterApiImpl packageManagerFlutterApi;
 
+    private final NotificationManagerFlutterApiImpl notificationManagerFlutterApi;
+
     /**
      * Constructs an {@link ContextHostApiImpl}.
      *
@@ -45,12 +48,14 @@ public class ContextHostApiImpl implements ContextHostApi {
         @NonNull PowerManagerFlutterApiImpl powerManagerFlutterApi,
         @NonNull AlarmManagerFlutterApiImpl alarmManagerFlutterApi,
         @NonNull PackageManagerFlutterApiImpl packageManagerFlutterApi,
+        @NonNull NotificationManagerFlutterApiImpl notificationManagerFlutterApi,
         @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
         this.powerManagerFlutterApi = powerManagerFlutterApi;
         this.alarmManagerFlutterApi = alarmManagerFlutterApi;
         this.packageManagerFlutterApi = packageManagerFlutterApi;
+        this.notificationManagerFlutterApi = notificationManagerFlutterApi;
         this.binaryMessenger = binaryMessenger;
         this.instanceManager = instanceManager;
     }
@@ -104,6 +109,8 @@ public class ContextHostApiImpl implements ContextHostApi {
             powerManagerFlutterApi.create((PowerManager) systemService);
         } else if (systemService instanceof AlarmManager) {
             alarmManagerFlutterApi.create((AlarmManager) systemService);
+        } else if (systemService instanceof NotificationManager) {
+            notificationManagerFlutterApi.create((NotificationManager) systemService);
         }
 
         final UUID systemServiceUuid = instanceManager.getIdentifierForStrongReference(systemService);

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/NotificationManagerFlutterApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/NotificationManagerFlutterApiImpl.java
@@ -1,0 +1,66 @@
+package com.baseflow.permissionhandler;
+
+import android.app.NotificationManager;
+
+import androidx.annotation.NonNull;
+
+import com.baseflow.instancemanager.InstanceManager;
+import com.baseflow.permissionhandler.PermissionHandlerPigeon.NotificationManagerFlutterApi;
+
+import java.util.UUID;
+
+import io.flutter.plugin.common.BinaryMessenger;
+
+/**
+ * Flutter API implementation for `NotificationManager`.
+ *
+ * <p>This class may handle adding native instances that are attached to a Dart instance or passing
+ * arguments of callbacks methods to a Dart instance.
+ */
+public class NotificationManagerFlutterApiImpl {
+    // To ease adding additional methods, this value is added prematurely.
+    @SuppressWarnings({"unused", "FieldCanBeLocal"})
+    private final BinaryMessenger binaryMessenger;
+
+    private final InstanceManager instanceManager;
+
+    private final NotificationManagerFlutterApi api;
+
+    /**
+     * Constructs a {@link NotificationManagerFlutterApiImpl}.
+     *
+     * @param binaryMessenger used to communicate with Dart over asynchronous messages
+     * @param instanceManager maintains instances stored to communicate with attached Dart objects
+     */
+    public NotificationManagerFlutterApiImpl(
+        @NonNull BinaryMessenger binaryMessenger,
+        @NonNull InstanceManager instanceManager
+    ) {
+        this.binaryMessenger = binaryMessenger;
+        this.instanceManager = instanceManager;
+        api = new NotificationManagerFlutterApi(binaryMessenger);
+    }
+
+    /**
+     * Stores the `NotificationManager` instance and notifies Dart to create and store a new `NotificationManager`
+     * instance that is attached to this one. If `instance` has already been added, this method does
+     * nothing.
+     */
+    public void create(@NonNull NotificationManager instance) {
+        if (!instanceManager.containsInstance(instance)) {
+            final UUID notificationManagerInstanceUuid = instanceManager.addHostCreatedInstance(instance);
+            api.create(notificationManagerInstanceUuid.toString(), reply -> {});
+        }
+    }
+
+    /**
+     * Disposes of the `NotificationManager` instance in the instance manager and notifies Dart to do the
+     * same. If `instance` was already disposed, this method does nothing.
+     */
+    public void dispose(NotificationManager instance) {
+        final UUID notificationManagerInstanceUuid = instanceManager.getIdentifierForStrongReference(instance);
+        if (notificationManagerInstanceUuid != null) {
+            api.dispose(notificationManagerInstanceUuid.toString(), reply -> {});
+        }
+    }
+}

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/NotificationManagerHostApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/NotificationManagerHostApiImpl.java
@@ -1,0 +1,67 @@
+package com.baseflow.permissionhandler;
+
+import android.app.NotificationManager;
+import android.os.Build;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+import androidx.core.app.NotificationManagerCompat;
+
+import com.baseflow.instancemanager.InstanceManager;
+import com.baseflow.permissionhandler.PermissionHandlerPigeon.NotificationManagerHostApi;
+
+import java.util.UUID;
+
+import io.flutter.plugin.common.BinaryMessenger;
+
+/**
+ * Host API implementation for `NotificationManager`.
+ *
+ * <p>This class may handle instantiating and adding native object instances that are attached to a
+ * Dart instance or handle method calls on the associated native class or an instance of the class.
+ */
+public class NotificationManagerHostApiImpl implements NotificationManagerHostApi {
+    // To ease adding additional methods, this value is added prematurely.
+    @SuppressWarnings({"unused", "FieldCanBeLocal"})
+    private final BinaryMessenger binaryMessenger;
+
+    private final InstanceManager instanceManager;
+
+    /**
+     * Constructs an {@link NotificationManagerHostApiImpl}.
+     *
+     * @param binaryMessenger used to communicate with Dart over asynchronous messages
+     * @param instanceManager maintains instances stored to communicate with attached Dart objects
+     */
+    public NotificationManagerHostApiImpl(
+        @NonNull BinaryMessenger binaryMessenger,
+        @NonNull InstanceManager instanceManager
+    ) {
+        this.binaryMessenger = binaryMessenger;
+        this.instanceManager = instanceManager;
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.M)
+    @NonNull
+    @Override
+    public Boolean isNotificationPolicyAccessGranted(
+        @NonNull String instanceId
+    ) {
+        final UUID instanceUuid = UUID.fromString(instanceId);
+        final NotificationManager notificationManager = instanceManager.getInstance(instanceUuid);
+
+        return notificationManager.isNotificationPolicyAccessGranted();
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.N)
+    @NonNull
+    @Override
+    public Boolean areNotificationsEnabled(
+        @NonNull String instanceId
+    ) {
+        final UUID instanceUuid = UUID.fromString(instanceId);
+        final NotificationManager notificationManager = instanceManager.getInstance(instanceUuid);
+
+        return notificationManager.areNotificationsEnabled();
+    }
+}

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPigeon.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPigeon.java
@@ -1231,7 +1231,7 @@ public class PermissionHandlerPigeon {
    * are attached to a Dart instance or handle method calls on the associated
    * native class or an instance of the class.
    *
-   * See https://developer.android.com/reference/kotlin/android/content/pm/PackageManager.
+   * See https://developer.android.com/reference/android/content/pm/PackageManager.
    *
    * Generated interface from Pigeon that represents a handler of messages from Flutter.
    */
@@ -1283,7 +1283,7 @@ public class PermissionHandlerPigeon {
    * attached to a native instance or receiving callback methods from an
    * overridden native class.
    *
-   * See https://developer.android.com/reference/kotlin/android/content/pm/PackageManager.
+   * See https://developer.android.com/reference/android/content/pm/PackageManager.
    *
    * Generated class from Pigeon that represents Flutter messages that can be called from Java.
    */
@@ -1329,7 +1329,7 @@ public class PermissionHandlerPigeon {
    * are attached to a Dart instance or handle method calls on the associated
    * native class or an instance of the class.
    *
-   * See https://developer.android.com/reference/kotlin/android/provider/Settings.
+   * See https://developer.android.com/reference/android/provider/Settings.
    *
    * Generated interface from Pigeon that represents a handler of messages from Flutter.
    */
@@ -1379,6 +1379,141 @@ public class PermissionHandlerPigeon {
           channel.setMessageHandler(null);
         }
       }
+    }
+  }
+  /**
+   * Host API for `NotificationManager`.
+   *
+   * This class may handle instantiating and adding native object instances that
+   * are attached to a Dart instance or handle method calls on the associated
+   * native class or an instance of the class.
+   *
+   * See https://developer.android.com/reference/android/app/NotificationManager.
+   *
+   * Generated interface from Pigeon that represents a handler of messages from Flutter.
+   */
+  public interface NotificationManagerHostApi {
+    /**
+     * Checks the ability to modify notification do not disturb policy for the calling package.
+     *
+     * Returns true if the calling package can modify notification policy.
+     *
+     * Apps can request policy access by sending the user to the activity that
+     * matches the system intent action
+     * [Settings.actionNotificationPolicyAccessSettings].
+     *
+     * See https://developer.android.com/reference/android/app/NotificationManager#isNotificationPolicyAccessGranted().
+     */
+    @NonNull 
+    Boolean isNotificationPolicyAccessGranted(@NonNull String instanceId);
+    /**
+     * Returns whether notifications from the calling package are enabled.
+     *
+     * See https://developer.android.com/reference/android/app/NotificationManager#areNotificationsEnabled().
+     */
+    @NonNull 
+    Boolean areNotificationsEnabled(@NonNull String instanceId);
+
+    /** The codec used by NotificationManagerHostApi. */
+    static @NonNull MessageCodec<Object> getCodec() {
+      return new StandardMessageCodec();
+    }
+    /**Sets up an instance of `NotificationManagerHostApi` to handle messages through the `binaryMessenger`. */
+    static void setup(@NonNull BinaryMessenger binaryMessenger, @Nullable NotificationManagerHostApi api) {
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(
+                binaryMessenger, "dev.flutter.pigeon.permission_handler_android.NotificationManagerHostApi.isNotificationPolicyAccessGranted", getCodec());
+        if (api != null) {
+          channel.setMessageHandler(
+              (message, reply) -> {
+                ArrayList<Object> wrapped = new ArrayList<Object>();
+                ArrayList<Object> args = (ArrayList<Object>) message;
+                String instanceIdArg = (String) args.get(0);
+                try {
+                  Boolean output = api.isNotificationPolicyAccessGranted(instanceIdArg);
+                  wrapped.add(0, output);
+                }
+ catch (Throwable exception) {
+                  ArrayList<Object> wrappedError = wrapError(exception);
+                  wrapped = wrappedError;
+                }
+                reply.reply(wrapped);
+              });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(
+                binaryMessenger, "dev.flutter.pigeon.permission_handler_android.NotificationManagerHostApi.areNotificationsEnabled", getCodec());
+        if (api != null) {
+          channel.setMessageHandler(
+              (message, reply) -> {
+                ArrayList<Object> wrapped = new ArrayList<Object>();
+                ArrayList<Object> args = (ArrayList<Object>) message;
+                String instanceIdArg = (String) args.get(0);
+                try {
+                  Boolean output = api.areNotificationsEnabled(instanceIdArg);
+                  wrapped.add(0, output);
+                }
+ catch (Throwable exception) {
+                  ArrayList<Object> wrappedError = wrapError(exception);
+                  wrapped = wrappedError;
+                }
+                reply.reply(wrapped);
+              });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+    }
+  }
+  /**
+   * Flutter API for `NotificationManager`.
+   *
+   * This class may handle instantiating and adding Dart instances that are
+   * attached to a native instance or receiving callback methods from an
+   * overridden native class.
+   *
+   * See https://developer.android.com/reference/android/app/NotificationManager.
+   *
+   * Generated class from Pigeon that represents Flutter messages that can be called from Java.
+   */
+  public static class NotificationManagerFlutterApi {
+    private final @NonNull BinaryMessenger binaryMessenger;
+
+    public NotificationManagerFlutterApi(@NonNull BinaryMessenger argBinaryMessenger) {
+      this.binaryMessenger = argBinaryMessenger;
+    }
+
+    /** Public interface for sending reply. */ 
+    @SuppressWarnings("UnknownNullness")
+    public interface Reply<T> {
+      void reply(T reply);
+    }
+    /** The codec used by NotificationManagerFlutterApi. */
+    static @NonNull MessageCodec<Object> getCodec() {
+      return new StandardMessageCodec();
+    }
+    /** Create a new Dart instance and add it to the `InstanceManager`. */
+    public void create(@NonNull String instanceIdArg, @NonNull Reply<Void> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(
+              binaryMessenger, "dev.flutter.pigeon.permission_handler_android.NotificationManagerFlutterApi.create", getCodec());
+      channel.send(
+          new ArrayList<Object>(Collections.singletonList(instanceIdArg)),
+          channelReply -> callback.reply(null));
+    }
+    /** Dispose of the Dart instance and remove it from the `InstanceManager`. */
+    public void dispose(@NonNull String instanceIdArg, @NonNull Reply<Void> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(
+              binaryMessenger, "dev.flutter.pigeon.permission_handler_android.NotificationManagerFlutterApi.dispose", getCodec());
+      channel.send(
+          new ArrayList<Object>(Collections.singletonList(instanceIdArg)),
+          channelReply -> callback.reply(null));
     }
   }
 }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
@@ -15,6 +15,7 @@ import com.baseflow.permissionhandler.PermissionHandlerPigeon.AlarmManagerHostAp
 import com.baseflow.permissionhandler.PermissionHandlerPigeon.BuildVersionHostApi;
 import com.baseflow.permissionhandler.PermissionHandlerPigeon.ContextHostApi;
 import com.baseflow.permissionhandler.PermissionHandlerPigeon.IntentHostApi;
+import com.baseflow.permissionhandler.PermissionHandlerPigeon.NotificationManagerHostApi;
 import com.baseflow.permissionhandler.PermissionHandlerPigeon.PackageManagerHostApi;
 import com.baseflow.permissionhandler.PermissionHandlerPigeon.PowerManagerHostApi;
 import com.baseflow.permissionhandler.PermissionHandlerPigeon.SettingsHostApi;
@@ -76,6 +77,10 @@ public final class PermissionHandlerPlugin implements FlutterPlugin, ActivityAwa
         final SettingsHostApi settingsHostApi = new SettingsHostApiImpl(binaryMessenger, instanceManager);
         SettingsHostApi.setup(binaryMessenger, settingsHostApi);
 
+        final NotificationManagerFlutterApiImpl notificationManagerFlutterApi = new NotificationManagerFlutterApiImpl(binaryMessenger, instanceManager);
+        final NotificationManagerHostApi notificationManagerHostApi = new NotificationManagerHostApiImpl(binaryMessenger, instanceManager);
+        NotificationManagerHostApi.setup(binaryMessenger, notificationManagerHostApi);
+
         activityFlutterApi = new ActivityFlutterApiImpl(binaryMessenger, instanceManager);
         activityHostApi = new ActivityHostApiImpl(
             binaryMessenger,
@@ -88,6 +93,7 @@ public final class PermissionHandlerPlugin implements FlutterPlugin, ActivityAwa
             powerManagerFlutterApi,
             alarmManagerFlutterApi,
             packageManagerFlutterApi,
+            notificationManagerFlutterApi,
             binaryMessenger,
             instanceManager
         );

--- a/permission_handler_android/lib/permission_handler_android.dart
+++ b/permission_handler_android/lib/permission_handler_android.dart
@@ -4,6 +4,7 @@ export 'src/android_object_mirrors/build.dart';
 export 'src/android_object_mirrors/context.dart';
 export 'src/android_object_mirrors/intent.dart';
 export 'src/android_object_mirrors/manifest.dart';
+export 'src/android_object_mirrors/notification_manager.dart';
 export 'src/android_object_mirrors/package_manager.dart';
 export 'src/android_object_mirrors/power_manager.dart';
 export 'src/android_object_mirrors/settings.dart';

--- a/permission_handler_android/lib/src/android_object_mirrors/activity.dart
+++ b/permission_handler_android/lib/src/android_object_mirrors/activity.dart
@@ -46,6 +46,15 @@ class Activity extends Context {
   /// See https://developer.android.com/reference/android/content/Context.html#ALARM_SERVICE.
   static const String alarmService = 'alarm';
 
+  /// Use with [Context.getSystemService] to retrieve a [NotificationManager]
+  /// for informing the user of background events.
+  ///
+  /// Copy of [Context.notificationService], as static fields are not inherited
+  /// in Dart.
+  ///
+  /// See https://developer.android.com/reference/android/content/Context.html#NOTIFICATION_SERVICE.
+  static const String notificationService = 'notification';
+
   /// Standard activity result: operation succeeded.
   ///
   /// Constant Value: -1 (0xffffffff).

--- a/permission_handler_android/lib/src/android_object_mirrors/context.dart
+++ b/permission_handler_android/lib/src/android_object_mirrors/context.dart
@@ -42,6 +42,12 @@ class Context extends JavaObject {
   /// See https://developer.android.com/reference/android/content/Context.html#ALARM_SERVICE.
   static const String alarmService = 'alarm';
 
+  /// Use with [Context.getSystemService] to retrieve a [NotificationManager]
+  /// for informing the user of background events.
+  ///
+  /// See https://developer.android.com/reference/android/content/Context.html#NOTIFICATION_SERVICE.
+  static const String notificationService = 'notification';
+
   /// Determines whether the application has been granted a particular permission.
   ///
   /// See https://developer.android.com/reference/android/content/Context#checkSelfPermission(java.lang.String).

--- a/permission_handler_android/lib/src/android_object_mirrors/notification_manager.dart
+++ b/permission_handler_android/lib/src/android_object_mirrors/notification_manager.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_instance_manager/flutter_instance_manager.dart';
+import 'package:permission_handler_android/src/android_permission_handler_api_impls.dart';
+
+import 'build.dart';
+
+/// Class to notify the user of events that happen.
+///
+/// This is how you tell the user that something has happened in the background.
+///
+/// See: https://developer.android.com/reference/android/app/NotificationManager
+class NotificationManager extends JavaObject {
+  /// Instantiates a [NotificationManager] without creating and attaching to an
+  /// instance of the associated native class.
+  NotificationManager.detached({
+    BinaryMessenger? binaryMessenger,
+    InstanceManager? instanceManager,
+  })  : _hostApi = NotificationManagerHostApiImpl(
+          binaryMessenger: binaryMessenger,
+          instanceManager: instanceManager,
+        ),
+        super.detached();
+
+  final NotificationManagerHostApiImpl _hostApi;
+
+  /// Checks the ability to modify notification do not disturb policy for the calling package.
+  ///
+  /// Returns true if the calling package can modify notification policy.
+  ///
+  /// Apps can request policy access by sending the user to the activity that
+  /// matches the system intent action
+  /// [Settings.actionNotificationPolicyAccessSettings].
+  ///
+  /// See https://developer.android.com/reference/android/app/NotificationManager#isNotificationPolicyAccessGranted().
+  Future<bool> isNotificationPolicyAccessGranted() async {
+    final int sdkVersion = await Build.version.sdkInt;
+    if (sdkVersion < Build.versionCodes.m) {
+      return true;
+    }
+
+    return _hostApi.isNotificationPolicyAccessGrantedFromInstance(this);
+  }
+
+  /// Returns whether notifications from the calling package are enabled.
+  ///
+  /// See https://developer.android.com/reference/android/app/NotificationManager#areNotificationsEnabled().
+  Future<bool> areNotificationsEnabled() async {
+    final int sdkVersion = await Build.version.sdkInt;
+    if (sdkVersion < Build.versionCodes.n) {
+      return true;
+    }
+
+    return _hostApi.areNotificationsEnabledFromInstance(this);
+  }
+}

--- a/permission_handler_android/lib/src/android_object_mirrors/package_manager.dart
+++ b/permission_handler_android/lib/src/android_object_mirrors/package_manager.dart
@@ -10,7 +10,7 @@ import 'build.dart';
 ///
 /// See https://developer.android.com/reference/android/content/pm/PackageManager.
 class PackageManager extends JavaObject {
-  /// Instantiates an [PackageManager] without creating and attaching to an
+  /// Instantiates a [PackageManager] without creating and attaching to an
   /// instance of the associated native class.
   PackageManager.detached({
     BinaryMessenger? binaryMessenger,

--- a/permission_handler_android/lib/src/android_object_mirrors/power_manager.dart
+++ b/permission_handler_android/lib/src/android_object_mirrors/power_manager.dart
@@ -8,7 +8,7 @@ import 'build.dart';
 ///
 /// See: https://developer.android.com/reference/android/os/PowerManager
 class PowerManager extends JavaObject {
-  /// Instantiates an [PowerManager] without creating and attaching to an
+  /// Instantiates a [PowerManager] without creating and attaching to an
   /// instance of the associated native class.
   PowerManager.detached({
     BinaryMessenger? binaryMessenger,

--- a/permission_handler_android/lib/src/permission_handler.pigeon.dart
+++ b/permission_handler_android/lib/src/permission_handler.pigeon.dart
@@ -1041,7 +1041,7 @@ abstract class AlarmManagerFlutterApi {
 /// are attached to a Dart instance or handle method calls on the associated
 /// native class or an instance of the class.
 ///
-/// See https://developer.android.com/reference/kotlin/android/content/pm/PackageManager.
+/// See https://developer.android.com/reference/android/content/pm/PackageManager.
 class PackageManagerHostApi {
   /// Constructor for [PackageManagerHostApi].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
@@ -1090,7 +1090,7 @@ class PackageManagerHostApi {
 /// attached to a native instance or receiving callback methods from an
 /// overridden native class.
 ///
-/// See https://developer.android.com/reference/kotlin/android/content/pm/PackageManager.
+/// See https://developer.android.com/reference/android/content/pm/PackageManager.
 abstract class PackageManagerFlutterApi {
   static const MessageCodec<Object?> codec = StandardMessageCodec();
 
@@ -1151,7 +1151,7 @@ abstract class PackageManagerFlutterApi {
 /// are attached to a Dart instance or handle method calls on the associated
 /// native class or an instance of the class.
 ///
-/// See https://developer.android.com/reference/kotlin/android/provider/Settings.
+/// See https://developer.android.com/reference/android/provider/Settings.
 class SettingsHostApi {
   /// Constructor for [SettingsHostApi].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
@@ -1197,6 +1197,153 @@ class SettingsHostApi {
       );
     } else {
       return (replyList[0] as bool?)!;
+    }
+  }
+}
+
+/// Host API for `NotificationManager`.
+///
+/// This class may handle instantiating and adding native object instances that
+/// are attached to a Dart instance or handle method calls on the associated
+/// native class or an instance of the class.
+///
+/// See https://developer.android.com/reference/android/app/NotificationManager.
+class NotificationManagerHostApi {
+  /// Constructor for [NotificationManagerHostApi].  The [binaryMessenger] named argument is
+  /// available for dependency injection.  If it is left null, the default
+  /// BinaryMessenger will be used which routes to the host platform.
+  NotificationManagerHostApi({BinaryMessenger? binaryMessenger})
+      : _binaryMessenger = binaryMessenger;
+  final BinaryMessenger? _binaryMessenger;
+
+  static const MessageCodec<Object?> codec = StandardMessageCodec();
+
+  /// Checks the ability to modify notification do not disturb policy for the calling package.
+  ///
+  /// Returns true if the calling package can modify notification policy.
+  ///
+  /// Apps can request policy access by sending the user to the activity that
+  /// matches the system intent action
+  /// [Settings.actionNotificationPolicyAccessSettings].
+  ///
+  /// See https://developer.android.com/reference/android/app/NotificationManager#isNotificationPolicyAccessGranted().
+  Future<bool> isNotificationPolicyAccessGranted(String arg_instanceId) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.permission_handler_android.NotificationManagerHostApi.isNotificationPolicyAccessGranted',
+        codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList =
+        await channel.send(<Object?>[arg_instanceId]) as List<Object?>?;
+    if (replyList == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyList.length > 1) {
+      throw PlatformException(
+        code: replyList[0]! as String,
+        message: replyList[1] as String?,
+        details: replyList[2],
+      );
+    } else if (replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (replyList[0] as bool?)!;
+    }
+  }
+
+  /// Returns whether notifications from the calling package are enabled.
+  ///
+  /// See https://developer.android.com/reference/android/app/NotificationManager#areNotificationsEnabled().
+  Future<bool> areNotificationsEnabled(String arg_instanceId) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.permission_handler_android.NotificationManagerHostApi.areNotificationsEnabled',
+        codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList =
+        await channel.send(<Object?>[arg_instanceId]) as List<Object?>?;
+    if (replyList == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyList.length > 1) {
+      throw PlatformException(
+        code: replyList[0]! as String,
+        message: replyList[1] as String?,
+        details: replyList[2],
+      );
+    } else if (replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (replyList[0] as bool?)!;
+    }
+  }
+}
+
+/// Flutter API for `NotificationManager`.
+///
+/// This class may handle instantiating and adding Dart instances that are
+/// attached to a native instance or receiving callback methods from an
+/// overridden native class.
+///
+/// See https://developer.android.com/reference/android/app/NotificationManager.
+abstract class NotificationManagerFlutterApi {
+  static const MessageCodec<Object?> codec = StandardMessageCodec();
+
+  /// Create a new Dart instance and add it to the `InstanceManager`.
+  void create(String instanceId);
+
+  /// Dispose of the Dart instance and remove it from the `InstanceManager`.
+  void dispose(String instanceId);
+
+  static void setup(NotificationManagerFlutterApi? api,
+      {BinaryMessenger? binaryMessenger}) {
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.NotificationManagerFlutterApi.create',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        channel.setMessageHandler(null);
+      } else {
+        channel.setMessageHandler((Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.NotificationManagerFlutterApi.create was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_instanceId = (args[0] as String?);
+          assert(arg_instanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.NotificationManagerFlutterApi.create was null, expected non-null String.');
+          api.create(arg_instanceId!);
+          return;
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.NotificationManagerFlutterApi.dispose',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        channel.setMessageHandler(null);
+      } else {
+        channel.setMessageHandler((Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.NotificationManagerFlutterApi.dispose was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_instanceId = (args[0] as String?);
+          assert(arg_instanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.NotificationManagerFlutterApi.dispose was null, expected non-null String.');
+          api.dispose(arg_instanceId!);
+          return;
+        });
+      }
     }
   }
 }

--- a/permission_handler_android/pigeons/android_permission_handler.dart
+++ b/permission_handler_android/pigeons/android_permission_handler.dart
@@ -355,7 +355,7 @@ abstract class AlarmManagerFlutterApi {
 /// are attached to a Dart instance or handle method calls on the associated
 /// native class or an instance of the class.
 ///
-/// See https://developer.android.com/reference/kotlin/android/content/pm/PackageManager.
+/// See https://developer.android.com/reference/android/content/pm/PackageManager.
 @HostApi(dartHostTestHandler: 'PackageManagerTestHostApi')
 abstract class PackageManagerHostApi {
   /// Checks whether the calling package is allowed to request package installs through package installer.
@@ -370,7 +370,7 @@ abstract class PackageManagerHostApi {
 /// attached to a native instance or receiving callback methods from an
 /// overridden native class.
 ///
-/// See https://developer.android.com/reference/kotlin/android/content/pm/PackageManager.
+/// See https://developer.android.com/reference/android/content/pm/PackageManager.
 @FlutterApi()
 abstract class PackageManagerFlutterApi {
   /// Create a new Dart instance and add it to the `InstanceManager`.
@@ -386,7 +386,7 @@ abstract class PackageManagerFlutterApi {
 /// are attached to a Dart instance or handle method calls on the associated
 /// native class or an instance of the class.
 ///
-/// See https://developer.android.com/reference/kotlin/android/provider/Settings.
+/// See https://developer.android.com/reference/android/provider/Settings.
 @HostApi(dartHostTestHandler: 'SettingsTestHostApi')
 abstract class SettingsHostApi {
   /// Checks if the specified context can draw on top of other apps.
@@ -402,4 +402,50 @@ abstract class SettingsHostApi {
   bool canDrawOverlays(
     String contextInstanceId,
   );
+}
+
+/// Host API for `NotificationManager`.
+///
+/// This class may handle instantiating and adding native object instances that
+/// are attached to a Dart instance or handle method calls on the associated
+/// native class or an instance of the class.
+///
+/// See https://developer.android.com/reference/android/app/NotificationManager.
+@HostApi(dartHostTestHandler: 'NotificationManagerTestHostApi')
+abstract class NotificationManagerHostApi {
+  /// Checks the ability to modify notification do not disturb policy for the calling package.
+  ///
+  /// Returns true if the calling package can modify notification policy.
+  ///
+  /// Apps can request policy access by sending the user to the activity that
+  /// matches the system intent action
+  /// [Settings.actionNotificationPolicyAccessSettings].
+  ///
+  /// See https://developer.android.com/reference/android/app/NotificationManager#isNotificationPolicyAccessGranted().
+  bool isNotificationPolicyAccessGranted(
+    String instanceId,
+  );
+
+  /// Returns whether notifications from the calling package are enabled.
+  ///
+  /// See https://developer.android.com/reference/android/app/NotificationManager#areNotificationsEnabled().
+  bool areNotificationsEnabled(
+    String instanceId,
+  );
+}
+
+/// Flutter API for `NotificationManager`.
+///
+/// This class may handle instantiating and adding Dart instances that are
+/// attached to a native instance or receiving callback methods from an
+/// overridden native class.
+///
+/// See https://developer.android.com/reference/android/app/NotificationManager.
+@FlutterApi()
+abstract class NotificationManagerFlutterApi {
+  /// Create a new Dart instance and add it to the `InstanceManager`.
+  void create(String instanceId);
+
+  /// Dispose of the Dart instance and remove it from the `InstanceManager`.
+  void dispose(String instanceId);
 }

--- a/permission_handler_android/test/test_permission_handler.pigeon.dart
+++ b/permission_handler_android/test/test_permission_handler.pigeon.dart
@@ -739,7 +739,7 @@ abstract class AlarmManagerTestHostApi {
 /// are attached to a Dart instance or handle method calls on the associated
 /// native class or an instance of the class.
 ///
-/// See https://developer.android.com/reference/kotlin/android/content/pm/PackageManager.
+/// See https://developer.android.com/reference/android/content/pm/PackageManager.
 abstract class PackageManagerTestHostApi {
   static TestDefaultBinaryMessengerBinding? get _testBinaryMessengerBinding =>
       TestDefaultBinaryMessengerBinding.instance;
@@ -784,7 +784,7 @@ abstract class PackageManagerTestHostApi {
 /// are attached to a Dart instance or handle method calls on the associated
 /// native class or an instance of the class.
 ///
-/// See https://developer.android.com/reference/kotlin/android/provider/Settings.
+/// See https://developer.android.com/reference/android/provider/Settings.
 abstract class SettingsTestHostApi {
   static TestDefaultBinaryMessengerBinding? get _testBinaryMessengerBinding =>
       TestDefaultBinaryMessengerBinding.instance;
@@ -823,6 +823,86 @@ abstract class SettingsTestHostApi {
           assert(arg_contextInstanceId != null,
               'Argument for dev.flutter.pigeon.permission_handler_android.SettingsHostApi.canDrawOverlays was null, expected non-null String.');
           final bool output = api.canDrawOverlays(arg_contextInstanceId!);
+          return <Object?>[output];
+        });
+      }
+    }
+  }
+}
+
+/// Host API for `NotificationManager`.
+///
+/// This class may handle instantiating and adding native object instances that
+/// are attached to a Dart instance or handle method calls on the associated
+/// native class or an instance of the class.
+///
+/// See https://developer.android.com/reference/android/app/NotificationManager.
+abstract class NotificationManagerTestHostApi {
+  static TestDefaultBinaryMessengerBinding? get _testBinaryMessengerBinding =>
+      TestDefaultBinaryMessengerBinding.instance;
+  static const MessageCodec<Object?> codec = StandardMessageCodec();
+
+  /// Checks the ability to modify notification do not disturb policy for the calling package.
+  ///
+  /// Returns true if the calling package can modify notification policy.
+  ///
+  /// Apps can request policy access by sending the user to the activity that
+  /// matches the system intent action
+  /// [Settings.actionNotificationPolicyAccessSettings].
+  ///
+  /// See https://developer.android.com/reference/android/app/NotificationManager#isNotificationPolicyAccessGranted().
+  bool isNotificationPolicyAccessGranted(String instanceId);
+
+  /// Returns whether notifications from the calling package are enabled.
+  ///
+  /// See https://developer.android.com/reference/android/app/NotificationManager#areNotificationsEnabled().
+  bool areNotificationsEnabled(String instanceId);
+
+  static void setup(NotificationManagerTestHostApi? api,
+      {BinaryMessenger? binaryMessenger}) {
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.NotificationManagerHostApi.isNotificationPolicyAccessGranted',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel,
+                (Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.NotificationManagerHostApi.isNotificationPolicyAccessGranted was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_instanceId = (args[0] as String?);
+          assert(arg_instanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.NotificationManagerHostApi.isNotificationPolicyAccessGranted was null, expected non-null String.');
+          final bool output =
+              api.isNotificationPolicyAccessGranted(arg_instanceId!);
+          return <Object?>[output];
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.NotificationManagerHostApi.areNotificationsEnabled',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel,
+                (Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.NotificationManagerHostApi.areNotificationsEnabled was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_instanceId = (args[0] as String?);
+          assert(arg_instanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.NotificationManagerHostApi.areNotificationsEnabled was null, expected non-null String.');
+          final bool output = api.areNotificationsEnabled(arg_instanceId!);
           return <Object?>[output];
         });
       }


### PR DESCRIPTION
**Note**: This PR should be merged after #1216.

Ports the necessary Android SDK bits for checking whether an application access notification policies.

Closes: https://github.com/orgs/Baseflow/projects/9/views/1?pane=issue&itemId=39927317.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `next`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
