### PR TITLE
Refactor: Port `PermissionInfo` related classes (Android)

### DIFF
--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ActivityFlutterApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ActivityFlutterApiImpl.java
@@ -18,10 +18,6 @@ import java.util.UUID;
  * arguments of callbacks methods to a Dart instance.
  */
 public class ActivityFlutterApiImpl {
-    // To ease adding additional methods, this value is added prematurely.
-    @SuppressWarnings({"unused", "FieldCanBeLocal"})
-    private final BinaryMessenger binaryMessenger;
-
     private final InstanceManager instanceManager;
 
     private final ActivityFlutterApi api;
@@ -36,7 +32,6 @@ public class ActivityFlutterApiImpl {
         @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
-        this.binaryMessenger = binaryMessenger;
         this.instanceManager = instanceManager;
         api = new ActivityFlutterApi(binaryMessenger);
     }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ActivityHostApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ActivityHostApiImpl.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.PluginRegistry;
 
 /**
@@ -47,10 +46,6 @@ public class ActivityHostApiImpl implements
      */
     static final int DEFAULT_REQUEST_CODE_ACTIVITY_FOR_RESULT = 834370754;
 
-    // To ease adding additional methods, this value is added prematurely.
-    @SuppressWarnings({"unused", "FieldCanBeLocal"})
-    private final BinaryMessenger binaryMessenger;
-
     private final InstanceManager instanceManager;
 
     /**
@@ -72,14 +67,11 @@ public class ActivityHostApiImpl implements
     /**
      * Constructs an {@link ActivityHostApiImpl}.
      *
-     * @param binaryMessenger used to communicate with Dart over asynchronous messages
      * @param instanceManager maintains instances stored to communicate with attached Dart objects
      */
     public ActivityHostApiImpl(
-        @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
-        this.binaryMessenger = binaryMessenger;
         this.instanceManager = instanceManager;
     }
 

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/AlarmManagerFlutterApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/AlarmManagerFlutterApiImpl.java
@@ -18,10 +18,6 @@ import io.flutter.plugin.common.BinaryMessenger;
  * arguments of callbacks methods to a Dart instance.
  */
 public class AlarmManagerFlutterApiImpl {
-    // To ease adding additional methods, this value is added prematurely.
-    @SuppressWarnings({"unused", "FieldCanBeLocal"})
-    private final BinaryMessenger binaryMessenger;
-
     private final InstanceManager instanceManager;
 
     private final AlarmManagerFlutterApi api;
@@ -36,7 +32,6 @@ public class AlarmManagerFlutterApiImpl {
         @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
-        this.binaryMessenger = binaryMessenger;
         this.instanceManager = instanceManager;
         api = new AlarmManagerFlutterApi(binaryMessenger);
     }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/AlarmManagerHostApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/AlarmManagerHostApiImpl.java
@@ -11,8 +11,6 @@ import com.baseflow.permissionhandler.PermissionHandlerPigeon.AlarmManagerHostAp
 
 import java.util.UUID;
 
-import io.flutter.plugin.common.BinaryMessenger;
-
 /**
  * Host API implementation for `AlarmManager`.
  *
@@ -20,23 +18,16 @@ import io.flutter.plugin.common.BinaryMessenger;
  * Dart instance or handle method calls on the associated native class or an instance of the class.
  */
 public class AlarmManagerHostApiImpl implements AlarmManagerHostApi {
-    // To ease adding additional methods, this value is added prematurely.
-    @SuppressWarnings({"unused", "FieldCanBeLocal"})
-    private final BinaryMessenger binaryMessenger;
-
     private final InstanceManager instanceManager;
 
     /**
      * Constructs an {@link AlarmManagerHostApiImpl}.
      *
-     * @param binaryMessenger used to communicate with Dart over asynchronous messages
      * @param instanceManager maintains instances stored to communicate with attached Dart objects
      */
     public AlarmManagerHostApiImpl(
-        @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
-        this.binaryMessenger = binaryMessenger;
         this.instanceManager = instanceManager;
     }
 

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ApplicationInfoFlagsFlutterApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ApplicationInfoFlagsFlutterApiImpl.java
@@ -1,0 +1,66 @@
+package com.baseflow.permissionhandler;
+
+import android.content.pm.PackageManager.ApplicationInfoFlags;
+
+import androidx.annotation.NonNull;
+
+import com.baseflow.instancemanager.InstanceManager;
+import com.baseflow.permissionhandler.PermissionHandlerPigeon.ApplicationInfoFlagsFlutterApi;
+
+import java.util.UUID;
+
+import io.flutter.plugin.common.BinaryMessenger;
+
+/**
+ * Flutter API implementation for `ApplicationInfoFlags`.
+ *
+ * <p>This class may handle adding native instances that are attached to a Dart instance or passing
+ * arguments of callbacks methods to a Dart instance.
+ */
+public class ApplicationInfoFlagsFlutterApiImpl {
+    // To ease adding additional methods, this value is added prematurely.
+    @SuppressWarnings({"unused", "FieldCanBeLocal"})
+    private final BinaryMessenger binaryMessenger;
+
+    private final InstanceManager instanceManager;
+
+    private final ApplicationInfoFlagsFlutterApi api;
+
+    /**
+     * Constructs a {@link ApplicationInfoFlagsFlutterApiImpl}.
+     *
+     * @param binaryMessenger used to communicate with Dart over asynchronous messages
+     * @param instanceManager maintains instances stored to communicate with attached Dart objects
+     */
+    public ApplicationInfoFlagsFlutterApiImpl(
+        @NonNull BinaryMessenger binaryMessenger,
+        @NonNull InstanceManager instanceManager
+    ) {
+        this.binaryMessenger = binaryMessenger;
+        this.instanceManager = instanceManager;
+        api = new ApplicationInfoFlagsFlutterApi(binaryMessenger);
+    }
+
+    /**
+     * Stores the `ApplicationInfoFlags` instance and notifies Dart to create and store a new
+     * `ApplicationInfoFlags` instance that is attached to this one. If `instance` has already been
+     * added, this method does nothing.
+     */
+    public void create(@NonNull ApplicationInfoFlags instance) {
+        if (!instanceManager.containsInstance(instance)) {
+            final UUID applicationInfoFlagsInstanceUuid = instanceManager.addHostCreatedInstance(instance);
+            api.create(applicationInfoFlagsInstanceUuid.toString(), reply -> {});
+        }
+    }
+
+    /**
+     * Disposes of the `ApplicationInfoFlags` instance in the instance manager and notifies Dart to
+     * do the same. If `instance` was already disposed, this method does nothing.
+     */
+    public void dispose(ApplicationInfoFlags instance) {
+        final UUID applicationInfoFlagsInstanceUuid = instanceManager.getIdentifierForStrongReference(instance);
+        if (applicationInfoFlagsInstanceUuid != null) {
+            api.dispose(applicationInfoFlagsInstanceUuid.toString(), reply -> {});
+        }
+    }
+}

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ApplicationInfoFlagsFlutterApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ApplicationInfoFlagsFlutterApiImpl.java
@@ -18,10 +18,6 @@ import io.flutter.plugin.common.BinaryMessenger;
  * arguments of callbacks methods to a Dart instance.
  */
 public class ApplicationInfoFlagsFlutterApiImpl {
-    // To ease adding additional methods, this value is added prematurely.
-    @SuppressWarnings({"unused", "FieldCanBeLocal"})
-    private final BinaryMessenger binaryMessenger;
-
     private final InstanceManager instanceManager;
 
     private final ApplicationInfoFlagsFlutterApi api;
@@ -36,7 +32,6 @@ public class ApplicationInfoFlagsFlutterApiImpl {
         @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
-        this.binaryMessenger = binaryMessenger;
         this.instanceManager = instanceManager;
         api = new ApplicationInfoFlagsFlutterApi(binaryMessenger);
     }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ApplicationInfoFlagsHostApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ApplicationInfoFlagsHostApiImpl.java
@@ -9,8 +9,6 @@ import androidx.annotation.RequiresApi;
 import com.baseflow.instancemanager.InstanceManager;
 import com.baseflow.permissionhandler.PermissionHandlerPigeon.ApplicationInfoFlagsHostApi;
 
-import io.flutter.plugin.common.BinaryMessenger;
-
 /**
  * Host API implementation for `ApplicationInfoFlags`.
  *
@@ -18,10 +16,6 @@ import io.flutter.plugin.common.BinaryMessenger;
  * Dart instance or handle method calls on the associated native class or an instance of the class.
  */
 public class ApplicationInfoFlagsHostApiImpl implements ApplicationInfoFlagsHostApi {
-    // To ease adding additional methods, this value is added prematurely.
-    @SuppressWarnings({"unused", "FieldCanBeLocal"})
-    private final BinaryMessenger binaryMessenger;
-
     private final InstanceManager instanceManager;
 
     private final ApplicationInfoFlagsFlutterApiImpl flutterApi;
@@ -29,16 +23,13 @@ public class ApplicationInfoFlagsHostApiImpl implements ApplicationInfoFlagsHost
     /**
      * Constructs an {@link ApplicationInfoFlagsHostApiImpl}.
      *
-     * @param binaryMessenger used to communicate with Dart over asynchronous messages
      * @param instanceManager maintains instances stored to communicate with attached Dart objects
      */
     public ApplicationInfoFlagsHostApiImpl(
         @NonNull ApplicationInfoFlagsFlutterApiImpl flutterApi,
-        @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
         this.flutterApi = flutterApi;
-        this.binaryMessenger = binaryMessenger;
         this.instanceManager = instanceManager;
     }
 

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ApplicationInfoFlagsHostApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ApplicationInfoFlagsHostApiImpl.java
@@ -1,39 +1,39 @@
 package com.baseflow.permissionhandler;
 
-import android.net.Uri;
+import android.content.pm.PackageManager;
+import android.os.Build;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
 
 import com.baseflow.instancemanager.InstanceManager;
-import com.baseflow.permissionhandler.PermissionHandlerPigeon.UriHostApi;
-
-import java.util.UUID;
+import com.baseflow.permissionhandler.PermissionHandlerPigeon.ApplicationInfoFlagsHostApi;
 
 import io.flutter.plugin.common.BinaryMessenger;
 
 /**
- * Host API implementation for `Uri`.
+ * Host API implementation for `ApplicationInfoFlags`.
  *
  * <p>This class may handle instantiating and adding native object instances that are attached to a
  * Dart instance or handle method calls on the associated native class or an instance of the class.
  */
-public class UriHostApiImpl implements UriHostApi {
+public class ApplicationInfoFlagsHostApiImpl implements ApplicationInfoFlagsHostApi {
     // To ease adding additional methods, this value is added prematurely.
     @SuppressWarnings({"unused", "FieldCanBeLocal"})
     private final BinaryMessenger binaryMessenger;
 
     private final InstanceManager instanceManager;
 
-    private final UriFlutterApiImpl flutterApi;
+    private final ApplicationInfoFlagsFlutterApiImpl flutterApi;
 
     /**
-     * Constructs an {@link UriHostApiImpl}.
+     * Constructs an {@link ApplicationInfoFlagsHostApiImpl}.
      *
      * @param binaryMessenger used to communicate with Dart over asynchronous messages
      * @param instanceManager maintains instances stored to communicate with attached Dart objects
      */
-    public UriHostApiImpl(
-        @NonNull UriFlutterApiImpl flutterApi,
+    public ApplicationInfoFlagsHostApiImpl(
+        @NonNull ApplicationInfoFlagsFlutterApiImpl flutterApi,
         @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
@@ -42,23 +42,12 @@ public class UriHostApiImpl implements UriHostApi {
         this.instanceManager = instanceManager;
     }
 
-    @Override
+    @RequiresApi(api = Build.VERSION_CODES.TIRAMISU)
     @NonNull
-    public String parse(
-        @NonNull String uriString
-    ) {
-        final Uri uri = Uri.parse(uriString);
-        flutterApi.create(uri);
-        final UUID instanceId = instanceManager.getIdentifierForStrongReference(uri);
-        return instanceId.toString();
-    }
-
     @Override
-    @NonNull public String toStringAsync(
-        @NonNull String uriInstanceId
-    ) {
-        final UUID instanceId = UUID.fromString(uriInstanceId);
-        final Uri uri = instanceManager.getInstance(instanceId);
-        return uri.toString();
+    public String of(@NonNull Long value) {
+        final PackageManager.ApplicationInfoFlags flags = PackageManager.ApplicationInfoFlags.of(value);
+        flutterApi.create(flags);
+        return instanceManager.getIdentifierForStrongReference(flags).toString();
     }
 }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ComponentInfoFlagsFlutterApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ComponentInfoFlagsFlutterApiImpl.java
@@ -1,0 +1,66 @@
+package com.baseflow.permissionhandler;
+
+import android.content.pm.PackageManager.ComponentInfoFlags;
+
+import androidx.annotation.NonNull;
+
+import com.baseflow.instancemanager.InstanceManager;
+import com.baseflow.permissionhandler.PermissionHandlerPigeon.ComponentInfoFlagsFlutterApi;
+
+import java.util.UUID;
+
+import io.flutter.plugin.common.BinaryMessenger;
+
+/**
+ * Flutter API implementation for `ComponentInfoFlags`.
+ *
+ * <p>This class may handle adding native instances that are attached to a Dart instance or passing
+ * arguments of callbacks methods to a Dart instance.
+ */
+public class ComponentInfoFlagsFlutterApiImpl {
+    // To ease adding additional methods, this value is added prematurely.
+    @SuppressWarnings({"unused", "FieldCanBeLocal"})
+    private final BinaryMessenger binaryMessenger;
+
+    private final InstanceManager instanceManager;
+
+    private final ComponentInfoFlagsFlutterApi api;
+
+    /**
+     * Constructs a {@link ComponentInfoFlagsFlutterApiImpl}.
+     *
+     * @param binaryMessenger used to communicate with Dart over asynchronous messages
+     * @param instanceManager maintains instances stored to communicate with attached Dart objects
+     */
+    public ComponentInfoFlagsFlutterApiImpl(
+        @NonNull BinaryMessenger binaryMessenger,
+        @NonNull InstanceManager instanceManager
+    ) {
+        this.binaryMessenger = binaryMessenger;
+        this.instanceManager = instanceManager;
+        api = new ComponentInfoFlagsFlutterApi(binaryMessenger);
+    }
+
+    /**
+     * Stores the `ComponentInfoFlags` instance and notifies Dart to create and store a new
+     * `ComponentInfoFlags` instance that is attached to this one. If `instance` has already been
+     * added, this method does nothing.
+     */
+    public void create(@NonNull ComponentInfoFlags instance) {
+        if (!instanceManager.containsInstance(instance)) {
+            final UUID componentInfoFlagsInstanceUuid = instanceManager.addHostCreatedInstance(instance);
+            api.create(componentInfoFlagsInstanceUuid.toString(), reply -> {});
+        }
+    }
+
+    /**
+     * Disposes of the `ComponentInfoFlags` instance in the instance manager and notifies Dart to do
+     * the same. If `instance` was already disposed, this method does nothing.
+     */
+    public void dispose(ComponentInfoFlags instance) {
+        final UUID componentInfoFlagsInstanceUuid = instanceManager.getIdentifierForStrongReference(instance);
+        if (componentInfoFlagsInstanceUuid != null) {
+            api.dispose(componentInfoFlagsInstanceUuid.toString(), reply -> {});
+        }
+    }
+}

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ComponentInfoFlagsFlutterApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ComponentInfoFlagsFlutterApiImpl.java
@@ -18,10 +18,6 @@ import io.flutter.plugin.common.BinaryMessenger;
  * arguments of callbacks methods to a Dart instance.
  */
 public class ComponentInfoFlagsFlutterApiImpl {
-    // To ease adding additional methods, this value is added prematurely.
-    @SuppressWarnings({"unused", "FieldCanBeLocal"})
-    private final BinaryMessenger binaryMessenger;
-
     private final InstanceManager instanceManager;
 
     private final ComponentInfoFlagsFlutterApi api;
@@ -36,7 +32,6 @@ public class ComponentInfoFlagsFlutterApiImpl {
         @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
-        this.binaryMessenger = binaryMessenger;
         this.instanceManager = instanceManager;
         api = new ComponentInfoFlagsFlutterApi(binaryMessenger);
     }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ComponentInfoFlagsHostApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ComponentInfoFlagsHostApiImpl.java
@@ -1,39 +1,39 @@
 package com.baseflow.permissionhandler;
 
-import android.net.Uri;
+import android.content.pm.PackageManager;
+import android.os.Build;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
 
 import com.baseflow.instancemanager.InstanceManager;
-import com.baseflow.permissionhandler.PermissionHandlerPigeon.UriHostApi;
-
-import java.util.UUID;
+import com.baseflow.permissionhandler.PermissionHandlerPigeon.ComponentInfoFlagsHostApi;
 
 import io.flutter.plugin.common.BinaryMessenger;
 
 /**
- * Host API implementation for `Uri`.
+ * Host API implementation for `ComponentInfoFlags`.
  *
  * <p>This class may handle instantiating and adding native object instances that are attached to a
  * Dart instance or handle method calls on the associated native class or an instance of the class.
  */
-public class UriHostApiImpl implements UriHostApi {
+public class ComponentInfoFlagsHostApiImpl implements ComponentInfoFlagsHostApi {
     // To ease adding additional methods, this value is added prematurely.
     @SuppressWarnings({"unused", "FieldCanBeLocal"})
     private final BinaryMessenger binaryMessenger;
 
     private final InstanceManager instanceManager;
 
-    private final UriFlutterApiImpl flutterApi;
+    private final ComponentInfoFlagsFlutterApiImpl flutterApi;
 
     /**
-     * Constructs an {@link UriHostApiImpl}.
+     * Constructs an {@link ComponentInfoFlagsHostApiImpl}.
      *
      * @param binaryMessenger used to communicate with Dart over asynchronous messages
      * @param instanceManager maintains instances stored to communicate with attached Dart objects
      */
-    public UriHostApiImpl(
-        @NonNull UriFlutterApiImpl flutterApi,
+    public ComponentInfoFlagsHostApiImpl(
+        @NonNull ComponentInfoFlagsFlutterApiImpl flutterApi,
         @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
@@ -42,23 +42,12 @@ public class UriHostApiImpl implements UriHostApi {
         this.instanceManager = instanceManager;
     }
 
-    @Override
+    @RequiresApi(api = Build.VERSION_CODES.TIRAMISU)
     @NonNull
-    public String parse(
-        @NonNull String uriString
-    ) {
-        final Uri uri = Uri.parse(uriString);
-        flutterApi.create(uri);
-        final UUID instanceId = instanceManager.getIdentifierForStrongReference(uri);
-        return instanceId.toString();
-    }
-
     @Override
-    @NonNull public String toStringAsync(
-        @NonNull String uriInstanceId
-    ) {
-        final UUID instanceId = UUID.fromString(uriInstanceId);
-        final Uri uri = instanceManager.getInstance(instanceId);
-        return uri.toString();
+    public String of(@NonNull Long value) {
+        final PackageManager.ComponentInfoFlags flags = PackageManager.ComponentInfoFlags.of(value);
+        flutterApi.create(flags);
+        return instanceManager.getIdentifierForStrongReference(flags).toString();
     }
 }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ComponentInfoFlagsHostApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ComponentInfoFlagsHostApiImpl.java
@@ -9,8 +9,6 @@ import androidx.annotation.RequiresApi;
 import com.baseflow.instancemanager.InstanceManager;
 import com.baseflow.permissionhandler.PermissionHandlerPigeon.ComponentInfoFlagsHostApi;
 
-import io.flutter.plugin.common.BinaryMessenger;
-
 /**
  * Host API implementation for `ComponentInfoFlags`.
  *
@@ -18,10 +16,6 @@ import io.flutter.plugin.common.BinaryMessenger;
  * Dart instance or handle method calls on the associated native class or an instance of the class.
  */
 public class ComponentInfoFlagsHostApiImpl implements ComponentInfoFlagsHostApi {
-    // To ease adding additional methods, this value is added prematurely.
-    @SuppressWarnings({"unused", "FieldCanBeLocal"})
-    private final BinaryMessenger binaryMessenger;
-
     private final InstanceManager instanceManager;
 
     private final ComponentInfoFlagsFlutterApiImpl flutterApi;
@@ -29,16 +23,13 @@ public class ComponentInfoFlagsHostApiImpl implements ComponentInfoFlagsHostApi 
     /**
      * Constructs an {@link ComponentInfoFlagsHostApiImpl}.
      *
-     * @param binaryMessenger used to communicate with Dart over asynchronous messages
      * @param instanceManager maintains instances stored to communicate with attached Dart objects
      */
     public ComponentInfoFlagsHostApiImpl(
         @NonNull ComponentInfoFlagsFlutterApiImpl flutterApi,
-        @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
         this.flutterApi = flutterApi;
-        this.binaryMessenger = binaryMessenger;
         this.instanceManager = instanceManager;
     }
 

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ContextFlutterApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ContextFlutterApiImpl.java
@@ -18,10 +18,6 @@ import io.flutter.plugin.common.BinaryMessenger;
  * arguments of callbacks methods to a Dart instance.
  */
 public class ContextFlutterApiImpl {
-    // To ease adding additional methods, this value is added prematurely.
-    @SuppressWarnings({"unused", "FieldCanBeLocal"})
-    private final BinaryMessenger binaryMessenger;
-
     private final InstanceManager instanceManager;
 
     private final ContextFlutterApi api;
@@ -36,7 +32,6 @@ public class ContextFlutterApiImpl {
         @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
-        this.binaryMessenger = binaryMessenger;
         this.instanceManager = instanceManager;
         api = new ContextFlutterApi(binaryMessenger);
     }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ContextHostApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ContextHostApiImpl.java
@@ -15,8 +15,6 @@ import com.baseflow.permissionhandler.PermissionHandlerPigeon.ContextHostApi;
 
 import java.util.UUID;
 
-import io.flutter.plugin.common.BinaryMessenger;
-
 /**
  * Host API implementation for `Context`.
  *
@@ -24,10 +22,6 @@ import io.flutter.plugin.common.BinaryMessenger;
  * Dart instance or handle method calls on the associated native class or an instance of the class.
  */
 public class ContextHostApiImpl implements ContextHostApi {
-    // To ease adding additional methods, this value is added prematurely.
-    @SuppressWarnings({"unused", "FieldCanBeLocal"})
-    private final BinaryMessenger binaryMessenger;
-
     private final InstanceManager instanceManager;
 
     private final PowerManagerFlutterApiImpl powerManagerFlutterApi;
@@ -41,7 +35,6 @@ public class ContextHostApiImpl implements ContextHostApi {
     /**
      * Constructs an {@link ContextHostApiImpl}.
      *
-     * @param binaryMessenger used to communicate with Dart over asynchronous messages
      * @param instanceManager maintains instances stored to communicate with attached Dart objects
      */
     public ContextHostApiImpl(
@@ -49,14 +42,12 @@ public class ContextHostApiImpl implements ContextHostApi {
         @NonNull AlarmManagerFlutterApiImpl alarmManagerFlutterApi,
         @NonNull PackageManagerFlutterApiImpl packageManagerFlutterApi,
         @NonNull NotificationManagerFlutterApiImpl notificationManagerFlutterApi,
-        @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
         this.powerManagerFlutterApi = powerManagerFlutterApi;
         this.alarmManagerFlutterApi = alarmManagerFlutterApi;
         this.packageManagerFlutterApi = packageManagerFlutterApi;
         this.notificationManagerFlutterApi = notificationManagerFlutterApi;
-        this.binaryMessenger = binaryMessenger;
         this.instanceManager = instanceManager;
     }
 

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/EnvironmentHostApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/EnvironmentHostApiImpl.java
@@ -1,0 +1,49 @@
+package com.baseflow.permissionhandler;
+
+import android.os.Build;
+import android.os.Environment;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+
+import com.baseflow.instancemanager.InstanceManager;
+import com.baseflow.permissionhandler.PermissionHandlerPigeon.EnvironmentHostApi;
+
+import io.flutter.plugin.common.BinaryMessenger;
+
+/**
+ * Host API implementation for `Environment`.
+ *
+ * <p>This class may handle instantiating and adding native object instances that are attached to a
+ * Dart instance or handle method calls on the associated native class or an instance of the class.
+ */
+public class EnvironmentHostApiImpl implements EnvironmentHostApi {
+    // To ease adding additional methods, this value is added prematurely.
+    @SuppressWarnings({"unused", "FieldCanBeLocal"})
+    private final BinaryMessenger binaryMessenger;
+
+    // To ease adding additional methods, this value is added prematurely.
+    @SuppressWarnings({"unused", "FieldCanBeLocal"})
+    private final InstanceManager instanceManager;
+
+    /**
+     * Constructs an {@link EnvironmentHostApiImpl}.
+     *
+     * @param binaryMessenger used to communicate with Dart over asynchronous messages
+     * @param instanceManager maintains instances stored to communicate with attached Dart objects
+     */
+    public EnvironmentHostApiImpl(
+        @NonNull BinaryMessenger binaryMessenger,
+        @NonNull InstanceManager instanceManager
+    ) {
+        this.binaryMessenger = binaryMessenger;
+        this.instanceManager = instanceManager;
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.R)
+    @NonNull
+    @Override
+    public Boolean isExternalStorageManager() {
+        return Environment.isExternalStorageManager();
+    }
+}

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/EnvironmentHostApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/EnvironmentHostApiImpl.java
@@ -9,8 +9,6 @@ import androidx.annotation.RequiresApi;
 import com.baseflow.instancemanager.InstanceManager;
 import com.baseflow.permissionhandler.PermissionHandlerPigeon.EnvironmentHostApi;
 
-import io.flutter.plugin.common.BinaryMessenger;
-
 /**
  * Host API implementation for `Environment`.
  *
@@ -20,23 +18,16 @@ import io.flutter.plugin.common.BinaryMessenger;
 public class EnvironmentHostApiImpl implements EnvironmentHostApi {
     // To ease adding additional methods, this value is added prematurely.
     @SuppressWarnings({"unused", "FieldCanBeLocal"})
-    private final BinaryMessenger binaryMessenger;
-
-    // To ease adding additional methods, this value is added prematurely.
-    @SuppressWarnings({"unused", "FieldCanBeLocal"})
     private final InstanceManager instanceManager;
 
     /**
      * Constructs an {@link EnvironmentHostApiImpl}.
      *
-     * @param binaryMessenger used to communicate with Dart over asynchronous messages
      * @param instanceManager maintains instances stored to communicate with attached Dart objects
      */
     public EnvironmentHostApiImpl(
-        @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
-        this.binaryMessenger = binaryMessenger;
         this.instanceManager = instanceManager;
     }
 

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/IntentHostApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/IntentHostApiImpl.java
@@ -10,8 +10,6 @@ import com.baseflow.permissionhandler.PermissionHandlerPigeon.IntentHostApi;
 
 import java.util.UUID;
 
-import io.flutter.plugin.common.BinaryMessenger;
-
 /**
  * Host API implementation for `Intent`.
  *
@@ -19,23 +17,16 @@ import io.flutter.plugin.common.BinaryMessenger;
  * Dart instance or handle method calls on the associated native class or an instance of the class.
  */
 public class IntentHostApiImpl implements IntentHostApi {
-    // To ease adding additional methods, this value is added prematurely.
-    @SuppressWarnings({"unused", "FieldCanBeLocal"})
-    private final BinaryMessenger binaryMessenger;
-
     private final InstanceManager instanceManager;
 
     /**
      * Constructs an {@link IntentHostApiImpl}.
      *
-     * @param binaryMessenger used to communicate with Dart over asynchronous messages
      * @param instanceManager maintains instances stored to communicate with attached Dart objects
      */
     public IntentHostApiImpl(
-        @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
-        this.binaryMessenger = binaryMessenger;
         this.instanceManager = instanceManager;
     }
 

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/NotificationManagerFlutterApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/NotificationManagerFlutterApiImpl.java
@@ -18,10 +18,6 @@ import io.flutter.plugin.common.BinaryMessenger;
  * arguments of callbacks methods to a Dart instance.
  */
 public class NotificationManagerFlutterApiImpl {
-    // To ease adding additional methods, this value is added prematurely.
-    @SuppressWarnings({"unused", "FieldCanBeLocal"})
-    private final BinaryMessenger binaryMessenger;
-
     private final InstanceManager instanceManager;
 
     private final NotificationManagerFlutterApi api;
@@ -36,7 +32,6 @@ public class NotificationManagerFlutterApiImpl {
         @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
-        this.binaryMessenger = binaryMessenger;
         this.instanceManager = instanceManager;
         api = new NotificationManagerFlutterApi(binaryMessenger);
     }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/NotificationManagerHostApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/NotificationManagerHostApiImpl.java
@@ -5,14 +5,11 @@ import android.os.Build;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
-import androidx.core.app.NotificationManagerCompat;
 
 import com.baseflow.instancemanager.InstanceManager;
 import com.baseflow.permissionhandler.PermissionHandlerPigeon.NotificationManagerHostApi;
 
 import java.util.UUID;
-
-import io.flutter.plugin.common.BinaryMessenger;
 
 /**
  * Host API implementation for `NotificationManager`.
@@ -21,23 +18,16 @@ import io.flutter.plugin.common.BinaryMessenger;
  * Dart instance or handle method calls on the associated native class or an instance of the class.
  */
 public class NotificationManagerHostApiImpl implements NotificationManagerHostApi {
-    // To ease adding additional methods, this value is added prematurely.
-    @SuppressWarnings({"unused", "FieldCanBeLocal"})
-    private final BinaryMessenger binaryMessenger;
-
     private final InstanceManager instanceManager;
 
     /**
      * Constructs an {@link NotificationManagerHostApiImpl}.
      *
-     * @param binaryMessenger used to communicate with Dart over asynchronous messages
      * @param instanceManager maintains instances stored to communicate with attached Dart objects
      */
     public NotificationManagerHostApiImpl(
-        @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
-        this.binaryMessenger = binaryMessenger;
         this.instanceManager = instanceManager;
     }
 

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PackageInfoFlagsFlutterApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PackageInfoFlagsFlutterApiImpl.java
@@ -1,0 +1,66 @@
+package com.baseflow.permissionhandler;
+
+import android.content.pm.PackageManager.PackageInfoFlags;
+
+import androidx.annotation.NonNull;
+
+import com.baseflow.instancemanager.InstanceManager;
+import com.baseflow.permissionhandler.PermissionHandlerPigeon.PackageInfoFlagsFlutterApi;
+
+import java.util.UUID;
+
+import io.flutter.plugin.common.BinaryMessenger;
+
+/**
+ * Flutter API implementation for `PackageInfoFlags`.
+ *
+ * <p>This class may handle adding native instances that are attached to a Dart instance or passing
+ * arguments of callbacks methods to a Dart instance.
+ */
+public class PackageInfoFlagsFlutterApiImpl {
+    // To ease adding additional methods, this value is added prematurely.
+    @SuppressWarnings({"unused", "FieldCanBeLocal"})
+    private final BinaryMessenger binaryMessenger;
+
+    private final InstanceManager instanceManager;
+
+    private final PackageInfoFlagsFlutterApi api;
+
+    /**
+     * Constructs a {@link PackageInfoFlagsFlutterApiImpl}.
+     *
+     * @param binaryMessenger used to communicate with Dart over asynchronous messages
+     * @param instanceManager maintains instances stored to communicate with attached Dart objects
+     */
+    public PackageInfoFlagsFlutterApiImpl(
+        @NonNull BinaryMessenger binaryMessenger,
+        @NonNull InstanceManager instanceManager
+    ) {
+        this.binaryMessenger = binaryMessenger;
+        this.instanceManager = instanceManager;
+        api = new PackageInfoFlagsFlutterApi(binaryMessenger);
+    }
+
+    /**
+     * Stores the `PackageInfoFlags` instance and notifies Dart to create and store a new
+     * `PackageInfoFlags` instance that is attached to this one. If `instance` has already been
+     * added, this method does nothing.
+     */
+    public void create(@NonNull PackageInfoFlags instance) {
+        if (!instanceManager.containsInstance(instance)) {
+            final UUID packageInfoFlagsInstanceUuid = instanceManager.addHostCreatedInstance(instance);
+            api.create(packageInfoFlagsInstanceUuid.toString(), reply -> {});
+        }
+    }
+
+    /**
+     * Disposes of the `PackageInfoFlags` instance in the instance manager and notifies Dart to do
+     * the same. If `instance` was already disposed, this method does nothing.
+     */
+    public void dispose(PackageInfoFlags instance) {
+        final UUID packageInfoFlagsInstanceUuid = instanceManager.getIdentifierForStrongReference(instance);
+        if (packageInfoFlagsInstanceUuid != null) {
+            api.dispose(packageInfoFlagsInstanceUuid.toString(), reply -> {});
+        }
+    }
+}

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PackageInfoFlagsFlutterApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PackageInfoFlagsFlutterApiImpl.java
@@ -18,10 +18,6 @@ import io.flutter.plugin.common.BinaryMessenger;
  * arguments of callbacks methods to a Dart instance.
  */
 public class PackageInfoFlagsFlutterApiImpl {
-    // To ease adding additional methods, this value is added prematurely.
-    @SuppressWarnings({"unused", "FieldCanBeLocal"})
-    private final BinaryMessenger binaryMessenger;
-
     private final InstanceManager instanceManager;
 
     private final PackageInfoFlagsFlutterApi api;
@@ -36,7 +32,6 @@ public class PackageInfoFlagsFlutterApiImpl {
         @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
-        this.binaryMessenger = binaryMessenger;
         this.instanceManager = instanceManager;
         api = new PackageInfoFlagsFlutterApi(binaryMessenger);
     }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PackageInfoFlagsHostApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PackageInfoFlagsHostApiImpl.java
@@ -1,39 +1,39 @@
 package com.baseflow.permissionhandler;
 
-import android.net.Uri;
+import android.content.pm.PackageManager;
+import android.os.Build;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
 
 import com.baseflow.instancemanager.InstanceManager;
-import com.baseflow.permissionhandler.PermissionHandlerPigeon.UriHostApi;
-
-import java.util.UUID;
+import com.baseflow.permissionhandler.PermissionHandlerPigeon.PackageInfoFlagsHostApi;
 
 import io.flutter.plugin.common.BinaryMessenger;
 
 /**
- * Host API implementation for `Uri`.
+ * Host API implementation for `PackageInfoFlags`.
  *
  * <p>This class may handle instantiating and adding native object instances that are attached to a
  * Dart instance or handle method calls on the associated native class or an instance of the class.
  */
-public class UriHostApiImpl implements UriHostApi {
+public class PackageInfoFlagsHostApiImpl implements PackageInfoFlagsHostApi {
     // To ease adding additional methods, this value is added prematurely.
     @SuppressWarnings({"unused", "FieldCanBeLocal"})
     private final BinaryMessenger binaryMessenger;
 
     private final InstanceManager instanceManager;
 
-    private final UriFlutterApiImpl flutterApi;
+    private final PackageInfoFlagsFlutterApiImpl flutterApi;
 
     /**
-     * Constructs an {@link UriHostApiImpl}.
+     * Constructs an {@link PackageInfoFlagsHostApiImpl}.
      *
      * @param binaryMessenger used to communicate with Dart over asynchronous messages
      * @param instanceManager maintains instances stored to communicate with attached Dart objects
      */
-    public UriHostApiImpl(
-        @NonNull UriFlutterApiImpl flutterApi,
+    public PackageInfoFlagsHostApiImpl(
+        @NonNull PackageInfoFlagsFlutterApiImpl flutterApi,
         @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
@@ -42,23 +42,12 @@ public class UriHostApiImpl implements UriHostApi {
         this.instanceManager = instanceManager;
     }
 
-    @Override
+    @RequiresApi(api = Build.VERSION_CODES.TIRAMISU)
     @NonNull
-    public String parse(
-        @NonNull String uriString
-    ) {
-        final Uri uri = Uri.parse(uriString);
-        flutterApi.create(uri);
-        final UUID instanceId = instanceManager.getIdentifierForStrongReference(uri);
-        return instanceId.toString();
-    }
-
     @Override
-    @NonNull public String toStringAsync(
-        @NonNull String uriInstanceId
-    ) {
-        final UUID instanceId = UUID.fromString(uriInstanceId);
-        final Uri uri = instanceManager.getInstance(instanceId);
-        return uri.toString();
+    public String of(@NonNull Long value) {
+        final PackageManager.PackageInfoFlags flags = PackageManager.PackageInfoFlags.of(value);
+        flutterApi.create(flags);
+        return instanceManager.getIdentifierForStrongReference(flags).toString();
     }
 }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PackageInfoFlagsHostApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PackageInfoFlagsHostApiImpl.java
@@ -9,8 +9,6 @@ import androidx.annotation.RequiresApi;
 import com.baseflow.instancemanager.InstanceManager;
 import com.baseflow.permissionhandler.PermissionHandlerPigeon.PackageInfoFlagsHostApi;
 
-import io.flutter.plugin.common.BinaryMessenger;
-
 /**
  * Host API implementation for `PackageInfoFlags`.
  *
@@ -18,10 +16,6 @@ import io.flutter.plugin.common.BinaryMessenger;
  * Dart instance or handle method calls on the associated native class or an instance of the class.
  */
 public class PackageInfoFlagsHostApiImpl implements PackageInfoFlagsHostApi {
-    // To ease adding additional methods, this value is added prematurely.
-    @SuppressWarnings({"unused", "FieldCanBeLocal"})
-    private final BinaryMessenger binaryMessenger;
-
     private final InstanceManager instanceManager;
 
     private final PackageInfoFlagsFlutterApiImpl flutterApi;
@@ -29,16 +23,13 @@ public class PackageInfoFlagsHostApiImpl implements PackageInfoFlagsHostApi {
     /**
      * Constructs an {@link PackageInfoFlagsHostApiImpl}.
      *
-     * @param binaryMessenger used to communicate with Dart over asynchronous messages
      * @param instanceManager maintains instances stored to communicate with attached Dart objects
      */
     public PackageInfoFlagsHostApiImpl(
         @NonNull PackageInfoFlagsFlutterApiImpl flutterApi,
-        @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
         this.flutterApi = flutterApi;
-        this.binaryMessenger = binaryMessenger;
         this.instanceManager = instanceManager;
     }
 

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PackageInfoFlutterApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PackageInfoFlutterApiImpl.java
@@ -1,7 +1,6 @@
 package com.baseflow.permissionhandler;
 
 import android.content.pm.PackageInfo;
-import android.content.pm.PackageManager.PackageInfoFlags;
 
 import androidx.annotation.NonNull;
 
@@ -19,10 +18,6 @@ import io.flutter.plugin.common.BinaryMessenger;
  * arguments of callbacks methods to a Dart instance.
  */
 public class PackageInfoFlutterApiImpl {
-    // To ease adding additional methods, this value is added prematurely.
-    @SuppressWarnings({"unused", "FieldCanBeLocal"})
-    private final BinaryMessenger binaryMessenger;
-
     private final InstanceManager instanceManager;
 
     private final PackageInfoFlutterApi api;
@@ -37,7 +32,6 @@ public class PackageInfoFlutterApiImpl {
         @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
-        this.binaryMessenger = binaryMessenger;
         this.instanceManager = instanceManager;
         api = new PackageInfoFlutterApi(binaryMessenger);
     }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PackageInfoFlutterApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PackageInfoFlutterApiImpl.java
@@ -1,0 +1,67 @@
+package com.baseflow.permissionhandler;
+
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager.PackageInfoFlags;
+
+import androidx.annotation.NonNull;
+
+import com.baseflow.instancemanager.InstanceManager;
+import com.baseflow.permissionhandler.PermissionHandlerPigeon.PackageInfoFlutterApi;
+
+import java.util.UUID;
+
+import io.flutter.plugin.common.BinaryMessenger;
+
+/**
+ * Flutter API implementation for `PackageInfo`.
+ *
+ * <p>This class may handle adding native instances that are attached to a Dart instance or passing
+ * arguments of callbacks methods to a Dart instance.
+ */
+public class PackageInfoFlutterApiImpl {
+    // To ease adding additional methods, this value is added prematurely.
+    @SuppressWarnings({"unused", "FieldCanBeLocal"})
+    private final BinaryMessenger binaryMessenger;
+
+    private final InstanceManager instanceManager;
+
+    private final PackageInfoFlutterApi api;
+
+    /**
+     * Constructs a {@link PackageInfoFlutterApiImpl}.
+     *
+     * @param binaryMessenger used to communicate with Dart over asynchronous messages
+     * @param instanceManager maintains instances stored to communicate with attached Dart objects
+     */
+    public PackageInfoFlutterApiImpl(
+        @NonNull BinaryMessenger binaryMessenger,
+        @NonNull InstanceManager instanceManager
+    ) {
+        this.binaryMessenger = binaryMessenger;
+        this.instanceManager = instanceManager;
+        api = new PackageInfoFlutterApi(binaryMessenger);
+    }
+
+    /**
+     * Stores the `PackageInfo` instance and notifies Dart to create and store a new `PackageInfo`
+     * instance that is attached to this one. If `instance` has already been added, this method does
+     * nothing.
+     */
+    public void create(@NonNull PackageInfo instance) {
+        if (!instanceManager.containsInstance(instance)) {
+            final UUID packageInfoInstanceUuid = instanceManager.addHostCreatedInstance(instance);
+            api.create(packageInfoInstanceUuid.toString(), reply -> {});
+        }
+    }
+
+    /**
+     * Disposes of the `PackageInfo` instance in the instance manager and notifies Dart to do the
+     * same. If `instance` was already disposed, this method does nothing.
+     */
+    public void dispose(PackageInfo instance) {
+        final UUID packageInfoInstanceUuid = instanceManager.getIdentifierForStrongReference(instance);
+        if (packageInfoInstanceUuid != null) {
+            api.dispose(packageInfoInstanceUuid.toString(), reply -> {});
+        }
+    }
+}

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PackageInfoHostApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PackageInfoHostApiImpl.java
@@ -1,64 +1,55 @@
 package com.baseflow.permissionhandler;
 
-import android.net.Uri;
+import android.content.pm.PackageInfo;
 
 import androidx.annotation.NonNull;
 
 import com.baseflow.instancemanager.InstanceManager;
-import com.baseflow.permissionhandler.PermissionHandlerPigeon.UriHostApi;
+import com.baseflow.permissionhandler.PermissionHandlerPigeon.PackageInfoHostApi;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 
 import io.flutter.plugin.common.BinaryMessenger;
 
 /**
- * Host API implementation for `Uri`.
+ * Host API implementation for `PackageInfo`.
  *
  * <p>This class may handle instantiating and adding native object instances that are attached to a
  * Dart instance or handle method calls on the associated native class or an instance of the class.
  */
-public class UriHostApiImpl implements UriHostApi {
+public class PackageInfoHostApiImpl implements PackageInfoHostApi {
     // To ease adding additional methods, this value is added prematurely.
     @SuppressWarnings({"unused", "FieldCanBeLocal"})
     private final BinaryMessenger binaryMessenger;
 
     private final InstanceManager instanceManager;
 
-    private final UriFlutterApiImpl flutterApi;
-
     /**
-     * Constructs an {@link UriHostApiImpl}.
+     * Constructs an {@link PackageInfoHostApiImpl}.
      *
      * @param binaryMessenger used to communicate with Dart over asynchronous messages
      * @param instanceManager maintains instances stored to communicate with attached Dart objects
      */
-    public UriHostApiImpl(
-        @NonNull UriFlutterApiImpl flutterApi,
+    public PackageInfoHostApiImpl(
         @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
-        this.flutterApi = flutterApi;
         this.binaryMessenger = binaryMessenger;
         this.instanceManager = instanceManager;
     }
 
-    @Override
     @NonNull
-    public String parse(
-        @NonNull String uriString
-    ) {
-        final Uri uri = Uri.parse(uriString);
-        flutterApi.create(uri);
-        final UUID instanceId = instanceManager.getIdentifierForStrongReference(uri);
-        return instanceId.toString();
-    }
-
     @Override
-    @NonNull public String toStringAsync(
-        @NonNull String uriInstanceId
-    ) {
-        final UUID instanceId = UUID.fromString(uriInstanceId);
-        final Uri uri = instanceManager.getInstance(instanceId);
-        return uri.toString();
+    public List<String> getRequestedPermissions(@NonNull String instanceId) {
+        final UUID instanceUuid = UUID.fromString(instanceId);
+        final PackageInfo packageInfo = instanceManager.getInstance(instanceUuid);
+        final String[] requestedPermissions = packageInfo.requestedPermissions;
+        if (requestedPermissions == null) {
+            return new ArrayList<>();
+        }
+        return Arrays.asList(requestedPermissions);
     }
 }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PackageInfoHostApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PackageInfoHostApiImpl.java
@@ -12,8 +12,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
-import io.flutter.plugin.common.BinaryMessenger;
-
 /**
  * Host API implementation for `PackageInfo`.
  *
@@ -21,23 +19,16 @@ import io.flutter.plugin.common.BinaryMessenger;
  * Dart instance or handle method calls on the associated native class or an instance of the class.
  */
 public class PackageInfoHostApiImpl implements PackageInfoHostApi {
-    // To ease adding additional methods, this value is added prematurely.
-    @SuppressWarnings({"unused", "FieldCanBeLocal"})
-    private final BinaryMessenger binaryMessenger;
-
     private final InstanceManager instanceManager;
 
     /**
      * Constructs an {@link PackageInfoHostApiImpl}.
      *
-     * @param binaryMessenger used to communicate with Dart over asynchronous messages
      * @param instanceManager maintains instances stored to communicate with attached Dart objects
      */
     public PackageInfoHostApiImpl(
-        @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
-        this.binaryMessenger = binaryMessenger;
         this.instanceManager = instanceManager;
     }
 

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PackageManagerFlutterApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PackageManagerFlutterApiImpl.java
@@ -18,10 +18,6 @@ import io.flutter.plugin.common.BinaryMessenger;
  * arguments of callbacks methods to a Dart instance.
  */
 public class PackageManagerFlutterApiImpl {
-    // To ease adding additional methods, this value is added prematurely.
-    @SuppressWarnings({"unused", "FieldCanBeLocal"})
-    private final BinaryMessenger binaryMessenger;
-
     private final InstanceManager instanceManager;
 
     private final PackageManagerFlutterApi api;
@@ -36,7 +32,6 @@ public class PackageManagerFlutterApiImpl {
         @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
-        this.binaryMessenger = binaryMessenger;
         this.instanceManager = instanceManager;
         api = new PackageManagerFlutterApi(binaryMessenger);
     }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PackageManagerHostApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PackageManagerHostApiImpl.java
@@ -1,6 +1,10 @@
 package com.baseflow.permissionhandler;
 
+import android.content.Intent;
+import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.content.pm.PackageManager.PackageInfoFlags;
+import android.content.pm.ResolveInfo;
 import android.os.Build;
 
 import androidx.annotation.NonNull;
@@ -9,6 +13,8 @@ import androidx.annotation.RequiresApi;
 import com.baseflow.instancemanager.InstanceManager;
 import com.baseflow.permissionhandler.PermissionHandlerPigeon.PackageManagerHostApi;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import io.flutter.plugin.common.BinaryMessenger;
@@ -26,6 +32,10 @@ public class PackageManagerHostApiImpl implements PackageManagerHostApi {
 
     private final InstanceManager instanceManager;
 
+    private final PackageInfoFlutterApiImpl packageInfoFlutterApi;
+
+    private final ResolveInfoFlutterApiImpl resolveInfoFlutterApi;
+
     /**
      * Constructs an {@link PackageManagerHostApiImpl}.
      *
@@ -33,9 +43,13 @@ public class PackageManagerHostApiImpl implements PackageManagerHostApi {
      * @param instanceManager maintains instances stored to communicate with attached Dart objects
      */
     public PackageManagerHostApiImpl(
+        @NonNull PackageInfoFlutterApiImpl packageInfoFlutterApi,
+        @NonNull ResolveInfoFlutterApiImpl resolveInfoFlutterApi,
         @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
+        this.packageInfoFlutterApi = packageInfoFlutterApi;
+        this.resolveInfoFlutterApi = resolveInfoFlutterApi;
         this.binaryMessenger = binaryMessenger;
         this.instanceManager = instanceManager;
     }
@@ -48,5 +62,114 @@ public class PackageManagerHostApiImpl implements PackageManagerHostApi {
         final PackageManager packageManager = instanceManager.getInstance(instanceUuid);
 
         return packageManager.canRequestPackageInstalls();
+    }
+
+    @Deprecated()
+    @Override
+    public String getPackageInfoWithFlags(
+        @NonNull String instanceId,
+        @NonNull String packageName,
+        @NonNull Long flags
+    ) {
+        final UUID instanceUuid = UUID.fromString(instanceId);
+        final PackageManager packageManager = instanceManager.getInstance(instanceUuid);
+
+        final PackageInfo packageInfo;
+        try {
+            packageInfo = packageManager.getPackageInfo(packageName, flags.intValue());
+        } catch (PackageManager.NameNotFoundException e) {
+            return null;
+        }
+
+        packageInfoFlutterApi.create(packageInfo);
+
+        return instanceManager.getIdentifierForStrongReference(packageInfo).toString();
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.TIRAMISU)
+    @Override
+    public String getPackageInfoWithInfoFlags(
+        @NonNull String instanceId,
+        @NonNull String packageName,
+        @NonNull String flagsInstanceId
+    ) {
+        final UUID instanceUuid = UUID.fromString(instanceId);
+        final UUID flagsInstanceUuid = UUID.fromString(flagsInstanceId);
+
+        final PackageManager packageManager = instanceManager.getInstance(instanceUuid);
+        final PackageInfoFlags packageInfoFlags = instanceManager.getInstance(flagsInstanceUuid);
+
+        final PackageInfo packageInfo;
+        try {
+            packageInfo = packageManager.getPackageInfo(packageName, packageInfoFlags);
+        } catch (PackageManager.NameNotFoundException e) {
+            return null;
+        }
+
+        packageInfoFlutterApi.create(packageInfo);
+
+        return instanceManager.getIdentifierForStrongReference(packageInfo).toString();
+    }
+
+    @NonNull
+    @Override
+    public Boolean hasSystemFeature(@NonNull String instanceId, @NonNull String featureName) {
+        final UUID instanceUuid = UUID.fromString(instanceId);
+        final PackageManager packageManager = instanceManager.getInstance(instanceUuid);
+        return packageManager.hasSystemFeature(featureName);
+    }
+
+    @Deprecated
+    @NonNull
+    @Override
+    public List<String> queryIntentActivitiesWithFlags(
+        @NonNull String instanceId,
+        @NonNull String intentInstanceId,
+        @NonNull Long flags
+    ) {
+        final UUID instanceUuid = UUID.fromString(instanceId);
+        final UUID intentInstanceUuid = UUID.fromString(intentInstanceId);
+
+        final PackageManager packageManager = instanceManager.getInstance(instanceUuid);
+        final Intent intent = instanceManager.getInstance(intentInstanceUuid);
+
+        final List<ResolveInfo> resolveInfoList = packageManager.queryIntentActivities(intent, flags.intValue());
+        final List<String> resolveInfoInstanceList = new ArrayList<>();
+
+        for (ResolveInfo resolveInfo : resolveInfoList) {
+            resolveInfoFlutterApi.create(resolveInfo);
+            final UUID resolveInfoUuid = instanceManager.getIdentifierForStrongReference(resolveInfo);
+            resolveInfoInstanceList.add(resolveInfoUuid.toString());
+        }
+
+        return resolveInfoInstanceList;
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.TIRAMISU)
+    @NonNull
+    @Override
+    public List<String> queryIntentActivitiesWithInfoFlags(
+        @NonNull String instanceId,
+        @NonNull String intentInstanceId,
+        @NonNull String flagsInstanceId
+    ) {
+        final UUID instanceUuid = UUID.fromString(instanceId);
+        final UUID intentInstanceUuid = UUID.fromString(intentInstanceId);
+        final UUID flagsInstanceUuid = UUID.fromString(flagsInstanceId);
+
+        final PackageManager packageManager = instanceManager.getInstance(instanceUuid);
+        final Intent intent = instanceManager.getInstance(intentInstanceUuid);
+        final PackageManager.ResolveInfoFlags flags = instanceManager.getInstance(flagsInstanceUuid);
+
+        final List<ResolveInfo> resolveInfoList = packageManager.queryIntentActivities(intent, flags);
+        final List<String> resolveInfoInstanceList = new ArrayList<>();
+
+        for (ResolveInfo resolveInfo : resolveInfoList) {
+            resolveInfoFlutterApi.create(resolveInfo);
+            final UUID resolveInfoUuid = instanceManager.getIdentifierForStrongReference(resolveInfo);
+            resolveInfoInstanceList.add(resolveInfoUuid.toString());
+        }
+
+        return resolveInfoInstanceList;
     }
 }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PackageManagerHostApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PackageManagerHostApiImpl.java
@@ -17,8 +17,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import io.flutter.plugin.common.BinaryMessenger;
-
 /**
  * Host API implementation for `PackageManager`.
  *
@@ -26,10 +24,6 @@ import io.flutter.plugin.common.BinaryMessenger;
  * Dart instance or handle method calls on the associated native class or an instance of the class.
  */
 public class PackageManagerHostApiImpl implements PackageManagerHostApi {
-    // To ease adding additional methods, this value is added prematurely.
-    @SuppressWarnings({"unused", "FieldCanBeLocal"})
-    private final BinaryMessenger binaryMessenger;
-
     private final InstanceManager instanceManager;
 
     private final PackageInfoFlutterApiImpl packageInfoFlutterApi;
@@ -39,18 +33,15 @@ public class PackageManagerHostApiImpl implements PackageManagerHostApi {
     /**
      * Constructs an {@link PackageManagerHostApiImpl}.
      *
-     * @param binaryMessenger used to communicate with Dart over asynchronous messages
      * @param instanceManager maintains instances stored to communicate with attached Dart objects
      */
     public PackageManagerHostApiImpl(
         @NonNull PackageInfoFlutterApiImpl packageInfoFlutterApi,
         @NonNull ResolveInfoFlutterApiImpl resolveInfoFlutterApi,
-        @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
         this.packageInfoFlutterApi = packageInfoFlutterApi;
         this.resolveInfoFlutterApi = resolveInfoFlutterApi;
-        this.binaryMessenger = binaryMessenger;
         this.instanceManager = instanceManager;
     }
 

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPigeon.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPigeon.java
@@ -1516,4 +1516,58 @@ public class PermissionHandlerPigeon {
           channelReply -> callback.reply(null));
     }
   }
+  /**
+   * Host API for `Environment`.
+   *
+   * This class may handle instantiating and adding native object instances that
+   * are attached to a Dart instance or handle method calls on the associated
+   * native class or an instance of the class.
+   *
+   * See https://developer.android.com/reference/android/os/Environment.
+   *
+   * Generated interface from Pigeon that represents a handler of messages from Flutter.
+   */
+  public interface EnvironmentHostApi {
+    /**
+     * Returns whether the calling app has All Files Access on the primary shared/external storage media.
+     *
+     * Declaring the permission [Manifest.permission.manageExternalStorage] is
+     * not enough to gain the access. To request access, use
+     * [Settings.actionManageAppAllFilesAccessPermission].
+     *
+     * See https://developer.android.com/reference/android/os/Environment#isExternalStorageManager().
+     */
+    @NonNull 
+    Boolean isExternalStorageManager();
+
+    /** The codec used by EnvironmentHostApi. */
+    static @NonNull MessageCodec<Object> getCodec() {
+      return new StandardMessageCodec();
+    }
+    /**Sets up an instance of `EnvironmentHostApi` to handle messages through the `binaryMessenger`. */
+    static void setup(@NonNull BinaryMessenger binaryMessenger, @Nullable EnvironmentHostApi api) {
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(
+                binaryMessenger, "dev.flutter.pigeon.permission_handler_android.EnvironmentHostApi.isExternalStorageManager", getCodec());
+        if (api != null) {
+          channel.setMessageHandler(
+              (message, reply) -> {
+                ArrayList<Object> wrapped = new ArrayList<Object>();
+                try {
+                  Boolean output = api.isExternalStorageManager();
+                  wrapped.add(0, output);
+                }
+ catch (Throwable exception) {
+                  ArrayList<Object> wrappedError = wrapError(exception);
+                  wrapped = wrappedError;
+                }
+                reply.reply(wrapped);
+              });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+    }
+  }
 }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPigeon.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPigeon.java
@@ -715,7 +715,8 @@ public class PermissionHandlerPigeon {
      *
      * See https://developer.android.com/reference/android/net/Uri#parse(java.lang.String).
      */
-    void parse(@NonNull String instanceId, @NonNull String uriString);
+    @NonNull 
+    String parse(@NonNull String uriString);
     /**
      * Returns the encoded string representation of this URI.
      *
@@ -744,11 +745,10 @@ public class PermissionHandlerPigeon {
               (message, reply) -> {
                 ArrayList<Object> wrapped = new ArrayList<Object>();
                 ArrayList<Object> args = (ArrayList<Object>) message;
-                String instanceIdArg = (String) args.get(0);
-                String uriStringArg = (String) args.get(1);
+                String uriStringArg = (String) args.get(0);
                 try {
-                  api.parse(instanceIdArg, uriStringArg);
-                  wrapped.add(0, null);
+                  String output = api.parse(uriStringArg);
+                  wrapped.add(0, output);
                 }
  catch (Throwable exception) {
                   ArrayList<Object> wrappedError = wrapError(exception);
@@ -784,6 +784,52 @@ public class PermissionHandlerPigeon {
           channel.setMessageHandler(null);
         }
       }
+    }
+  }
+  /**
+   * Flutter API for `Uri`.
+   *
+   * This class may handle instantiating and adding Dart instances that are
+   * attached to a native instance or receiving callback methods from an
+   * overridden native class.
+   *
+   * See https://developer.android.com/reference/android/net/Uri.
+   *
+   * Generated class from Pigeon that represents Flutter messages that can be called from Java.
+   */
+  public static class UriFlutterApi {
+    private final @NonNull BinaryMessenger binaryMessenger;
+
+    public UriFlutterApi(@NonNull BinaryMessenger argBinaryMessenger) {
+      this.binaryMessenger = argBinaryMessenger;
+    }
+
+    /** Public interface for sending reply. */ 
+    @SuppressWarnings("UnknownNullness")
+    public interface Reply<T> {
+      void reply(T reply);
+    }
+    /** The codec used by UriFlutterApi. */
+    static @NonNull MessageCodec<Object> getCodec() {
+      return new StandardMessageCodec();
+    }
+    /** Create a new Dart instance and add it to the `InstanceManager`. */
+    public void create(@NonNull String instanceIdArg, @NonNull Reply<Void> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(
+              binaryMessenger, "dev.flutter.pigeon.permission_handler_android.UriFlutterApi.create", getCodec());
+      channel.send(
+          new ArrayList<Object>(Collections.singletonList(instanceIdArg)),
+          channelReply -> callback.reply(null));
+    }
+    /** Dispose of the Dart instance and remove it from the `InstanceManager`. */
+    public void dispose(@NonNull String instanceIdArg, @NonNull Reply<Void> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(
+              binaryMessenger, "dev.flutter.pigeon.permission_handler_android.UriFlutterApi.dispose", getCodec());
+      channel.send(
+          new ArrayList<Object>(Collections.singletonList(instanceIdArg)),
+          channelReply -> callback.reply(null));
     }
   }
   /**
@@ -1243,6 +1289,43 @@ public class PermissionHandlerPigeon {
      */
     @NonNull 
     Boolean canRequestPackageInstalls(@NonNull String instanceId);
+    /**
+     * Retrieve overall information about an application package that is installed on the system.
+     *
+     * Use [getPackageInfoWithInfoFlags] when long flags are needed.
+     *
+     * See https://developer.android.com/reference/android/content/pm/PackageManager#getPackageInfo(java.lang.String,%20int).
+     */
+    @Nullable 
+    String getPackageInfoWithFlags(@NonNull String instanceId, @NonNull String packageName, @NonNull Long flags);
+    /**
+     * Retrieve overall information about an application package that is installed on the system.
+     *
+     * See https://developer.android.com/reference/android/content/pm/PackageManager#getPackageInfo(java.lang.String,%20android.content.pm.PackageManager.PackageInfoFlags).
+     */
+    @Nullable 
+    String getPackageInfoWithInfoFlags(@NonNull String instanceId, @NonNull String packageName, @NonNull String flagsInstanceId);
+    /**
+     * Check whether the given feature name is one of the available features as returned by getSystemAvailableFeatures().
+     *
+     * See https://developer.android.com/reference/android/content/pm/PackageManager#hasSystemFeature(java.lang.String).
+     */
+    @NonNull 
+    Boolean hasSystemFeature(@NonNull String instanceId, @NonNull String featureName);
+    /**
+     * Retrieve all activities that can be performed for the given intent.
+     *
+     * See https://developer.android.com/reference/android/content/pm/PackageManager#queryIntentActivities(android.content.Intent,%20int).
+     */
+    @NonNull 
+    List<String> queryIntentActivitiesWithFlags(@NonNull String instanceId, @NonNull String intentInstanceId, @NonNull Long flags);
+    /**
+     * Retrieve all activities that can be performed for the given intent.
+     *
+     * See https://developer.android.com/reference/android/content/pm/PackageManager#queryIntentActivities(android.content.Intent,%20android.content.pm.ResolveInfoFlags).
+     */
+    @NonNull 
+    List<String> queryIntentActivitiesWithInfoFlags(@NonNull String instanceId, @NonNull String intentInstanceId, @NonNull String flagsInstanceId);
 
     /** The codec used by PackageManagerHostApi. */
     static @NonNull MessageCodec<Object> getCodec() {
@@ -1262,6 +1345,135 @@ public class PermissionHandlerPigeon {
                 String instanceIdArg = (String) args.get(0);
                 try {
                   Boolean output = api.canRequestPackageInstalls(instanceIdArg);
+                  wrapped.add(0, output);
+                }
+ catch (Throwable exception) {
+                  ArrayList<Object> wrappedError = wrapError(exception);
+                  wrapped = wrappedError;
+                }
+                reply.reply(wrapped);
+              });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(
+                binaryMessenger, "dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.getPackageInfoWithFlags", getCodec());
+        if (api != null) {
+          channel.setMessageHandler(
+              (message, reply) -> {
+                ArrayList<Object> wrapped = new ArrayList<Object>();
+                ArrayList<Object> args = (ArrayList<Object>) message;
+                String instanceIdArg = (String) args.get(0);
+                String packageNameArg = (String) args.get(1);
+                Number flagsArg = (Number) args.get(2);
+                try {
+                  String output = api.getPackageInfoWithFlags(instanceIdArg, packageNameArg, (flagsArg == null) ? null : flagsArg.longValue());
+                  wrapped.add(0, output);
+                }
+ catch (Throwable exception) {
+                  ArrayList<Object> wrappedError = wrapError(exception);
+                  wrapped = wrappedError;
+                }
+                reply.reply(wrapped);
+              });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(
+                binaryMessenger, "dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.getPackageInfoWithInfoFlags", getCodec());
+        if (api != null) {
+          channel.setMessageHandler(
+              (message, reply) -> {
+                ArrayList<Object> wrapped = new ArrayList<Object>();
+                ArrayList<Object> args = (ArrayList<Object>) message;
+                String instanceIdArg = (String) args.get(0);
+                String packageNameArg = (String) args.get(1);
+                String flagsInstanceIdArg = (String) args.get(2);
+                try {
+                  String output = api.getPackageInfoWithInfoFlags(instanceIdArg, packageNameArg, flagsInstanceIdArg);
+                  wrapped.add(0, output);
+                }
+ catch (Throwable exception) {
+                  ArrayList<Object> wrappedError = wrapError(exception);
+                  wrapped = wrappedError;
+                }
+                reply.reply(wrapped);
+              });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(
+                binaryMessenger, "dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.hasSystemFeature", getCodec());
+        if (api != null) {
+          channel.setMessageHandler(
+              (message, reply) -> {
+                ArrayList<Object> wrapped = new ArrayList<Object>();
+                ArrayList<Object> args = (ArrayList<Object>) message;
+                String instanceIdArg = (String) args.get(0);
+                String featureNameArg = (String) args.get(1);
+                try {
+                  Boolean output = api.hasSystemFeature(instanceIdArg, featureNameArg);
+                  wrapped.add(0, output);
+                }
+ catch (Throwable exception) {
+                  ArrayList<Object> wrappedError = wrapError(exception);
+                  wrapped = wrappedError;
+                }
+                reply.reply(wrapped);
+              });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(
+                binaryMessenger, "dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.queryIntentActivitiesWithFlags", getCodec());
+        if (api != null) {
+          channel.setMessageHandler(
+              (message, reply) -> {
+                ArrayList<Object> wrapped = new ArrayList<Object>();
+                ArrayList<Object> args = (ArrayList<Object>) message;
+                String instanceIdArg = (String) args.get(0);
+                String intentInstanceIdArg = (String) args.get(1);
+                Number flagsArg = (Number) args.get(2);
+                try {
+                  List<String> output = api.queryIntentActivitiesWithFlags(instanceIdArg, intentInstanceIdArg, (flagsArg == null) ? null : flagsArg.longValue());
+                  wrapped.add(0, output);
+                }
+ catch (Throwable exception) {
+                  ArrayList<Object> wrappedError = wrapError(exception);
+                  wrapped = wrappedError;
+                }
+                reply.reply(wrapped);
+              });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(
+                binaryMessenger, "dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.queryIntentActivitiesWithInfoFlags", getCodec());
+        if (api != null) {
+          channel.setMessageHandler(
+              (message, reply) -> {
+                ArrayList<Object> wrapped = new ArrayList<Object>();
+                ArrayList<Object> args = (ArrayList<Object>) message;
+                String instanceIdArg = (String) args.get(0);
+                String intentInstanceIdArg = (String) args.get(1);
+                String flagsInstanceIdArg = (String) args.get(2);
+                try {
+                  List<String> output = api.queryIntentActivitiesWithInfoFlags(instanceIdArg, intentInstanceIdArg, flagsInstanceIdArg);
                   wrapped.add(0, output);
                 }
  catch (Throwable exception) {
@@ -1568,6 +1780,530 @@ public class PermissionHandlerPigeon {
           channel.setMessageHandler(null);
         }
       }
+    }
+  }
+  /**
+   * Host API for `PackageInfo`.
+   *
+   * This class may handle instantiating and adding native object instances that
+   * are attached to a Dart instance or handle method calls on the associated
+   * native class or an instance of the class.
+   *
+   * See https://developer.android.com/reference/android/content/pm/PackageInfo.
+   *
+   * Generated interface from Pigeon that represents a handler of messages from Flutter.
+   */
+  public interface PackageInfoHostApi {
+    /**
+     * Array of all <uses-permission> tags included under <manifest>, or null if there were none.
+     *
+     * This is only filled in if the flag PackageManager#GET_PERMISSIONS was set.
+     * This list includes all permissions requested, even those that were not
+     * granted or known by the system at install time.
+     *
+     * See https://developer.android.com/reference/android/content/pm/PackageInfo#requestedPermissions.
+     */
+    @NonNull 
+    List<String> getRequestedPermissions(@NonNull String instanceId);
+
+    /** The codec used by PackageInfoHostApi. */
+    static @NonNull MessageCodec<Object> getCodec() {
+      return new StandardMessageCodec();
+    }
+    /**Sets up an instance of `PackageInfoHostApi` to handle messages through the `binaryMessenger`. */
+    static void setup(@NonNull BinaryMessenger binaryMessenger, @Nullable PackageInfoHostApi api) {
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(
+                binaryMessenger, "dev.flutter.pigeon.permission_handler_android.PackageInfoHostApi.getRequestedPermissions", getCodec());
+        if (api != null) {
+          channel.setMessageHandler(
+              (message, reply) -> {
+                ArrayList<Object> wrapped = new ArrayList<Object>();
+                ArrayList<Object> args = (ArrayList<Object>) message;
+                String instanceIdArg = (String) args.get(0);
+                try {
+                  List<String> output = api.getRequestedPermissions(instanceIdArg);
+                  wrapped.add(0, output);
+                }
+ catch (Throwable exception) {
+                  ArrayList<Object> wrappedError = wrapError(exception);
+                  wrapped = wrappedError;
+                }
+                reply.reply(wrapped);
+              });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+    }
+  }
+  /**
+   * Flutter API for `PackageInfo`.
+   *
+   * This class may handle instantiating and adding Dart instances that are
+   * attached to a native instance or receiving callback methods from an
+   * overridden native class.
+   *
+   * See https://developer.android.com/reference/android/content/pm/PackageInfo.
+   *
+   * Generated class from Pigeon that represents Flutter messages that can be called from Java.
+   */
+  public static class PackageInfoFlutterApi {
+    private final @NonNull BinaryMessenger binaryMessenger;
+
+    public PackageInfoFlutterApi(@NonNull BinaryMessenger argBinaryMessenger) {
+      this.binaryMessenger = argBinaryMessenger;
+    }
+
+    /** Public interface for sending reply. */ 
+    @SuppressWarnings("UnknownNullness")
+    public interface Reply<T> {
+      void reply(T reply);
+    }
+    /** The codec used by PackageInfoFlutterApi. */
+    static @NonNull MessageCodec<Object> getCodec() {
+      return new StandardMessageCodec();
+    }
+    /** Create a new Dart instance and add it to the `InstanceManager`. */
+    public void create(@NonNull String instanceIdArg, @NonNull Reply<Void> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(
+              binaryMessenger, "dev.flutter.pigeon.permission_handler_android.PackageInfoFlutterApi.create", getCodec());
+      channel.send(
+          new ArrayList<Object>(Collections.singletonList(instanceIdArg)),
+          channelReply -> callback.reply(null));
+    }
+    /** Dispose of the Dart instance and remove it from the `InstanceManager`. */
+    public void dispose(@NonNull String instanceIdArg, @NonNull Reply<Void> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(
+              binaryMessenger, "dev.flutter.pigeon.permission_handler_android.PackageInfoFlutterApi.dispose", getCodec());
+      channel.send(
+          new ArrayList<Object>(Collections.singletonList(instanceIdArg)),
+          channelReply -> callback.reply(null));
+    }
+  }
+  /**
+   * Host API for `PackageInfoFlags`.
+   *
+   * This class may handle instantiating and adding native object instances that
+   * are attached to a Dart instance or handle method calls on the associated
+   * native class or an instance of the class.
+   *
+   * See https://developer.android.com/reference/android/content/pm/PackageManager#PackageInfoFlags.
+   *
+   * Generated interface from Pigeon that represents a handler of messages from Flutter.
+   */
+  public interface PackageInfoFlagsHostApi {
+    /** See https://developer.android.com/reference/android/content/pm/PackageManager.PackageInfoFlags#of(long). */
+    @NonNull 
+    String of(@NonNull Long value);
+
+    /** The codec used by PackageInfoFlagsHostApi. */
+    static @NonNull MessageCodec<Object> getCodec() {
+      return new StandardMessageCodec();
+    }
+    /**Sets up an instance of `PackageInfoFlagsHostApi` to handle messages through the `binaryMessenger`. */
+    static void setup(@NonNull BinaryMessenger binaryMessenger, @Nullable PackageInfoFlagsHostApi api) {
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(
+                binaryMessenger, "dev.flutter.pigeon.permission_handler_android.PackageInfoFlagsHostApi.of", getCodec());
+        if (api != null) {
+          channel.setMessageHandler(
+              (message, reply) -> {
+                ArrayList<Object> wrapped = new ArrayList<Object>();
+                ArrayList<Object> args = (ArrayList<Object>) message;
+                Number valueArg = (Number) args.get(0);
+                try {
+                  String output = api.of((valueArg == null) ? null : valueArg.longValue());
+                  wrapped.add(0, output);
+                }
+ catch (Throwable exception) {
+                  ArrayList<Object> wrappedError = wrapError(exception);
+                  wrapped = wrappedError;
+                }
+                reply.reply(wrapped);
+              });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+    }
+  }
+  /**
+   * Flutter API for `PackageInfoFlags`.
+   *
+   * This class may handle instantiating and adding Dart instances that are
+   * attached to a native instance or receiving callback methods from an
+   * overridden native class.
+   *
+   * See https://developer.android.com/reference/android/content/pm/PackageManager#PackageInfoFlags.
+   *
+   * Generated class from Pigeon that represents Flutter messages that can be called from Java.
+   */
+  public static class PackageInfoFlagsFlutterApi {
+    private final @NonNull BinaryMessenger binaryMessenger;
+
+    public PackageInfoFlagsFlutterApi(@NonNull BinaryMessenger argBinaryMessenger) {
+      this.binaryMessenger = argBinaryMessenger;
+    }
+
+    /** Public interface for sending reply. */ 
+    @SuppressWarnings("UnknownNullness")
+    public interface Reply<T> {
+      void reply(T reply);
+    }
+    /** The codec used by PackageInfoFlagsFlutterApi. */
+    static @NonNull MessageCodec<Object> getCodec() {
+      return new StandardMessageCodec();
+    }
+    /** Create a new Dart instance and add it to the `InstanceManager`. */
+    public void create(@NonNull String instanceIdArg, @NonNull Reply<Void> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(
+              binaryMessenger, "dev.flutter.pigeon.permission_handler_android.PackageInfoFlagsFlutterApi.create", getCodec());
+      channel.send(
+          new ArrayList<Object>(Collections.singletonList(instanceIdArg)),
+          channelReply -> callback.reply(null));
+    }
+    /** Dispose of the Dart instance and remove it from the `InstanceManager`. */
+    public void dispose(@NonNull String instanceIdArg, @NonNull Reply<Void> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(
+              binaryMessenger, "dev.flutter.pigeon.permission_handler_android.PackageInfoFlagsFlutterApi.dispose", getCodec());
+      channel.send(
+          new ArrayList<Object>(Collections.singletonList(instanceIdArg)),
+          channelReply -> callback.reply(null));
+    }
+  }
+  /**
+   * Host API for `ResolveInfoFlags`.
+   *
+   * This class may handle instantiating and adding native object instances that
+   * are attached to a Dart instance or handle method calls on the associated
+   * native class or an instance of the class.
+   *
+   * See https://developer.android.com/reference/android/content/pm/PackageManager#ResolveInfoFlags.
+   *
+   * Generated interface from Pigeon that represents a handler of messages from Flutter.
+   */
+  public interface ResolveInfoFlagsHostApi {
+    /** See https://developer.android.com/reference/android/content/pm/PackageManager.ResolveInfoFlags#of(long). */
+    @NonNull 
+    String of(@NonNull Long value);
+
+    /** The codec used by ResolveInfoFlagsHostApi. */
+    static @NonNull MessageCodec<Object> getCodec() {
+      return new StandardMessageCodec();
+    }
+    /**Sets up an instance of `ResolveInfoFlagsHostApi` to handle messages through the `binaryMessenger`. */
+    static void setup(@NonNull BinaryMessenger binaryMessenger, @Nullable ResolveInfoFlagsHostApi api) {
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(
+                binaryMessenger, "dev.flutter.pigeon.permission_handler_android.ResolveInfoFlagsHostApi.of", getCodec());
+        if (api != null) {
+          channel.setMessageHandler(
+              (message, reply) -> {
+                ArrayList<Object> wrapped = new ArrayList<Object>();
+                ArrayList<Object> args = (ArrayList<Object>) message;
+                Number valueArg = (Number) args.get(0);
+                try {
+                  String output = api.of((valueArg == null) ? null : valueArg.longValue());
+                  wrapped.add(0, output);
+                }
+ catch (Throwable exception) {
+                  ArrayList<Object> wrappedError = wrapError(exception);
+                  wrapped = wrappedError;
+                }
+                reply.reply(wrapped);
+              });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+    }
+  }
+  /**
+   * Flutter API for `ResolveInfoFlags`.
+   *
+   * This class may handle instantiating and adding Dart instances that are
+   * attached to a native instance or receiving callback methods from an
+   * overridden native class.
+   *
+   * See https://developer.android.com/reference/android/content/pm/PackageManager#ResolveInfoFlags.
+   *
+   * Generated class from Pigeon that represents Flutter messages that can be called from Java.
+   */
+  public static class ResolveInfoFlagsFlutterApi {
+    private final @NonNull BinaryMessenger binaryMessenger;
+
+    public ResolveInfoFlagsFlutterApi(@NonNull BinaryMessenger argBinaryMessenger) {
+      this.binaryMessenger = argBinaryMessenger;
+    }
+
+    /** Public interface for sending reply. */ 
+    @SuppressWarnings("UnknownNullness")
+    public interface Reply<T> {
+      void reply(T reply);
+    }
+    /** The codec used by ResolveInfoFlagsFlutterApi. */
+    static @NonNull MessageCodec<Object> getCodec() {
+      return new StandardMessageCodec();
+    }
+    /** Create a new Dart instance and add it to the `InstanceManager`. */
+    public void create(@NonNull String instanceIdArg, @NonNull Reply<Void> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(
+              binaryMessenger, "dev.flutter.pigeon.permission_handler_android.ResolveInfoFlagsFlutterApi.create", getCodec());
+      channel.send(
+          new ArrayList<Object>(Collections.singletonList(instanceIdArg)),
+          channelReply -> callback.reply(null));
+    }
+    /** Dispose of the Dart instance and remove it from the `InstanceManager`. */
+    public void dispose(@NonNull String instanceIdArg, @NonNull Reply<Void> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(
+              binaryMessenger, "dev.flutter.pigeon.permission_handler_android.ResolveInfoFlagsFlutterApi.dispose", getCodec());
+      channel.send(
+          new ArrayList<Object>(Collections.singletonList(instanceIdArg)),
+          channelReply -> callback.reply(null));
+    }
+  }
+  /**
+   * Host API for `ApplicationInfoFlags`.
+   *
+   * This class may handle instantiating and adding native object instances that
+   * are attached to a Dart instance or handle method calls on the associated
+   * native class or an instance of the class.
+   *
+   * See https://developer.android.com/reference/android/content/pm/PackageManager#ApplicationInfoFlags.
+   *
+   * Generated interface from Pigeon that represents a handler of messages from Flutter.
+   */
+  public interface ApplicationInfoFlagsHostApi {
+    /** See https://developer.android.com/reference/android/content/pm/PackageManager.ApplicationInfoFlags#of(long). */
+    @NonNull 
+    String of(@NonNull Long value);
+
+    /** The codec used by ApplicationInfoFlagsHostApi. */
+    static @NonNull MessageCodec<Object> getCodec() {
+      return new StandardMessageCodec();
+    }
+    /**Sets up an instance of `ApplicationInfoFlagsHostApi` to handle messages through the `binaryMessenger`. */
+    static void setup(@NonNull BinaryMessenger binaryMessenger, @Nullable ApplicationInfoFlagsHostApi api) {
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(
+                binaryMessenger, "dev.flutter.pigeon.permission_handler_android.ApplicationInfoFlagsHostApi.of", getCodec());
+        if (api != null) {
+          channel.setMessageHandler(
+              (message, reply) -> {
+                ArrayList<Object> wrapped = new ArrayList<Object>();
+                ArrayList<Object> args = (ArrayList<Object>) message;
+                Number valueArg = (Number) args.get(0);
+                try {
+                  String output = api.of((valueArg == null) ? null : valueArg.longValue());
+                  wrapped.add(0, output);
+                }
+ catch (Throwable exception) {
+                  ArrayList<Object> wrappedError = wrapError(exception);
+                  wrapped = wrappedError;
+                }
+                reply.reply(wrapped);
+              });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+    }
+  }
+  /**
+   * Flutter API for `ApplicationInfoFlags`.
+   *
+   * This class may handle instantiating and adding Dart instances that are
+   * attached to a native instance or receiving callback methods from an
+   * overridden native class.
+   *
+   * See https://developer.android.com/reference/android/content/pm/PackageManager#ApplicationInfoFlags.
+   *
+   * Generated class from Pigeon that represents Flutter messages that can be called from Java.
+   */
+  public static class ApplicationInfoFlagsFlutterApi {
+    private final @NonNull BinaryMessenger binaryMessenger;
+
+    public ApplicationInfoFlagsFlutterApi(@NonNull BinaryMessenger argBinaryMessenger) {
+      this.binaryMessenger = argBinaryMessenger;
+    }
+
+    /** Public interface for sending reply. */ 
+    @SuppressWarnings("UnknownNullness")
+    public interface Reply<T> {
+      void reply(T reply);
+    }
+    /** The codec used by ApplicationInfoFlagsFlutterApi. */
+    static @NonNull MessageCodec<Object> getCodec() {
+      return new StandardMessageCodec();
+    }
+    /** Create a new Dart instance and add it to the `InstanceManager`. */
+    public void create(@NonNull String instanceIdArg, @NonNull Reply<Void> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(
+              binaryMessenger, "dev.flutter.pigeon.permission_handler_android.ApplicationInfoFlagsFlutterApi.create", getCodec());
+      channel.send(
+          new ArrayList<Object>(Collections.singletonList(instanceIdArg)),
+          channelReply -> callback.reply(null));
+    }
+    /** Dispose of the Dart instance and remove it from the `InstanceManager`. */
+    public void dispose(@NonNull String instanceIdArg, @NonNull Reply<Void> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(
+              binaryMessenger, "dev.flutter.pigeon.permission_handler_android.ApplicationInfoFlagsFlutterApi.dispose", getCodec());
+      channel.send(
+          new ArrayList<Object>(Collections.singletonList(instanceIdArg)),
+          channelReply -> callback.reply(null));
+    }
+  }
+  /**
+   * Host API for `ComponentInfoFlags`.
+   *
+   * This class may handle instantiating and adding native object instances that
+   * are attached to a Dart instance or handle method calls on the associated
+   * native class or an instance of the class.
+   *
+   * See https://developer.android.com/reference/android/content/pm/PackageManager#ComponentInfoFlags.
+   *
+   * Generated interface from Pigeon that represents a handler of messages from Flutter.
+   */
+  public interface ComponentInfoFlagsHostApi {
+    /** See https://developer.android.com/reference/android/content/pm/PackageManager.ComponentInfoFlags#of(long). */
+    @NonNull 
+    String of(@NonNull Long value);
+
+    /** The codec used by ComponentInfoFlagsHostApi. */
+    static @NonNull MessageCodec<Object> getCodec() {
+      return new StandardMessageCodec();
+    }
+    /**Sets up an instance of `ComponentInfoFlagsHostApi` to handle messages through the `binaryMessenger`. */
+    static void setup(@NonNull BinaryMessenger binaryMessenger, @Nullable ComponentInfoFlagsHostApi api) {
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(
+                binaryMessenger, "dev.flutter.pigeon.permission_handler_android.ComponentInfoFlagsHostApi.of", getCodec());
+        if (api != null) {
+          channel.setMessageHandler(
+              (message, reply) -> {
+                ArrayList<Object> wrapped = new ArrayList<Object>();
+                ArrayList<Object> args = (ArrayList<Object>) message;
+                Number valueArg = (Number) args.get(0);
+                try {
+                  String output = api.of((valueArg == null) ? null : valueArg.longValue());
+                  wrapped.add(0, output);
+                }
+ catch (Throwable exception) {
+                  ArrayList<Object> wrappedError = wrapError(exception);
+                  wrapped = wrappedError;
+                }
+                reply.reply(wrapped);
+              });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+    }
+  }
+  /**
+   * Flutter API for `ComponentInfoFlags`.
+   *
+   * This class may handle instantiating and adding Dart instances that are
+   * attached to a native instance or receiving callback methods from an
+   * overridden native class.
+   *
+   * See https://developer.android.com/reference/android/content/pm/PackageManager#ComponentInfoFlags.
+   *
+   * Generated class from Pigeon that represents Flutter messages that can be called from Java.
+   */
+  public static class ComponentInfoFlagsFlutterApi {
+    private final @NonNull BinaryMessenger binaryMessenger;
+
+    public ComponentInfoFlagsFlutterApi(@NonNull BinaryMessenger argBinaryMessenger) {
+      this.binaryMessenger = argBinaryMessenger;
+    }
+
+    /** Public interface for sending reply. */ 
+    @SuppressWarnings("UnknownNullness")
+    public interface Reply<T> {
+      void reply(T reply);
+    }
+    /** The codec used by ComponentInfoFlagsFlutterApi. */
+    static @NonNull MessageCodec<Object> getCodec() {
+      return new StandardMessageCodec();
+    }
+    /** Create a new Dart instance and add it to the `InstanceManager`. */
+    public void create(@NonNull String instanceIdArg, @NonNull Reply<Void> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(
+              binaryMessenger, "dev.flutter.pigeon.permission_handler_android.ComponentInfoFlagsFlutterApi.create", getCodec());
+      channel.send(
+          new ArrayList<Object>(Collections.singletonList(instanceIdArg)),
+          channelReply -> callback.reply(null));
+    }
+    /** Dispose of the Dart instance and remove it from the `InstanceManager`. */
+    public void dispose(@NonNull String instanceIdArg, @NonNull Reply<Void> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(
+              binaryMessenger, "dev.flutter.pigeon.permission_handler_android.ComponentInfoFlagsFlutterApi.dispose", getCodec());
+      channel.send(
+          new ArrayList<Object>(Collections.singletonList(instanceIdArg)),
+          channelReply -> callback.reply(null));
+    }
+  }
+  /**
+   * Flutter API for `ResolveInfo`.
+   *
+   * This class may handle instantiating and adding Dart instances that are
+   * attached to a native instance or receiving callback methods from an
+   * overridden native class.
+   *
+   * See https://developer.android.com/reference/android/content/pm/ResolveInfo.
+   *
+   * Generated class from Pigeon that represents Flutter messages that can be called from Java.
+   */
+  public static class ResolveInfoFlutterApi {
+    private final @NonNull BinaryMessenger binaryMessenger;
+
+    public ResolveInfoFlutterApi(@NonNull BinaryMessenger argBinaryMessenger) {
+      this.binaryMessenger = argBinaryMessenger;
+    }
+
+    /** Public interface for sending reply. */ 
+    @SuppressWarnings("UnknownNullness")
+    public interface Reply<T> {
+      void reply(T reply);
+    }
+    /** The codec used by ResolveInfoFlutterApi. */
+    static @NonNull MessageCodec<Object> getCodec() {
+      return new StandardMessageCodec();
+    }
+    /** Create a new Dart instance and add it to the `InstanceManager`. */
+    public void create(@NonNull String instanceIdArg, @NonNull Reply<Void> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(
+              binaryMessenger, "dev.flutter.pigeon.permission_handler_android.ResolveInfoFlutterApi.create", getCodec());
+      channel.send(
+          new ArrayList<Object>(Collections.singletonList(instanceIdArg)),
+          channelReply -> callback.reply(null));
+    }
+    /** Dispose of the Dart instance and remove it from the `InstanceManager`. */
+    public void dispose(@NonNull String instanceIdArg, @NonNull Reply<Void> callback) {
+      BasicMessageChannel<Object> channel =
+          new BasicMessageChannel<>(
+              binaryMessenger, "dev.flutter.pigeon.permission_handler_android.ResolveInfoFlutterApi.dispose", getCodec());
+      channel.send(
+          new ArrayList<Object>(Collections.singletonList(instanceIdArg)),
+          channelReply -> callback.reply(null));
     }
   }
 }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
@@ -17,6 +17,11 @@ import com.baseflow.permissionhandler.PermissionHandlerPigeon.ContextHostApi;
 import com.baseflow.permissionhandler.PermissionHandlerPigeon.EnvironmentHostApi;
 import com.baseflow.permissionhandler.PermissionHandlerPigeon.IntentHostApi;
 import com.baseflow.permissionhandler.PermissionHandlerPigeon.NotificationManagerHostApi;
+import com.baseflow.permissionhandler.PermissionHandlerPigeon.PackageInfoFlagsHostApi;
+import com.baseflow.permissionhandler.PermissionHandlerPigeon.PackageInfoHostApi;
+import com.baseflow.permissionhandler.PermissionHandlerPigeon.ResolveInfoFlagsHostApi;
+import com.baseflow.permissionhandler.PermissionHandlerPigeon.ComponentInfoFlagsHostApi;
+import com.baseflow.permissionhandler.PermissionHandlerPigeon.ApplicationInfoFlagsHostApi;
 import com.baseflow.permissionhandler.PermissionHandlerPigeon.PackageManagerHostApi;
 import com.baseflow.permissionhandler.PermissionHandlerPigeon.PowerManagerHostApi;
 import com.baseflow.permissionhandler.PermissionHandlerPigeon.SettingsHostApi;
@@ -57,7 +62,8 @@ public final class PermissionHandlerPlugin implements FlutterPlugin, ActivityAwa
         final JavaObjectHostApi javaObjectHostApi = new JavaObjectHostApiImpl(instanceManager);
         JavaObjectHostApi.setup(binaryMessenger, javaObjectHostApi);
 
-        final UriHostApi uriHostApi = new UriHostApiImpl(binaryMessenger, instanceManager);
+        final UriFlutterApiImpl uriFlutterApi = new UriFlutterApiImpl(binaryMessenger, instanceManager);
+        final UriHostApi uriHostApi = new UriHostApiImpl(uriFlutterApi, binaryMessenger, instanceManager);
         UriHostApi.setup(binaryMessenger, uriHostApi);
 
         final IntentHostApi intentHostApi = new IntentHostApiImpl(binaryMessenger, instanceManager);
@@ -71,8 +77,30 @@ public final class PermissionHandlerPlugin implements FlutterPlugin, ActivityAwa
         final AlarmManagerHostApi alarmManagerHostApi = new AlarmManagerHostApiImpl(binaryMessenger, instanceManager);
         AlarmManagerHostApi.setup(binaryMessenger, alarmManagerHostApi);
 
+        final PackageInfoFlagsFlutterApiImpl packageInfoFlagsFlutterApi = new PackageInfoFlagsFlutterApiImpl(binaryMessenger, instanceManager);
+        final PackageInfoFlagsHostApi packageInfoFlagsHostApi = new PackageInfoFlagsHostApiImpl(packageInfoFlagsFlutterApi, binaryMessenger, instanceManager);
+        PackageInfoFlagsHostApi.setup(binaryMessenger, packageInfoFlagsHostApi);
+
+        final ResolveInfoFlagsFlutterApiImpl resolveInfoFlagsFlutterApi = new ResolveInfoFlagsFlutterApiImpl(binaryMessenger, instanceManager);
+        final ResolveInfoFlagsHostApi resolveInfoFlagsHostApi = new ResolveInfoFlagsHostApiImpl(resolveInfoFlagsFlutterApi, binaryMessenger, instanceManager);
+        ResolveInfoFlagsHostApi.setup(binaryMessenger, resolveInfoFlagsHostApi);
+
+        final ResolveInfoFlutterApiImpl resolveInfoFlutterApi = new ResolveInfoFlutterApiImpl(binaryMessenger, instanceManager);
+
+        final ComponentInfoFlagsFlutterApiImpl componentInfoFlagsFlutterApi = new ComponentInfoFlagsFlutterApiImpl(binaryMessenger, instanceManager);
+        final ComponentInfoFlagsHostApi componentInfoFlagsHostApi = new ComponentInfoFlagsHostApiImpl(componentInfoFlagsFlutterApi, binaryMessenger, instanceManager);
+        ComponentInfoFlagsHostApi.setup(binaryMessenger, componentInfoFlagsHostApi);
+
+        final ApplicationInfoFlagsFlutterApiImpl applicationInfoFlagsFlutterApi = new ApplicationInfoFlagsFlutterApiImpl(binaryMessenger, instanceManager);
+        final ApplicationInfoFlagsHostApi applicationInfoFlagsHostApi = new ApplicationInfoFlagsHostApiImpl(applicationInfoFlagsFlutterApi, binaryMessenger, instanceManager);
+        ApplicationInfoFlagsHostApi.setup(binaryMessenger, applicationInfoFlagsHostApi);
+
+        final PackageInfoFlutterApiImpl packageInfoFlutterApi = new PackageInfoFlutterApiImpl(binaryMessenger, instanceManager);
+        final PackageInfoHostApi packageInfoHostApi = new PackageInfoHostApiImpl(binaryMessenger, instanceManager);
+        PackageInfoHostApi.setup(binaryMessenger, packageInfoHostApi);
+
         final PackageManagerFlutterApiImpl packageManagerFlutterApi = new PackageManagerFlutterApiImpl(binaryMessenger, instanceManager);
-        final PackageManagerHostApi packageManagerHostApi = new PackageManagerHostApiImpl(binaryMessenger, instanceManager);
+        final PackageManagerHostApi packageManagerHostApi = new PackageManagerHostApiImpl(packageInfoFlutterApi, resolveInfoFlutterApi, binaryMessenger, instanceManager);
         PackageManagerHostApi.setup(binaryMessenger, packageManagerHostApi);
 
         final SettingsHostApi settingsHostApi = new SettingsHostApiImpl(binaryMessenger, instanceManager);

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
@@ -14,6 +14,7 @@ import com.baseflow.permissionhandler.PermissionHandlerPigeon.ActivityHostApi;
 import com.baseflow.permissionhandler.PermissionHandlerPigeon.AlarmManagerHostApi;
 import com.baseflow.permissionhandler.PermissionHandlerPigeon.BuildVersionHostApi;
 import com.baseflow.permissionhandler.PermissionHandlerPigeon.ContextHostApi;
+import com.baseflow.permissionhandler.PermissionHandlerPigeon.EnvironmentHostApi;
 import com.baseflow.permissionhandler.PermissionHandlerPigeon.IntentHostApi;
 import com.baseflow.permissionhandler.PermissionHandlerPigeon.NotificationManagerHostApi;
 import com.baseflow.permissionhandler.PermissionHandlerPigeon.PackageManagerHostApi;
@@ -80,6 +81,9 @@ public final class PermissionHandlerPlugin implements FlutterPlugin, ActivityAwa
         final NotificationManagerFlutterApiImpl notificationManagerFlutterApi = new NotificationManagerFlutterApiImpl(binaryMessenger, instanceManager);
         final NotificationManagerHostApi notificationManagerHostApi = new NotificationManagerHostApiImpl(binaryMessenger, instanceManager);
         NotificationManagerHostApi.setup(binaryMessenger, notificationManagerHostApi);
+
+        final EnvironmentHostApi environmentHostApi = new EnvironmentHostApiImpl(binaryMessenger, instanceManager);
+        EnvironmentHostApi.setup(binaryMessenger, environmentHostApi);
 
         activityFlutterApi = new ActivityFlutterApiImpl(binaryMessenger, instanceManager);
         activityHostApi = new ActivityHostApiImpl(

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
@@ -63,61 +63,58 @@ public final class PermissionHandlerPlugin implements FlutterPlugin, ActivityAwa
         JavaObjectHostApi.setup(binaryMessenger, javaObjectHostApi);
 
         final UriFlutterApiImpl uriFlutterApi = new UriFlutterApiImpl(binaryMessenger, instanceManager);
-        final UriHostApi uriHostApi = new UriHostApiImpl(uriFlutterApi, binaryMessenger, instanceManager);
+        final UriHostApi uriHostApi = new UriHostApiImpl(uriFlutterApi, instanceManager);
         UriHostApi.setup(binaryMessenger, uriHostApi);
 
-        final IntentHostApi intentHostApi = new IntentHostApiImpl(binaryMessenger, instanceManager);
+        final IntentHostApi intentHostApi = new IntentHostApiImpl(instanceManager);
         IntentHostApi.setup(binaryMessenger, intentHostApi);
 
         final PowerManagerFlutterApiImpl powerManagerFlutterApi = new PowerManagerFlutterApiImpl(binaryMessenger, instanceManager);
-        final PowerManagerHostApi powerManagerHostApi = new PowerManagerHostApiImpl(binaryMessenger, instanceManager);
+        final PowerManagerHostApi powerManagerHostApi = new PowerManagerHostApiImpl(instanceManager);
         PowerManagerHostApi.setup(binaryMessenger, powerManagerHostApi);
 
         final AlarmManagerFlutterApiImpl alarmManagerFlutterApi = new AlarmManagerFlutterApiImpl(binaryMessenger, instanceManager);
-        final AlarmManagerHostApi alarmManagerHostApi = new AlarmManagerHostApiImpl(binaryMessenger, instanceManager);
+        final AlarmManagerHostApi alarmManagerHostApi = new AlarmManagerHostApiImpl(instanceManager);
         AlarmManagerHostApi.setup(binaryMessenger, alarmManagerHostApi);
 
         final PackageInfoFlagsFlutterApiImpl packageInfoFlagsFlutterApi = new PackageInfoFlagsFlutterApiImpl(binaryMessenger, instanceManager);
-        final PackageInfoFlagsHostApi packageInfoFlagsHostApi = new PackageInfoFlagsHostApiImpl(packageInfoFlagsFlutterApi, binaryMessenger, instanceManager);
+        final PackageInfoFlagsHostApi packageInfoFlagsHostApi = new PackageInfoFlagsHostApiImpl(packageInfoFlagsFlutterApi, instanceManager);
         PackageInfoFlagsHostApi.setup(binaryMessenger, packageInfoFlagsHostApi);
 
         final ResolveInfoFlagsFlutterApiImpl resolveInfoFlagsFlutterApi = new ResolveInfoFlagsFlutterApiImpl(binaryMessenger, instanceManager);
-        final ResolveInfoFlagsHostApi resolveInfoFlagsHostApi = new ResolveInfoFlagsHostApiImpl(resolveInfoFlagsFlutterApi, binaryMessenger, instanceManager);
+        final ResolveInfoFlagsHostApi resolveInfoFlagsHostApi = new ResolveInfoFlagsHostApiImpl(resolveInfoFlagsFlutterApi, instanceManager);
         ResolveInfoFlagsHostApi.setup(binaryMessenger, resolveInfoFlagsHostApi);
 
         final ResolveInfoFlutterApiImpl resolveInfoFlutterApi = new ResolveInfoFlutterApiImpl(binaryMessenger, instanceManager);
 
         final ComponentInfoFlagsFlutterApiImpl componentInfoFlagsFlutterApi = new ComponentInfoFlagsFlutterApiImpl(binaryMessenger, instanceManager);
-        final ComponentInfoFlagsHostApi componentInfoFlagsHostApi = new ComponentInfoFlagsHostApiImpl(componentInfoFlagsFlutterApi, binaryMessenger, instanceManager);
+        final ComponentInfoFlagsHostApi componentInfoFlagsHostApi = new ComponentInfoFlagsHostApiImpl(componentInfoFlagsFlutterApi, instanceManager);
         ComponentInfoFlagsHostApi.setup(binaryMessenger, componentInfoFlagsHostApi);
 
         final ApplicationInfoFlagsFlutterApiImpl applicationInfoFlagsFlutterApi = new ApplicationInfoFlagsFlutterApiImpl(binaryMessenger, instanceManager);
-        final ApplicationInfoFlagsHostApi applicationInfoFlagsHostApi = new ApplicationInfoFlagsHostApiImpl(applicationInfoFlagsFlutterApi, binaryMessenger, instanceManager);
+        final ApplicationInfoFlagsHostApi applicationInfoFlagsHostApi = new ApplicationInfoFlagsHostApiImpl(applicationInfoFlagsFlutterApi, instanceManager);
         ApplicationInfoFlagsHostApi.setup(binaryMessenger, applicationInfoFlagsHostApi);
 
         final PackageInfoFlutterApiImpl packageInfoFlutterApi = new PackageInfoFlutterApiImpl(binaryMessenger, instanceManager);
-        final PackageInfoHostApi packageInfoHostApi = new PackageInfoHostApiImpl(binaryMessenger, instanceManager);
+        final PackageInfoHostApi packageInfoHostApi = new PackageInfoHostApiImpl(instanceManager);
         PackageInfoHostApi.setup(binaryMessenger, packageInfoHostApi);
 
         final PackageManagerFlutterApiImpl packageManagerFlutterApi = new PackageManagerFlutterApiImpl(binaryMessenger, instanceManager);
-        final PackageManagerHostApi packageManagerHostApi = new PackageManagerHostApiImpl(packageInfoFlutterApi, resolveInfoFlutterApi, binaryMessenger, instanceManager);
+        final PackageManagerHostApi packageManagerHostApi = new PackageManagerHostApiImpl(packageInfoFlutterApi, resolveInfoFlutterApi, instanceManager);
         PackageManagerHostApi.setup(binaryMessenger, packageManagerHostApi);
 
-        final SettingsHostApi settingsHostApi = new SettingsHostApiImpl(binaryMessenger, instanceManager);
+        final SettingsHostApi settingsHostApi = new SettingsHostApiImpl(instanceManager);
         SettingsHostApi.setup(binaryMessenger, settingsHostApi);
 
         final NotificationManagerFlutterApiImpl notificationManagerFlutterApi = new NotificationManagerFlutterApiImpl(binaryMessenger, instanceManager);
-        final NotificationManagerHostApi notificationManagerHostApi = new NotificationManagerHostApiImpl(binaryMessenger, instanceManager);
+        final NotificationManagerHostApi notificationManagerHostApi = new NotificationManagerHostApiImpl(instanceManager);
         NotificationManagerHostApi.setup(binaryMessenger, notificationManagerHostApi);
 
-        final EnvironmentHostApi environmentHostApi = new EnvironmentHostApiImpl(binaryMessenger, instanceManager);
+        final EnvironmentHostApi environmentHostApi = new EnvironmentHostApiImpl(instanceManager);
         EnvironmentHostApi.setup(binaryMessenger, environmentHostApi);
 
         activityFlutterApi = new ActivityFlutterApiImpl(binaryMessenger, instanceManager);
-        activityHostApi = new ActivityHostApiImpl(
-            binaryMessenger,
-            instanceManager
-        );
+        activityHostApi = new ActivityHostApiImpl(instanceManager);
         ActivityHostApi.setup(binaryMessenger, activityHostApi);
 
         contextFlutterApi = new ContextFlutterApiImpl(binaryMessenger, instanceManager);
@@ -126,7 +123,6 @@ public final class PermissionHandlerPlugin implements FlutterPlugin, ActivityAwa
             alarmManagerFlutterApi,
             packageManagerFlutterApi,
             notificationManagerFlutterApi,
-            binaryMessenger,
             instanceManager
         );
         ContextHostApi.setup(binaryMessenger, contextHostApi);

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PowerManagerFlutterApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PowerManagerFlutterApiImpl.java
@@ -18,10 +18,6 @@ import io.flutter.plugin.common.BinaryMessenger;
  * arguments of callbacks methods to a Dart instance.
  */
 public class PowerManagerFlutterApiImpl {
-    // To ease adding additional methods, this value is added prematurely.
-    @SuppressWarnings({"unused", "FieldCanBeLocal"})
-    private final BinaryMessenger binaryMessenger;
-
     private final InstanceManager instanceManager;
 
     private final PowerManagerFlutterApi api;
@@ -36,7 +32,6 @@ public class PowerManagerFlutterApiImpl {
         @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
-        this.binaryMessenger = binaryMessenger;
         this.instanceManager = instanceManager;
         api = new PowerManagerFlutterApi(binaryMessenger);
     }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PowerManagerHostApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PowerManagerHostApiImpl.java
@@ -11,8 +11,6 @@ import com.baseflow.permissionhandler.PermissionHandlerPigeon.PowerManagerHostAp
 
 import java.util.UUID;
 
-import io.flutter.plugin.common.BinaryMessenger;
-
 /**
  * Host API implementation for `PowerManager`.
  *
@@ -20,23 +18,16 @@ import io.flutter.plugin.common.BinaryMessenger;
  * Dart instance or handle method calls on the associated native class or an instance of the class.
  */
 public class PowerManagerHostApiImpl implements PowerManagerHostApi {
-    // To ease adding additional methods, this value is added prematurely.
-    @SuppressWarnings({"unused", "FieldCanBeLocal"})
-    private final BinaryMessenger binaryMessenger;
-
     private final InstanceManager instanceManager;
 
     /**
      * Constructs an {@link PowerManagerHostApiImpl}.
      *
-     * @param binaryMessenger used to communicate with Dart over asynchronous messages
      * @param instanceManager maintains instances stored to communicate with attached Dart objects
      */
     public PowerManagerHostApiImpl(
-        @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
-        this.binaryMessenger = binaryMessenger;
         this.instanceManager = instanceManager;
     }
 

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ResolveInfoFlagsFlutterApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ResolveInfoFlagsFlutterApiImpl.java
@@ -1,0 +1,66 @@
+package com.baseflow.permissionhandler;
+
+import android.content.pm.PackageManager.ResolveInfoFlags;
+
+import androidx.annotation.NonNull;
+
+import com.baseflow.instancemanager.InstanceManager;
+import com.baseflow.permissionhandler.PermissionHandlerPigeon.ResolveInfoFlagsFlutterApi;
+
+import java.util.UUID;
+
+import io.flutter.plugin.common.BinaryMessenger;
+
+/**
+ * Flutter API implementation for `ResolveInfoFlags`.
+ *
+ * <p>This class may handle adding native instances that are attached to a Dart instance or passing
+ * arguments of callbacks methods to a Dart instance.
+ */
+public class ResolveInfoFlagsFlutterApiImpl {
+    // To ease adding additional methods, this value is added prematurely.
+    @SuppressWarnings({"unused", "FieldCanBeLocal"})
+    private final BinaryMessenger binaryMessenger;
+
+    private final InstanceManager instanceManager;
+
+    private final ResolveInfoFlagsFlutterApi api;
+
+    /**
+     * Constructs a {@link ResolveInfoFlagsFlutterApiImpl}.
+     *
+     * @param binaryMessenger used to communicate with Dart over asynchronous messages
+     * @param instanceManager maintains instances stored to communicate with attached Dart objects
+     */
+    public ResolveInfoFlagsFlutterApiImpl(
+        @NonNull BinaryMessenger binaryMessenger,
+        @NonNull InstanceManager instanceManager
+    ) {
+        this.binaryMessenger = binaryMessenger;
+        this.instanceManager = instanceManager;
+        api = new ResolveInfoFlagsFlutterApi(binaryMessenger);
+    }
+
+    /**
+     * Stores the `ResolveInfoFlags` instance and notifies Dart to create and store a new
+     * `ResolveInfoFlags` instance that is attached to this one. If `instance` has already been
+     * added, this method does nothing.
+     */
+    public void create(@NonNull ResolveInfoFlags instance) {
+        if (!instanceManager.containsInstance(instance)) {
+            final UUID resolveInfoFlagsInstanceUuid = instanceManager.addHostCreatedInstance(instance);
+            api.create(resolveInfoFlagsInstanceUuid.toString(), reply -> {});
+        }
+    }
+
+    /**
+     * Disposes of the `ResolveInfoFlags` instance in the instance manager and notifies Dart to
+     * do the same. If `instance` was already disposed, this method does nothing.
+     */
+    public void dispose(ResolveInfoFlags instance) {
+        final UUID resolveInfoFlagsInstanceUuid = instanceManager.getIdentifierForStrongReference(instance);
+        if (resolveInfoFlagsInstanceUuid != null) {
+            api.dispose(resolveInfoFlagsInstanceUuid.toString(), reply -> {});
+        }
+    }
+}

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ResolveInfoFlagsFlutterApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ResolveInfoFlagsFlutterApiImpl.java
@@ -18,10 +18,6 @@ import io.flutter.plugin.common.BinaryMessenger;
  * arguments of callbacks methods to a Dart instance.
  */
 public class ResolveInfoFlagsFlutterApiImpl {
-    // To ease adding additional methods, this value is added prematurely.
-    @SuppressWarnings({"unused", "FieldCanBeLocal"})
-    private final BinaryMessenger binaryMessenger;
-
     private final InstanceManager instanceManager;
 
     private final ResolveInfoFlagsFlutterApi api;
@@ -36,7 +32,6 @@ public class ResolveInfoFlagsFlutterApiImpl {
         @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
-        this.binaryMessenger = binaryMessenger;
         this.instanceManager = instanceManager;
         api = new ResolveInfoFlagsFlutterApi(binaryMessenger);
     }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ResolveInfoFlagsHostApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ResolveInfoFlagsHostApiImpl.java
@@ -9,8 +9,6 @@ import androidx.annotation.RequiresApi;
 import com.baseflow.instancemanager.InstanceManager;
 import com.baseflow.permissionhandler.PermissionHandlerPigeon.ResolveInfoFlagsHostApi;
 
-import io.flutter.plugin.common.BinaryMessenger;
-
 /**
  * Host API implementation for `ResolveInfoFlags`.
  *
@@ -18,10 +16,6 @@ import io.flutter.plugin.common.BinaryMessenger;
  * Dart instance or handle method calls on the associated native class or an instance of the class.
  */
 public class ResolveInfoFlagsHostApiImpl implements ResolveInfoFlagsHostApi {
-    // To ease adding additional methods, this value is added prematurely.
-    @SuppressWarnings({"unused", "FieldCanBeLocal"})
-    private final BinaryMessenger binaryMessenger;
-
     private final InstanceManager instanceManager;
 
     private final ResolveInfoFlagsFlutterApiImpl flutterApi;
@@ -29,16 +23,13 @@ public class ResolveInfoFlagsHostApiImpl implements ResolveInfoFlagsHostApi {
     /**
      * Constructs an {@link ResolveInfoFlagsHostApiImpl}.
      *
-     * @param binaryMessenger used to communicate with Dart over asynchronous messages
      * @param instanceManager maintains instances stored to communicate with attached Dart objects
      */
     public ResolveInfoFlagsHostApiImpl(
         @NonNull ResolveInfoFlagsFlutterApiImpl flutterApi,
-        @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
         this.flutterApi = flutterApi;
-        this.binaryMessenger = binaryMessenger;
         this.instanceManager = instanceManager;
     }
 

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ResolveInfoFlagsHostApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ResolveInfoFlagsHostApiImpl.java
@@ -1,39 +1,39 @@
 package com.baseflow.permissionhandler;
 
-import android.net.Uri;
+import android.content.pm.PackageManager;
+import android.os.Build;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
 
 import com.baseflow.instancemanager.InstanceManager;
-import com.baseflow.permissionhandler.PermissionHandlerPigeon.UriHostApi;
-
-import java.util.UUID;
+import com.baseflow.permissionhandler.PermissionHandlerPigeon.ResolveInfoFlagsHostApi;
 
 import io.flutter.plugin.common.BinaryMessenger;
 
 /**
- * Host API implementation for `Uri`.
+ * Host API implementation for `ResolveInfoFlags`.
  *
  * <p>This class may handle instantiating and adding native object instances that are attached to a
  * Dart instance or handle method calls on the associated native class or an instance of the class.
  */
-public class UriHostApiImpl implements UriHostApi {
+public class ResolveInfoFlagsHostApiImpl implements ResolveInfoFlagsHostApi {
     // To ease adding additional methods, this value is added prematurely.
     @SuppressWarnings({"unused", "FieldCanBeLocal"})
     private final BinaryMessenger binaryMessenger;
 
     private final InstanceManager instanceManager;
 
-    private final UriFlutterApiImpl flutterApi;
+    private final ResolveInfoFlagsFlutterApiImpl flutterApi;
 
     /**
-     * Constructs an {@link UriHostApiImpl}.
+     * Constructs an {@link ResolveInfoFlagsHostApiImpl}.
      *
      * @param binaryMessenger used to communicate with Dart over asynchronous messages
      * @param instanceManager maintains instances stored to communicate with attached Dart objects
      */
-    public UriHostApiImpl(
-        @NonNull UriFlutterApiImpl flutterApi,
+    public ResolveInfoFlagsHostApiImpl(
+        @NonNull ResolveInfoFlagsFlutterApiImpl flutterApi,
         @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
@@ -42,23 +42,12 @@ public class UriHostApiImpl implements UriHostApi {
         this.instanceManager = instanceManager;
     }
 
-    @Override
+    @RequiresApi(api = Build.VERSION_CODES.TIRAMISU)
     @NonNull
-    public String parse(
-        @NonNull String uriString
-    ) {
-        final Uri uri = Uri.parse(uriString);
-        flutterApi.create(uri);
-        final UUID instanceId = instanceManager.getIdentifierForStrongReference(uri);
-        return instanceId.toString();
-    }
-
     @Override
-    @NonNull public String toStringAsync(
-        @NonNull String uriInstanceId
-    ) {
-        final UUID instanceId = UUID.fromString(uriInstanceId);
-        final Uri uri = instanceManager.getInstance(instanceId);
-        return uri.toString();
+    public String of(@NonNull Long value) {
+        final PackageManager.ResolveInfoFlags flags = PackageManager.ResolveInfoFlags.of(value);
+        flutterApi.create(flags);
+        return instanceManager.getIdentifierForStrongReference(flags).toString();
     }
 }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ResolveInfoFlutterApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ResolveInfoFlutterApiImpl.java
@@ -18,10 +18,6 @@ import io.flutter.plugin.common.BinaryMessenger;
  * arguments of callbacks methods to a Dart instance.
  */
 public class ResolveInfoFlutterApiImpl {
-    // To ease adding additional methods, this value is added prematurely.
-    @SuppressWarnings({"unused", "FieldCanBeLocal"})
-    private final BinaryMessenger binaryMessenger;
-
     private final InstanceManager instanceManager;
 
     private final ResolveInfoFlutterApi api;
@@ -36,7 +32,6 @@ public class ResolveInfoFlutterApiImpl {
         @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
-        this.binaryMessenger = binaryMessenger;
         this.instanceManager = instanceManager;
         api = new ResolveInfoFlutterApi(binaryMessenger);
     }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ResolveInfoFlutterApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/ResolveInfoFlutterApiImpl.java
@@ -1,0 +1,66 @@
+package com.baseflow.permissionhandler;
+
+import android.content.pm.ResolveInfo;
+
+import androidx.annotation.NonNull;
+
+import com.baseflow.instancemanager.InstanceManager;
+import com.baseflow.permissionhandler.PermissionHandlerPigeon.ResolveInfoFlutterApi;
+
+import java.util.UUID;
+
+import io.flutter.plugin.common.BinaryMessenger;
+
+/**
+ * Flutter API implementation for `ResolveInfo`.
+ *
+ * <p>This class may handle adding native instances that are attached to a Dart instance or passing
+ * arguments of callbacks methods to a Dart instance.
+ */
+public class ResolveInfoFlutterApiImpl {
+    // To ease adding additional methods, this value is added prematurely.
+    @SuppressWarnings({"unused", "FieldCanBeLocal"})
+    private final BinaryMessenger binaryMessenger;
+
+    private final InstanceManager instanceManager;
+
+    private final ResolveInfoFlutterApi api;
+
+    /**
+     * Constructs a {@link ResolveInfoFlutterApiImpl}.
+     *
+     * @param binaryMessenger used to communicate with Dart over asynchronous messages
+     * @param instanceManager maintains instances stored to communicate with attached Dart objects
+     */
+    public ResolveInfoFlutterApiImpl(
+        @NonNull BinaryMessenger binaryMessenger,
+        @NonNull InstanceManager instanceManager
+    ) {
+        this.binaryMessenger = binaryMessenger;
+        this.instanceManager = instanceManager;
+        api = new ResolveInfoFlutterApi(binaryMessenger);
+    }
+
+    /**
+     * Stores the `ResolveInfo` instance and notifies Dart to create and store a new `ResolveInfo`
+     * instance that is attached to this one. If `instance` has already been added, this method does
+     * nothing.
+     */
+    public void create(@NonNull ResolveInfo instance) {
+        if (!instanceManager.containsInstance(instance)) {
+            final UUID resolveInfoInstanceUuid = instanceManager.addHostCreatedInstance(instance);
+            api.create(resolveInfoInstanceUuid.toString(), reply -> {});
+        }
+    }
+
+    /**
+     * Disposes of the `ResolveInfo` instance in the instance manager and notifies Dart to do the
+     * same. If `instance` was already disposed, this method does nothing.
+     */
+    public void dispose(ResolveInfo instance) {
+        final UUID resolveInfoInstanceUuid = instanceManager.getIdentifierForStrongReference(instance);
+        if (resolveInfoInstanceUuid != null) {
+            api.dispose(resolveInfoInstanceUuid.toString(), reply -> {});
+        }
+    }
+}

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/SettingsHostApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/SettingsHostApiImpl.java
@@ -12,8 +12,6 @@ import com.baseflow.permissionhandler.PermissionHandlerPigeon.SettingsHostApi;
 
 import java.util.UUID;
 
-import io.flutter.plugin.common.BinaryMessenger;
-
 /**
  * Host API implementation for `Settings`.
  *
@@ -21,23 +19,16 @@ import io.flutter.plugin.common.BinaryMessenger;
  * Dart instance or handle method calls on the associated native class or an instance of the class.
  */
 public class SettingsHostApiImpl implements SettingsHostApi {
-    // To ease adding additional methods, this value is added prematurely.
-    @SuppressWarnings({"unused", "FieldCanBeLocal"})
-    private final BinaryMessenger binaryMessenger;
-
     private final InstanceManager instanceManager;
 
     /**
      * Constructs an {@link SettingsHostApiImpl}.
      *
-     * @param binaryMessenger used to communicate with Dart over asynchronous messages
      * @param instanceManager maintains instances stored to communicate with attached Dart objects
      */
     public SettingsHostApiImpl(
-        @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
-        this.binaryMessenger = binaryMessenger;
         this.instanceManager = instanceManager;
     }
 

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/UriFlutterApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/UriFlutterApiImpl.java
@@ -18,10 +18,6 @@ import io.flutter.plugin.common.BinaryMessenger;
  * arguments of callbacks methods to a Dart instance.
  */
 public class UriFlutterApiImpl {
-    // To ease adding additional methods, this value is added prematurely.
-    @SuppressWarnings({"unused", "FieldCanBeLocal"})
-    private final BinaryMessenger binaryMessenger;
-
     private final InstanceManager instanceManager;
 
     private final UriFlutterApi api;
@@ -36,7 +32,6 @@ public class UriFlutterApiImpl {
         @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
-        this.binaryMessenger = binaryMessenger;
         this.instanceManager = instanceManager;
         api = new UriFlutterApi(binaryMessenger);
     }

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/UriFlutterApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/UriFlutterApiImpl.java
@@ -1,0 +1,65 @@
+package com.baseflow.permissionhandler;
+
+import android.net.Uri;
+
+import androidx.annotation.NonNull;
+
+import com.baseflow.instancemanager.InstanceManager;
+import com.baseflow.permissionhandler.PermissionHandlerPigeon.UriFlutterApi;
+
+import java.util.UUID;
+
+import io.flutter.plugin.common.BinaryMessenger;
+
+/**
+ * Flutter API implementation for `Uri`.
+ *
+ * <p>This class may handle adding native instances that are attached to a Dart instance or passing
+ * arguments of callbacks methods to a Dart instance.
+ */
+public class UriFlutterApiImpl {
+    // To ease adding additional methods, this value is added prematurely.
+    @SuppressWarnings({"unused", "FieldCanBeLocal"})
+    private final BinaryMessenger binaryMessenger;
+
+    private final InstanceManager instanceManager;
+
+    private final UriFlutterApi api;
+
+    /**
+     * Constructs a {@link UriFlutterApiImpl}.
+     *
+     * @param binaryMessenger used to communicate with Dart over asynchronous messages
+     * @param instanceManager maintains instances stored to communicate with attached Dart objects
+     */
+    public UriFlutterApiImpl(
+        @NonNull BinaryMessenger binaryMessenger,
+        @NonNull InstanceManager instanceManager
+    ) {
+        this.binaryMessenger = binaryMessenger;
+        this.instanceManager = instanceManager;
+        api = new UriFlutterApi(binaryMessenger);
+    }
+
+    /**
+     * Stores the `Uri` instance and notifies Dart to create and store a new `Uri` instance that is
+     * attached to this one. If `instance` has already been added, this method does nothing.
+     */
+    public void create(@NonNull Uri instance) {
+        if (!instanceManager.containsInstance(instance)) {
+            final UUID uriInstanceUuid = instanceManager.addHostCreatedInstance(instance);
+            api.create(uriInstanceUuid.toString(), reply -> {});
+        }
+    }
+
+    /**
+     * Disposes of the `Uri` instance in the instance manager and notifies Dart to do the same. If
+     * `instance` was already disposed, this method does nothing.
+     */
+    public void dispose(Uri instance) {
+        final UUID uriInstanceUuid = instanceManager.getIdentifierForStrongReference(instance);
+        if (uriInstanceUuid != null) {
+            api.dispose(uriInstanceUuid.toString(), reply -> {});
+        }
+    }
+}

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/UriHostApiImpl.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/UriHostApiImpl.java
@@ -9,8 +9,6 @@ import com.baseflow.permissionhandler.PermissionHandlerPigeon.UriHostApi;
 
 import java.util.UUID;
 
-import io.flutter.plugin.common.BinaryMessenger;
-
 /**
  * Host API implementation for `Uri`.
  *
@@ -18,10 +16,6 @@ import io.flutter.plugin.common.BinaryMessenger;
  * Dart instance or handle method calls on the associated native class or an instance of the class.
  */
 public class UriHostApiImpl implements UriHostApi {
-    // To ease adding additional methods, this value is added prematurely.
-    @SuppressWarnings({"unused", "FieldCanBeLocal"})
-    private final BinaryMessenger binaryMessenger;
-
     private final InstanceManager instanceManager;
 
     private final UriFlutterApiImpl flutterApi;
@@ -29,16 +23,13 @@ public class UriHostApiImpl implements UriHostApi {
     /**
      * Constructs an {@link UriHostApiImpl}.
      *
-     * @param binaryMessenger used to communicate with Dart over asynchronous messages
      * @param instanceManager maintains instances stored to communicate with attached Dart objects
      */
     public UriHostApiImpl(
         @NonNull UriFlutterApiImpl flutterApi,
-        @NonNull BinaryMessenger binaryMessenger,
         @NonNull InstanceManager instanceManager
     ) {
         this.flutterApi = flutterApi;
-        this.binaryMessenger = binaryMessenger;
         this.instanceManager = instanceManager;
     }
 

--- a/permission_handler_android/lib/permission_handler_android.dart
+++ b/permission_handler_android/lib/permission_handler_android.dart
@@ -2,6 +2,7 @@ export 'src/android_object_mirrors/activity.dart';
 export 'src/android_object_mirrors/alarm_manager.dart';
 export 'src/android_object_mirrors/build.dart';
 export 'src/android_object_mirrors/context.dart';
+export 'src/android_object_mirrors/environment.dart';
 export 'src/android_object_mirrors/intent.dart';
 export 'src/android_object_mirrors/manifest.dart';
 export 'src/android_object_mirrors/notification_manager.dart';

--- a/permission_handler_android/lib/permission_handler_android.dart
+++ b/permission_handler_android/lib/permission_handler_android.dart
@@ -6,8 +6,10 @@ export 'src/android_object_mirrors/environment.dart';
 export 'src/android_object_mirrors/intent.dart';
 export 'src/android_object_mirrors/manifest.dart';
 export 'src/android_object_mirrors/notification_manager.dart';
+export 'src/android_object_mirrors/package_info.dart';
 export 'src/android_object_mirrors/package_manager.dart';
 export 'src/android_object_mirrors/power_manager.dart';
+export 'src/android_object_mirrors/resolve_info.dart';
 export 'src/android_object_mirrors/settings.dart';
 export 'src/android_object_mirrors/uri.dart';
 

--- a/permission_handler_android/lib/src/android_object_mirrors/alarm_manager.dart
+++ b/permission_handler_android/lib/src/android_object_mirrors/alarm_manager.dart
@@ -2,8 +2,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_instance_manager/flutter_instance_manager.dart';
 import 'package:permission_handler_android/src/android_permission_handler_api_impls.dart';
 
-import 'build.dart';
-
 /// This class provides access to the system alarm services.
 ///
 /// These allow you to schedule your application to be run at some point in the
@@ -28,7 +26,10 @@ class AlarmManager extends JavaObject {
           binaryMessenger: binaryMessenger,
           instanceManager: instanceManager,
         ),
-        super.detached();
+        super.detached(
+          binaryMessenger: binaryMessenger,
+          instanceManager: instanceManager,
+        );
 
   final AlarmManagerHostApiImpl _hostApi;
 
@@ -38,12 +39,7 @@ class AlarmManager extends JavaObject {
   /// [Build.versionCodes.s].
   ///
   /// See https://developer.android.com/reference/android/app/AlarmManager#canScheduleExactAlarms().
-  Future<bool> canScheduleExactAlarms() async {
-    final int sdkVersion = await Build.version.sdkInt;
-    if (sdkVersion < Build.versionCodes.s) {
-      return true;
-    }
-
+  Future<bool> canScheduleExactAlarms() {
     return _hostApi.canScheduleExactAlarmsFromInstance(this);
   }
 }

--- a/permission_handler_android/lib/src/android_object_mirrors/context.dart
+++ b/permission_handler_android/lib/src/android_object_mirrors/context.dart
@@ -13,8 +13,8 @@ import '../android_permission_handler_api_impls.dart';
 ///
 /// See https://developer.android.com/reference/android/content/Context.
 class Context extends JavaObject {
-  /// Instantiates an [Context] without creating and attaching to an instance
-  /// of the associated native class.
+  /// Instantiates a [Context] without creating and attaching to an instance of
+  /// the associated native class.
   Context.detached({
     InstanceManager? instanceManager,
     BinaryMessenger? binaryMessenger,

--- a/permission_handler_android/lib/src/android_object_mirrors/environment.dart
+++ b/permission_handler_android/lib/src/android_object_mirrors/environment.dart
@@ -1,0 +1,21 @@
+import '../permission_handler.pigeon.dart';
+
+/// Provides access to environment variables.
+///
+/// See https://developer.android.com/reference/android/os/Environment.
+class Environment {
+  const Environment._();
+
+  static final EnvironmentHostApi _hostApi = EnvironmentHostApi();
+
+  /// Returns whether the calling app has All Files Access on the primary shared/external storage media.
+  ///
+  /// Declaring the permission [Manifest.permission.manageExternalStorage] is
+  /// not enough to gain the access. To request access, use
+  /// [Settings.actionManageAppAllFilesAccessPermission].
+  ///
+  /// See https://developer.android.com/reference/android/os/Environment#isExternalStorageManager().
+  static Future<bool> isExternalStorageManager() {
+    return _hostApi.isExternalStorageManager();
+  }
+}

--- a/permission_handler_android/lib/src/android_object_mirrors/intent.dart
+++ b/permission_handler_android/lib/src/android_object_mirrors/intent.dart
@@ -46,6 +46,11 @@ class Intent extends JavaObject {
 
   final IntentHostApiImpl _hostApi;
 
+  /// Activity Action: Perform a call to someone specified by the data.
+  ///
+  /// See https://developer.android.com/reference/android/content/Intent#ACTION_CALL.
+  static const String actionCall = 'android.intent.action.CALL';
+
   /// Sets the general action to be performed.
   ///
   /// See https://developer.android.com/reference/android/content/Intent#setAction(java.lang.String).
@@ -98,19 +103,19 @@ class Intent extends JavaObject {
   /// Constant Value: 268435456 (0x10000000).
   ///
   /// See https://developer.android.com/reference/android/content/Intent#FLAG_ACTIVITY_NEW_TASK.
-  static const int flagActivityNewTask = 268435456;
+  static const int flagActivityNewTask = 0x10000000;
 
   /// If set, the new activity is not kept in the history stack.
   ///
   /// Constant Value: 1073741824 (0x40000000).
   ///
   /// See https://developer.android.com/reference/android/content/Intent#FLAG_ACTIVITY_NO_HISTORY.
-  static const int flagActivityNoHistory = 1073741824;
+  static const int flagActivityNoHistory = 0x40000000;
 
   /// If set, the new activity is not kept in the list of recently launched activities.
   ///
   /// Constant Value: 8388608 (0x00800000).
   ///
   /// See https://developer.android.com/reference/android/content/Intent#FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS.
-  static const int flagActivityExcludeFromRecents = 8388608;
+  static const int flagActivityExcludeFromRecents = 0x00800000;
 }

--- a/permission_handler_android/lib/src/android_object_mirrors/notification_manager.dart
+++ b/permission_handler_android/lib/src/android_object_mirrors/notification_manager.dart
@@ -2,8 +2,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_instance_manager/flutter_instance_manager.dart';
 import 'package:permission_handler_android/src/android_permission_handler_api_impls.dart';
 
-import 'build.dart';
-
 /// Class to notify the user of events that happen.
 ///
 /// This is how you tell the user that something has happened in the background.
@@ -19,7 +17,10 @@ class NotificationManager extends JavaObject {
           binaryMessenger: binaryMessenger,
           instanceManager: instanceManager,
         ),
-        super.detached();
+        super.detached(
+          binaryMessenger: binaryMessenger,
+          instanceManager: instanceManager,
+        );
 
   final NotificationManagerHostApiImpl _hostApi;
 
@@ -32,24 +33,14 @@ class NotificationManager extends JavaObject {
   /// [Settings.actionNotificationPolicyAccessSettings].
   ///
   /// See https://developer.android.com/reference/android/app/NotificationManager#isNotificationPolicyAccessGranted().
-  Future<bool> isNotificationPolicyAccessGranted() async {
-    final int sdkVersion = await Build.version.sdkInt;
-    if (sdkVersion < Build.versionCodes.m) {
-      return true;
-    }
-
+  Future<bool> isNotificationPolicyAccessGranted() {
     return _hostApi.isNotificationPolicyAccessGrantedFromInstance(this);
   }
 
   /// Returns whether notifications from the calling package are enabled.
   ///
   /// See https://developer.android.com/reference/android/app/NotificationManager#areNotificationsEnabled().
-  Future<bool> areNotificationsEnabled() async {
-    final int sdkVersion = await Build.version.sdkInt;
-    if (sdkVersion < Build.versionCodes.n) {
-      return true;
-    }
-
+  Future<bool> areNotificationsEnabled() {
     return _hostApi.areNotificationsEnabledFromInstance(this);
   }
 }

--- a/permission_handler_android/lib/src/android_object_mirrors/package_info.dart
+++ b/permission_handler_android/lib/src/android_object_mirrors/package_info.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_instance_manager/flutter_instance_manager.dart';
+
+import '../android_permission_handler_api_impls.dart';
+
+/// Overall information about the contents of a package.
+///
+/// This corresponds to all of the information collected from
+/// AndroidManifest.xml.
+///
+/// See https://developer.android.com/reference/android/content/pm/PackageInfo.
+class PackageInfo extends JavaObject {
+  /// Instantiates a [PackageInfo] without creating and attaching to an instance
+  /// of the associated native class.
+  PackageInfo.detached({
+    InstanceManager? instanceManager,
+    BinaryMessenger? binaryMessenger,
+  })  : _hostApi = PackageInfoHostApiImpl(
+          binaryMessenger: binaryMessenger,
+          instanceManager: instanceManager,
+        ),
+        super.detached(
+          instanceManager: instanceManager,
+          binaryMessenger: binaryMessenger,
+        );
+
+  final PackageInfoHostApiImpl _hostApi;
+
+  /// PackageInfo flag: return information about permissions in the package in PackageInfo#permissions.
+  ///
+  /// Constant Value: 4096 (0x00001000).
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager#GET_PERMISSIONS.
+  static const int getPermissions = 0x00001000;
+
+  /// Array of all <uses-permission> tags included under <manifest>, or null if there were none.
+  ///
+  /// This is only filled in if the flag PackageManager#GET_PERMISSIONS was set.
+  /// This list includes all permissions requested, even those that were not
+  /// granted or known by the system at install time.
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageInfo#requestedPermissions.
+  Future<List<String>> get requestedPermissions =>
+      _hostApi.getRequestedPermissionsFromInstance(this);
+}

--- a/permission_handler_android/lib/src/android_object_mirrors/package_manager.dart
+++ b/permission_handler_android/lib/src/android_object_mirrors/package_manager.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_instance_manager/flutter_instance_manager.dart';
+import 'package:permission_handler_android/src/android_object_mirrors/package_info.dart';
 
 import '../android_permission_handler_api_impls.dart';
-import 'build.dart';
+import 'intent.dart';
+import 'resolve_info.dart';
 
 /// Class for retrieving various kinds of information related to the application
 /// packages that are currently installed on the device. You can find this class
@@ -19,7 +21,10 @@ class PackageManager extends JavaObject {
           binaryMessenger: binaryMessenger,
           instanceManager: instanceManager,
         ),
-        super.detached();
+        super.detached(
+          binaryMessenger: binaryMessenger,
+          instanceManager: instanceManager,
+        );
 
   final PackageManagerHostApiImpl _hostApi;
 
@@ -36,12 +41,157 @@ class PackageManager extends JavaObject {
   /// Checks whether the calling package is allowed to request package installs through package installer.
   ///
   /// See https://developer.android.com/reference/android/content/pm/PackageManager#canRequestPackageInstalls().
-  Future<bool> canRequestPackageInstalls() async {
-    final int sdkVersion = await Build.version.sdkInt;
-    if (sdkVersion < Build.versionCodes.m) {
-      return true;
-    }
-
+  Future<bool> canRequestPackageInstalls() {
     return _hostApi.canRequestPackageInstallsFromInstance(this);
+  }
+
+  /// Retrieve overall information about an application package that is installed on the system.
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager#getPackageInfo(java.lang.String,%20int).
+  Future<PackageInfo?> getPackageInfoWithFlags(
+    String packageName,
+    int flags,
+  ) {
+    return _hostApi.getPackageInfoWithFlagsFromInstance(
+      this,
+      packageName,
+      flags,
+    );
+  }
+
+  /// Retrieve overall information about an application package that is installed on the system.
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager#getPackageInfo(java.lang.String,%20android.content.pm.PackageManager.PackageInfoFlags).
+  Future<PackageInfo?> getPackageInfo(
+    String packageName,
+    PackageInfoFlags flags,
+  ) {
+    return _hostApi.getPackageInfoWithInfoFlagsFromInstance(
+      this,
+      packageName,
+      flags,
+    );
+  }
+
+  /// Retrieve all activities that can be performed for the given intent.
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager#queryIntentActivities(android.content.Intent,%20int).
+  Future<List<ResolveInfo>> queryIntentActivitiesWithFlags(
+    Intent intent,
+    int flags,
+  ) {
+    return _hostApi.queryIntentActivitiesWithFlagsFromInstance(
+      this,
+      intent,
+      flags,
+    );
+  }
+
+  /// Retrieve all activities that can be performed for the given intent.
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager#queryIntentActivities(android.content.Intent,%20android.content.pm.ResolveInfoFlags).
+  Future<List<ResolveInfo>> queryIntentActivities(
+    Intent intent,
+    ResolveInfoFlags resolveInfoFlags,
+  ) {
+    return _hostApi.queryIntentActivitiesWithInfoFlagsFromInstance(
+      this,
+      intent,
+      resolveInfoFlags,
+    );
+  }
+}
+
+/// Specific flags used for retrieving package info.
+///
+/// Example: `PackageManager.getPackageInfoWithInfoFlags(packageName, PackageInfoFlags.of(0)`.
+///
+/// See https://developer.android.com/reference/android/content/pm/PackageManager.PackageInfoFlags.
+class PackageInfoFlags extends JavaObject {
+  /// Instantiates a [PackageInfoFlags] without creating and attaching to an
+  /// instance of the associated native class.
+  PackageInfoFlags.detached({
+    BinaryMessenger? binaryMessenger,
+    InstanceManager? instanceManager,
+  }) : super.detached(
+          binaryMessenger: binaryMessenger,
+          instanceManager: instanceManager,
+        );
+
+  static final PackageInfoFlagsHostApiImpl _hostApi =
+      PackageInfoFlagsHostApiImpl();
+
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager.PackageInfoFlags#of(long).
+  static Future<PackageInfoFlags> of(int value) {
+    return _hostApi.ofFromClass(value);
+  }
+}
+
+/// Specific flags used for retrieving resolve info.
+///
+/// See https://developer.android.com/reference/android/content/pm/PackageManager.ResolveInfoFlags.
+class ResolveInfoFlags extends JavaObject {
+  /// Instantiates a [ResolveInfoFlags] without creating and attaching to an
+  /// instance of the associated native class.
+  ResolveInfoFlags.detached({
+    BinaryMessenger? binaryMessenger,
+    InstanceManager? instanceManager,
+  }) : super.detached(
+          binaryMessenger: binaryMessenger,
+          instanceManager: instanceManager,
+        );
+
+  static final ResolveInfoFlagsHostApiImpl _hostApi =
+      ResolveInfoFlagsHostApiImpl();
+
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager.ResolveInfoFlags#of(long).
+  static Future<ResolveInfoFlags> of(int value) {
+    return _hostApi.ofFromClass(value);
+  }
+}
+
+/// Specific flags used for retrieving application info.
+///
+/// See https://developer.android.com/reference/android/content/pm/PackageManager.ApplicationInfoFlags.
+class ApplicationInfoFlags extends JavaObject {
+  /// Instantiates an [ApplicationInfoFlags] without creating and attaching to
+  /// an instance of the associated native class.
+  ApplicationInfoFlags.detached({
+    BinaryMessenger? binaryMessenger,
+    InstanceManager? instanceManager,
+  }) : super.detached(
+          binaryMessenger: binaryMessenger,
+          instanceManager: instanceManager,
+        );
+
+  static final ApplicationInfoFlagsHostApiImpl _hostApi =
+      ApplicationInfoFlagsHostApiImpl();
+
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager.ApplicationInfoFlags#of(long).
+  static Future<ApplicationInfoFlags> of(int value) {
+    return _hostApi.ofFromClass(value);
+  }
+}
+
+/// Specific flags used for retrieving component info.
+///
+/// See https://developer.android.com/reference/android/content/pm/PackageManager.ComponentInfoFlags.
+class ComponentInfoFlags extends JavaObject {
+  /// Instantiates a [ComponentInfoFlags] without creating and attaching to an
+  /// instance of the associated native class.
+  ComponentInfoFlags.detached({
+    BinaryMessenger? binaryMessenger,
+    InstanceManager? instanceManager,
+  }) : super.detached(
+          binaryMessenger: binaryMessenger,
+          instanceManager: instanceManager,
+        );
+
+  static final ComponentInfoFlagsHostApiImpl _hostApi =
+      ComponentInfoFlagsHostApiImpl();
+
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager.ComponentInfoFlags#of(long).
+  static Future<ComponentInfoFlags> of(int value) {
+    return _hostApi.ofFromClass(value);
   }
 }

--- a/permission_handler_android/lib/src/android_object_mirrors/power_manager.dart
+++ b/permission_handler_android/lib/src/android_object_mirrors/power_manager.dart
@@ -2,8 +2,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_instance_manager/flutter_instance_manager.dart';
 import 'package:permission_handler_android/src/android_permission_handler_api_impls.dart';
 
-import 'build.dart';
-
 /// This class lets you query and request control of aspects of the device's power state.
 ///
 /// See: https://developer.android.com/reference/android/os/PowerManager
@@ -17,7 +15,10 @@ class PowerManager extends JavaObject {
           binaryMessenger: binaryMessenger,
           instanceManager: instanceManager,
         ),
-        super.detached();
+        super.detached(
+          binaryMessenger: binaryMessenger,
+          instanceManager: instanceManager,
+        );
 
   final PowerManagerHostApiImpl _hostApi;
 
@@ -33,12 +34,7 @@ class PowerManager extends JavaObject {
   /// be applied.
   ///
   /// See https://developer.android.com/reference/android/os/PowerManager#isIgnoringBatteryOptimizations(java.lang.String).
-  Future<bool> isIgnoringBatteryOptimizations(String packageName) async {
-    final int sdkVersion = await Build.version.sdkInt;
-    if (sdkVersion < Build.versionCodes.m) {
-      return false;
-    }
-
+  Future<bool> isIgnoringBatteryOptimizations(String packageName) {
     return _hostApi.isIgnoringBatteryOptimizationsFromInstance(
       this,
       packageName,

--- a/permission_handler_android/lib/src/android_object_mirrors/resolve_info.dart
+++ b/permission_handler_android/lib/src/android_object_mirrors/resolve_info.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_instance_manager/flutter_instance_manager.dart';
+
+/// Information that is returned from resolving an intent against an IntentFilter.
+///
+/// This partially corresponds to information collected from the
+/// AndroidManifest.xml's <intent> tags.
+///
+/// See https://developer.android.com/reference/android/content/pm/ResolveInfo.
+class ResolveInfo extends JavaObject {
+  /// Instantiates a [ResolveInfo] without creating and attaching to an instance
+  /// of the associated native class.
+  ResolveInfo.detached({
+    InstanceManager? instanceManager,
+    BinaryMessenger? binaryMessenger,
+  }) : super.detached(
+          instanceManager: instanceManager,
+          binaryMessenger: binaryMessenger,
+        );
+}

--- a/permission_handler_android/lib/src/android_object_mirrors/settings.dart
+++ b/permission_handler_android/lib/src/android_object_mirrors/settings.dart
@@ -102,12 +102,7 @@ class Settings {
   /// See https://developer.android.com/reference/android/provider/Settings#canDrawOverlays(android.content.Context).
   static Future<bool> canDrawOverlays(
     Context context,
-  ) async {
-    final int sdkVersion = await Build.version.sdkInt;
-    if (sdkVersion < Build.versionCodes.m) {
-      return true;
-    }
-
+  ) {
     return _hostApi.canDrawOverlaysFromInstance(
       context,
     );

--- a/permission_handler_android/lib/src/android_object_mirrors/uri.dart
+++ b/permission_handler_android/lib/src/android_object_mirrors/uri.dart
@@ -14,40 +14,27 @@ import '../android_permission_handler_api_impls.dart';
 ///
 /// See https://developer.android.com/reference/android/net/Uri.
 class Uri extends JavaObject {
-  /// Instantiates a [Uri], creating and attaching it to an instance of the
+  /// Instantiates a [Uri] without creating and attaching to an instance of the
   /// associated native class.
-  ///
-  /// For internal use only. Instead, use [Uri.parse].
-  Uri._({
+  Uri.detached({
     InstanceManager? instanceManager,
     BinaryMessenger? binaryMessenger,
-  })  : _hostApi = UriHostApiImpl(
-          instanceManager: instanceManager,
-          binaryMessenger: binaryMessenger,
-        ),
-        super.detached(
+  }) : super.detached(
           instanceManager: instanceManager,
           binaryMessenger: binaryMessenger,
         );
 
-  final UriHostApiImpl _hostApi;
+  static final UriHostApiImpl _hostApi = UriHostApiImpl();
 
   /// Creates a [Uri] which parses the given encoded URI string.
   ///
   /// See https://developer.android.com/reference/android/net/Uri#parse(java.lang.String).
-  factory Uri.parse(
+  static Future<Uri> parse(
     String uriString, {
     BinaryMessenger? binaryMessenger,
     InstanceManager? instanceManager,
   }) {
-    final Uri uri = Uri._(
-      binaryMessenger: binaryMessenger,
-      instanceManager: instanceManager,
-    );
-
-    uri._hostApi.parseFromInstance(uri, uriString);
-
-    return uri;
+    return _hostApi.parseFromClass(uriString);
   }
 
   /// Returns the encoded string representation of this URI.

--- a/permission_handler_android/lib/src/android_permission_handler_api_impls.dart
+++ b/permission_handler_android/lib/src/android_permission_handler_api_impls.dart
@@ -730,3 +730,22 @@ class NotificationManagerFlutterApiImpl extends NotificationManagerFlutterApi {
     _instanceManager.remove(instanceId);
   }
 }
+
+/// Host API implementation of Environment.
+class EnvironmentHostApiImpl extends EnvironmentHostApi {
+  /// Creates a new instance of [EnvironmentHostApiImpl].
+  EnvironmentHostApiImpl({
+    this.binaryMessenger,
+    InstanceManager? instanceManager,
+  })  : instanceManager = instanceManager ?? JavaObject.globalInstanceManager,
+        super(binaryMessenger: binaryMessenger);
+
+  /// Sends binary data across the Flutter platform barrier.
+  ///
+  /// If it is null, the default BinaryMessenger will be used which routes to
+  /// the host platform.
+  final BinaryMessenger? binaryMessenger;
+
+  /// Maintains instances stored to communicate with native language objects.
+  final InstanceManager instanceManager;
+}

--- a/permission_handler_android/lib/src/android_permission_handler_api_impls.dart
+++ b/permission_handler_android/lib/src/android_permission_handler_api_impls.dart
@@ -10,19 +10,39 @@ class AndroidPermissionHandlerFlutterApis {
   AndroidPermissionHandlerFlutterApis({
     ActivityFlutterApiImpl? activityFlutterApi,
     ContextFlutterApiImpl? contextFlutterApi,
+    UriFlutterApiImpl? uriFlutterApi,
     PowerManagerFlutterApiImpl? powerManagerFlutterApi,
     AlarmManagerFlutterApiImpl? alarmManagerFlutterApi,
     PackageManagerFlutterApiImpl? packageManagerFlutterApi,
+    PackageInfoFlutterApiImpl? packageInfoFlutterApi,
+    PackageInfoFlagsFlutterApiImpl? packageInfoFlagsFlutterApi,
+    ResolveInfoFlagsFlutterApiImpl? resolveInfoFlagsFlutterApi,
+    ResolveInfoFlutterApiImpl? resolveInfoFlutterApi,
+    ComponentInfoFlagsFlutterApiImpl? componentInfoFlagsFlutterApi,
+    ApplicationInfoFlagsFlutterApiImpl? applicationInfoFlagsFlutterApi,
     NotificationManagerFlutterApiImpl? notificationManagerFlutterApi,
   }) {
     this.activityFlutterApi = activityFlutterApi ?? ActivityFlutterApiImpl();
     this.contextFlutterApi = contextFlutterApi ?? ContextFlutterApiImpl();
+    this.uriFlutterApi = uriFlutterApi ?? UriFlutterApiImpl();
     this.powerManagerFlutterApi =
         powerManagerFlutterApi ?? PowerManagerFlutterApiImpl();
     this.alarmManagerFlutterApi =
         alarmManagerFlutterApi ?? AlarmManagerFlutterApiImpl();
     this.packageManagerFlutterApi =
         packageManagerFlutterApi ?? PackageManagerFlutterApiImpl();
+    this.packageInfoFlutterApi =
+        packageInfoFlutterApi ?? PackageInfoFlutterApiImpl();
+    this.packageInfoFlagsFlutterApi =
+        packageInfoFlagsFlutterApi ?? PackageInfoFlagsFlutterApiImpl();
+    this.resolveInfoFlagsFlutterApi =
+        resolveInfoFlagsFlutterApi ?? ResolveInfoFlagsFlutterApiImpl();
+    this.resolveInfoFlutterApi =
+        resolveInfoFlutterApi ?? ResolveInfoFlutterApiImpl();
+    this.componentInfoFlagsFlutterApi =
+        componentInfoFlagsFlutterApi ?? ComponentInfoFlagsFlutterApiImpl();
+    this.applicationInfoFlagsFlutterApi =
+        applicationInfoFlagsFlutterApi ?? ApplicationInfoFlagsFlutterApiImpl();
     this.notificationManagerFlutterApi =
         notificationManagerFlutterApi ?? NotificationManagerFlutterApiImpl();
   }
@@ -44,6 +64,9 @@ class AndroidPermissionHandlerFlutterApis {
   /// Flutter API for [Context].
   late final ContextFlutterApiImpl contextFlutterApi;
 
+  /// Flutter API for [Uri].
+  late final UriFlutterApiImpl uriFlutterApi;
+
   /// Flutter API for [PowerManager].
   late final PowerManagerFlutterApiImpl powerManagerFlutterApi;
 
@@ -53,6 +76,24 @@ class AndroidPermissionHandlerFlutterApis {
   /// Flutter API for [PackageManager].
   late final PackageManagerFlutterApiImpl packageManagerFlutterApi;
 
+  /// Flutter API for [PackageInfo].
+  late final PackageInfoFlutterApiImpl packageInfoFlutterApi;
+
+  /// Flutter API for [PackageInfoFlags].
+  late final PackageInfoFlagsFlutterApiImpl packageInfoFlagsFlutterApi;
+
+  /// Flutter API for [ResolveInfoFlags].
+  late final ResolveInfoFlagsFlutterApiImpl resolveInfoFlagsFlutterApi;
+
+  /// Flutter API for [ResolveInfo].
+  late final ResolveInfoFlutterApiImpl resolveInfoFlutterApi;
+
+  /// Flutter API for [ComponentInfoFlags].
+  late final ComponentInfoFlagsFlutterApiImpl componentInfoFlagsFlutterApi;
+
+  /// Flutter API for [ApplicationInfoFlags].
+  late final ApplicationInfoFlagsFlutterApiImpl applicationInfoFlagsFlutterApi;
+
   /// Flutter API for [NotificationManager].
   late final NotificationManagerFlutterApiImpl notificationManagerFlutterApi;
 
@@ -61,9 +102,16 @@ class AndroidPermissionHandlerFlutterApis {
     if (!_haveBeenSetUp) {
       ActivityFlutterApi.setup(activityFlutterApi);
       ContextFlutterApi.setup(contextFlutterApi);
+      UriFlutterApi.setup(uriFlutterApi);
       PowerManagerFlutterApi.setup(powerManagerFlutterApi);
       AlarmManagerFlutterApi.setup(alarmManagerFlutterApi);
       PackageManagerFlutterApi.setup(packageManagerFlutterApi);
+      PackageInfoFlutterApi.setup(packageInfoFlutterApi);
+      PackageInfoFlagsFlutterApi.setup(packageInfoFlagsFlutterApi);
+      ResolveInfoFlagsFlutterApi.setup(resolveInfoFlagsFlutterApi);
+      ResolveInfoFlutterApi.setup(resolveInfoFlutterApi);
+      ComponentInfoFlagsFlutterApi.setup(componentInfoFlagsFlutterApi);
+      ApplicationInfoFlagsFlutterApi.setup(applicationInfoFlagsFlutterApi);
       NotificationManagerFlutterApi.setup(notificationManagerFlutterApi);
 
       _haveBeenSetUp = true;
@@ -321,13 +369,12 @@ class UriHostApiImpl extends UriHostApi {
   /// Creates a Uri which parses the given encoded URI string.
   ///
   /// See https://developer.android.com/reference/android/net/Uri#parse(java.lang.String).
-  void parseFromInstance(
-    Uri uriInstance,
+  Future<Uri> parseFromClass(
     String uriString,
   ) async {
-    final String instanceId =
-        instanceManager.addDartCreatedInstance(uriInstance);
-    await parse(instanceId, uriString);
+    final String instanceId = await parse(uriString);
+
+    return instanceManager.getInstanceWithWeakReference(instanceId) as Uri;
   }
 
   /// Returns the encoded string representation of this URI.
@@ -339,6 +386,31 @@ class UriHostApiImpl extends UriHostApi {
     Uri uriInstance,
   ) {
     return toStringAsync(instanceManager.getIdentifier(uriInstance)!);
+  }
+}
+
+/// Flutter API implementation of Uri.
+class UriFlutterApiImpl extends UriFlutterApi {
+  /// Constructs a new instance of [UriFlutterApiImpl].
+  UriFlutterApiImpl({
+    InstanceManager? instanceManager,
+  }) : _instanceManager = instanceManager ?? JavaObject.globalInstanceManager;
+
+  /// Maintains instances stored to communicate with native language objects.
+  final InstanceManager _instanceManager;
+
+  @override
+  void create(String instanceId) {
+    final Uri uri = Uri.detached();
+    _instanceManager.addHostCreatedInstance(
+      uri,
+      instanceId,
+    );
+  }
+
+  @override
+  void dispose(String instanceId) {
+    _instanceManager.remove(instanceId);
   }
 }
 
@@ -459,11 +531,15 @@ class PowerManagerHostApiImpl extends PowerManagerHostApi {
     PowerManager powerManager,
     String packageName,
   ) async {
-    return await Build.version.sdkInt >= Build.versionCodes.m &&
-        await isIgnoringBatteryOptimizations(
-          instanceManager.getIdentifier(powerManager)!,
-          packageName,
-        );
+    final int sdkVersion = await Build.version.sdkInt;
+    if (sdkVersion < Build.versionCodes.m) {
+      return false;
+    }
+
+    return await isIgnoringBatteryOptimizations(
+      instanceManager.getIdentifier(powerManager)!,
+      packageName,
+    );
   }
 }
 
@@ -535,6 +611,11 @@ class AlarmManagerHostApiImpl extends AlarmManagerHostApi {
   Future<bool> canScheduleExactAlarmsFromInstance(
     AlarmManager alarmManager,
   ) async {
+    final int sdkVersion = await Build.version.sdkInt;
+    if (sdkVersion < Build.versionCodes.s) {
+      return true;
+    }
+
     return await canScheduleExactAlarms(
       instanceManager.getIdentifier(alarmManager)!,
     );
@@ -589,10 +670,118 @@ class PackageManagerHostApiImpl extends PackageManagerHostApi {
   /// See https://developer.android.com/reference/android/content/pm/PackageManager#canRequestPackageInstalls().
   Future<bool> canRequestPackageInstallsFromInstance(
     PackageManager packageManager,
-  ) {
+  ) async {
+    final int sdkVersion = await Build.version.sdkInt;
+    if (sdkVersion < Build.versionCodes.m) {
+      return true;
+    }
+
     return canRequestPackageInstalls(
       instanceManager.getIdentifier(packageManager)!,
     );
+  }
+
+  /// Retrieve overall information about an application package that is installed on the system.
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager#getPackageInfo(java.lang.String,%20android.content.pm.PackageManager.PackageInfoFlags).
+  Future<PackageInfo?> getPackageInfoWithFlagsFromInstance(
+    PackageManager packageManager,
+    String packageName,
+    int flags,
+  ) async {
+    final String? instanceId = await getPackageInfoWithFlags(
+      instanceManager.getIdentifier(packageManager)!,
+      packageName,
+      flags,
+    );
+
+    if (instanceId == null) {
+      return null;
+    }
+    return instanceManager.getInstanceWithWeakReference(instanceId)
+        as PackageInfo;
+  }
+
+  /// Retrieve overall information about an application package that is installed on the system.
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager#getPackageInfo(java.lang.String,%20android.content.pm.PackageManager.PackageInfoFlags).
+  Future<PackageInfo?> getPackageInfoWithInfoFlagsFromInstance(
+    PackageManager packageManager,
+    String packageName,
+    PackageInfoFlags flags,
+  ) async {
+    final int sdkVersion = await Build.version.sdkInt;
+    if (sdkVersion < Build.versionCodes.tiramisu) {
+      return null;
+    }
+
+    final String? instanceId = await getPackageInfoWithInfoFlags(
+      instanceManager.getIdentifier(packageManager)!,
+      packageName,
+      instanceManager.getIdentifier(flags)!,
+    );
+
+    if (instanceId == null) {
+      return null;
+    }
+    return instanceManager.getInstanceWithWeakReference(instanceId)
+        as PackageInfo;
+  }
+
+  /// Check whether the given feature name is one of the available features as returned by getSystemAvailableFeatures().
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager#hasSystemFeature(java.lang.String).
+  Future<bool> hasSystemFeatureFromInstance(
+    PackageManager packageManager,
+    String featureName,
+  ) {
+    return hasSystemFeature(
+      instanceManager.getIdentifier(packageManager)!,
+      featureName,
+    );
+  }
+
+  /// Retrieve all activities that can be performed for the given intent.
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager#queryIntentActivities(android.content.Intent,%20int).
+  Future<List<ResolveInfo>> queryIntentActivitiesWithFlagsFromInstance(
+    PackageManager packageManager,
+    Intent intent,
+    int flags,
+  ) async {
+    return (await queryIntentActivitiesWithFlags(
+      instanceManager.getIdentifier(packageManager)!,
+      instanceManager.getIdentifier(intent)!,
+      flags,
+    ))
+        .whereType<String>()
+        .map((String instanceId) => instanceManager
+            .getInstanceWithWeakReference(instanceId) as ResolveInfo)
+        .toList();
+  }
+
+  /// Retrieve all activities that can be performed for the given intent.
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager#queryIntentActivities(android.content.Intent,%20android.content.pm.PackageManager.ResolveInfoFlags).
+  Future<List<ResolveInfo>> queryIntentActivitiesWithInfoFlagsFromInstance(
+    PackageManager packageManager,
+    Intent intent,
+    ResolveInfoFlags resolveInfoFlags,
+  ) async {
+    final int sdkVersion = await Build.version.sdkInt;
+    if (sdkVersion < Build.versionCodes.tiramisu) {
+      return [];
+    }
+
+    return (await queryIntentActivitiesWithInfoFlags(
+      instanceManager.getIdentifier(packageManager)!,
+      instanceManager.getIdentifier(intent)!,
+      instanceManager.getIdentifier(resolveInfoFlags)!,
+    ))
+        .whereType<String>()
+        .map((String instanceId) => instanceManager
+            .getInstanceWithWeakReference(instanceId) as ResolveInfo)
+        .toList();
   }
 }
 
@@ -651,7 +840,12 @@ class SettingsHostApiImpl extends SettingsHostApi {
   /// See https://developer.android.com/reference/android/provider/Settings#canDrawOverlays(android.content.Context).
   Future<bool> canDrawOverlaysFromInstance(
     Context context,
-  ) {
+  ) async {
+    final int sdkVersion = await Build.version.sdkInt;
+    if (sdkVersion < Build.versionCodes.m) {
+      return true;
+    }
+
     return canDrawOverlays(
       instanceManager.getIdentifier(context)!,
     );
@@ -687,7 +881,12 @@ class NotificationManagerHostApiImpl extends NotificationManagerHostApi {
   /// See https://developer.android.com/reference/android/app/NotificationManager#isNotificationPolicyAccessGranted().
   Future<bool> isNotificationPolicyAccessGrantedFromInstance(
     NotificationManager notificationManager,
-  ) {
+  ) async {
+    final int sdkVersion = await Build.version.sdkInt;
+    if (sdkVersion < Build.versionCodes.m) {
+      return true;
+    }
+
     return isNotificationPolicyAccessGranted(
       instanceManager.getIdentifier(notificationManager)!,
     );
@@ -698,7 +897,12 @@ class NotificationManagerHostApiImpl extends NotificationManagerHostApi {
   /// See https://developer.android.com/reference/android/app/NotificationManager#areNotificationsEnabled().
   Future<bool> areNotificationsEnabledFromInstance(
     NotificationManager notificationManager,
-  ) {
+  ) async {
+    final int sdkVersion = await Build.version.sdkInt;
+    if (sdkVersion < Build.versionCodes.n) {
+      return true;
+    }
+
     return areNotificationsEnabled(
       instanceManager.getIdentifier(notificationManager)!,
     );
@@ -748,4 +952,336 @@ class EnvironmentHostApiImpl extends EnvironmentHostApi {
 
   /// Maintains instances stored to communicate with native language objects.
   final InstanceManager instanceManager;
+}
+
+/// Host API implementation of PackageInfoFlags.
+class PackageInfoFlagsHostApiImpl extends PackageInfoFlagsHostApi {
+  /// Creates a new instance of [PackageInfoFlagsHostApiImpl].
+  PackageInfoFlagsHostApiImpl({
+    this.binaryMessenger,
+    InstanceManager? instanceManager,
+  })  : instanceManager = instanceManager ?? JavaObject.globalInstanceManager,
+        super(binaryMessenger: binaryMessenger);
+
+  /// Sends binary data across the Flutter platform barrier.
+  ///
+  /// If it is null, the default BinaryMessenger will be used which routes to
+  /// the host platform.
+  final BinaryMessenger? binaryMessenger;
+
+  /// Maintains instances stored to communicate with native language objects.
+  final InstanceManager instanceManager;
+
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager.PackageInfoFlags#of(long).
+  Future<PackageInfoFlags> ofFromClass(
+    int value,
+  ) async {
+    final int sdkVersion = await Build.version.sdkInt;
+    if (sdkVersion < Build.versionCodes.tiramisu) {
+      throw UnsupportedError(
+        'ApplicationInfoFlags.of() is only supported on Android 13 and above.',
+      );
+    }
+
+    final String instanceId = await of(value);
+    final PackageInfoFlags flags = instanceManager
+        .getInstanceWithWeakReference(instanceId) as PackageInfoFlags;
+    return flags;
+  }
+}
+
+/// Flutter API implementation of PackageInfoFlags.
+class PackageInfoFlagsFlutterApiImpl extends PackageInfoFlagsFlutterApi {
+  /// Constructs a new instance of [PackageInfoFlagsFlutterApiImpl].
+  PackageInfoFlagsFlutterApiImpl({
+    InstanceManager? instanceManager,
+  }) : _instanceManager = instanceManager ?? JavaObject.globalInstanceManager;
+
+  /// Maintains instances stored to communicate with native language objects.
+  final InstanceManager _instanceManager;
+
+  @override
+  void create(String instanceId) {
+    final PackageInfoFlags packageInfoFlags = PackageInfoFlags.detached();
+    _instanceManager.addHostCreatedInstance(
+      packageInfoFlags,
+      instanceId,
+    );
+  }
+
+  @override
+  void dispose(String instanceId) {
+    _instanceManager.remove(instanceId);
+  }
+}
+
+/// Host API implementation of PackageInfoFlags.
+class ResolveInfoFlagsHostApiImpl extends ResolveInfoFlagsHostApi {
+  /// Creates a new instance of [ResolveInfoFlagsHostApiImpl].
+  ResolveInfoFlagsHostApiImpl({
+    this.binaryMessenger,
+    InstanceManager? instanceManager,
+  })  : instanceManager = instanceManager ?? JavaObject.globalInstanceManager,
+        super(binaryMessenger: binaryMessenger);
+
+  /// Sends binary data across the Flutter platform barrier.
+  ///
+  /// If it is null, the default BinaryMessenger will be used which routes to
+  /// the host platform.
+  final BinaryMessenger? binaryMessenger;
+
+  /// Maintains instances stored to communicate with native language objects.
+  final InstanceManager instanceManager;
+
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager.ResolveInfoFlags#of(long).
+  Future<ResolveInfoFlags> ofFromClass(
+    int value,
+  ) async {
+    final int sdkVersion = await Build.version.sdkInt;
+    if (sdkVersion < Build.versionCodes.tiramisu) {
+      throw UnsupportedError(
+        'ApplicationInfoFlags.of() is only supported on Android 13 and above.',
+      );
+    }
+
+    final String instanceId = await of(value);
+    final ResolveInfoFlags flags = instanceManager
+        .getInstanceWithWeakReference(instanceId) as ResolveInfoFlags;
+    return flags;
+  }
+}
+
+/// Flutter API implementation of ResolveInfoFlags.
+class ResolveInfoFlagsFlutterApiImpl extends ResolveInfoFlagsFlutterApi {
+  /// Constructs a new instance of [ResolveInfoFlagsFlutterApiImpl].
+  ResolveInfoFlagsFlutterApiImpl({
+    InstanceManager? instanceManager,
+  }) : _instanceManager = instanceManager ?? JavaObject.globalInstanceManager;
+
+  /// Maintains instances stored to communicate with native language objects.
+  final InstanceManager _instanceManager;
+
+  @override
+  void create(String instanceId) {
+    final ResolveInfoFlags resolveInfoFlags = ResolveInfoFlags.detached();
+    _instanceManager.addHostCreatedInstance(
+      resolveInfoFlags,
+      instanceId,
+    );
+  }
+
+  @override
+  void dispose(String instanceId) {
+    _instanceManager.remove(instanceId);
+  }
+}
+
+/// Host API implementation of ApplicationInfoFlags.
+class ApplicationInfoFlagsHostApiImpl extends ApplicationInfoFlagsHostApi {
+  /// Creates a new instance of [ApplicationInfoFlagsHostApiImpl].
+  ApplicationInfoFlagsHostApiImpl({
+    this.binaryMessenger,
+    InstanceManager? instanceManager,
+  })  : instanceManager = instanceManager ?? JavaObject.globalInstanceManager,
+        super(binaryMessenger: binaryMessenger);
+
+  /// Sends binary data across the Flutter platform barrier.
+  ///
+  /// If it is null, the default BinaryMessenger will be used which routes to
+  /// the host platform.
+  final BinaryMessenger? binaryMessenger;
+
+  /// Maintains instances stored to communicate with native language objects.
+  final InstanceManager instanceManager;
+
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager.ApplicationInfoFlags#of(long).
+  Future<ApplicationInfoFlags> ofFromClass(
+    int value,
+  ) async {
+    final int sdkVersion = await Build.version.sdkInt;
+    if (sdkVersion < Build.versionCodes.tiramisu) {
+      throw UnsupportedError(
+        'ApplicationInfoFlags.of() is only supported on Android 13 and above.',
+      );
+    }
+
+    final String instanceId = await of(value);
+    final ApplicationInfoFlags flags = instanceManager
+        .getInstanceWithWeakReference(instanceId) as ApplicationInfoFlags;
+    return flags;
+  }
+}
+
+/// Flutter API implementation of ApplicationInfoFlags.
+class ApplicationInfoFlagsFlutterApiImpl
+    extends ApplicationInfoFlagsFlutterApi {
+  /// Constructs a new instance of [ApplicationInfoFlagsFlutterApiImpl].
+  ApplicationInfoFlagsFlutterApiImpl({
+    InstanceManager? instanceManager,
+  }) : _instanceManager = instanceManager ?? JavaObject.globalInstanceManager;
+
+  /// Maintains instances stored to communicate with native language objects.
+  final InstanceManager _instanceManager;
+
+  @override
+  void create(String instanceId) {
+    final ApplicationInfoFlags applicationInfoFlags =
+        ApplicationInfoFlags.detached();
+    _instanceManager.addHostCreatedInstance(
+      applicationInfoFlags,
+      instanceId,
+    );
+  }
+
+  @override
+  void dispose(String instanceId) {
+    _instanceManager.remove(instanceId);
+  }
+}
+
+/// Host API implementation of ComponentInfoFlags.
+class ComponentInfoFlagsHostApiImpl extends ComponentInfoFlagsHostApi {
+  /// Creates a new instance of [ComponentInfoFlagsHostApiImpl].
+  ComponentInfoFlagsHostApiImpl({
+    this.binaryMessenger,
+    InstanceManager? instanceManager,
+  })  : instanceManager = instanceManager ?? JavaObject.globalInstanceManager,
+        super(binaryMessenger: binaryMessenger);
+
+  /// Sends binary data across the Flutter platform barrier.
+  ///
+  /// If it is null, the default BinaryMessenger will be used which routes to
+  /// the host platform.
+  final BinaryMessenger? binaryMessenger;
+
+  /// Maintains instances stored to communicate with native language objects.
+  final InstanceManager instanceManager;
+
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager.ComponentInfoFlags#of(long).
+  Future<ComponentInfoFlags> ofFromClass(
+    int value,
+  ) async {
+    final int sdkVersion = await Build.version.sdkInt;
+    if (sdkVersion < Build.versionCodes.tiramisu) {
+      throw UnsupportedError(
+        'ApplicationInfoFlags.of() is only supported on Android 13 and above.',
+      );
+    }
+
+    final String instanceId = await of(value);
+    final ComponentInfoFlags flags = instanceManager
+        .getInstanceWithWeakReference(instanceId) as ComponentInfoFlags;
+    return flags;
+  }
+}
+
+/// Flutter API implementation of ComponentInfoFlags.
+class ComponentInfoFlagsFlutterApiImpl extends ComponentInfoFlagsFlutterApi {
+  /// Constructs a new instance of [ComponentInfoFlagsFlutterApiImpl].
+  ComponentInfoFlagsFlutterApiImpl({
+    InstanceManager? instanceManager,
+  }) : _instanceManager = instanceManager ?? JavaObject.globalInstanceManager;
+
+  /// Maintains instances stored to communicate with native language objects.
+  final InstanceManager _instanceManager;
+
+  @override
+  void create(String instanceId) {
+    final ComponentInfoFlags componentInfoFlags = ComponentInfoFlags.detached();
+    _instanceManager.addHostCreatedInstance(
+      componentInfoFlags,
+      instanceId,
+    );
+  }
+
+  @override
+  void dispose(String instanceId) {
+    _instanceManager.remove(instanceId);
+  }
+}
+
+/// Host API implementation of PackageInfo.
+class PackageInfoHostApiImpl extends PackageInfoHostApi {
+  /// Creates a new instance of [PackageInfoHostApiImpl].
+  PackageInfoHostApiImpl({
+    this.binaryMessenger,
+    InstanceManager? instanceManager,
+  })  : instanceManager = instanceManager ?? JavaObject.globalInstanceManager,
+        super(binaryMessenger: binaryMessenger);
+
+  /// Sends binary data across the Flutter platform barrier.
+  ///
+  /// If it is null, the default BinaryMessenger will be used which routes to
+  /// the host platform.
+  final BinaryMessenger? binaryMessenger;
+
+  /// Maintains instances stored to communicate with native language objects.
+  final InstanceManager instanceManager;
+
+  /// Array of all <uses-permission> tags included under <manifest>, or null if there were none.
+  ///
+  /// This is only filled in if the flag PackageManager#GET_PERMISSIONS was set.
+  /// This list includes all permissions requested, even those that were not
+  /// granted or known by the system at install time.
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageInfo#requestedPermissions.
+  Future<List<String>> getRequestedPermissionsFromInstance(
+    PackageInfo packageInfo,
+  ) async {
+    return (await getRequestedPermissions(
+      instanceManager.getIdentifier(packageInfo)!,
+    ))
+        .whereType<String>()
+        .toList();
+  }
+}
+
+/// Flutter API implementation of PackageInfo.
+class PackageInfoFlutterApiImpl extends PackageInfoFlutterApi {
+  /// Constructs a new instance of [PackageInfoFlutterApiImpl].
+  PackageInfoFlutterApiImpl({
+    InstanceManager? instanceManager,
+  }) : _instanceManager = instanceManager ?? JavaObject.globalInstanceManager;
+
+  /// Maintains instances stored to communicate with native language objects.
+  final InstanceManager _instanceManager;
+
+  @override
+  void create(String instanceId) {
+    final PackageInfo packageInfo = PackageInfo.detached();
+    _instanceManager.addHostCreatedInstance(
+      packageInfo,
+      instanceId,
+    );
+  }
+
+  @override
+  void dispose(String instanceId) {
+    _instanceManager.remove(instanceId);
+  }
+}
+
+/// Flutter API implementation of ResolveInfo.
+class ResolveInfoFlutterApiImpl extends ResolveInfoFlutterApi {
+  /// Constructs a new instance of [ResolveInfoFlutterApiImpl].
+  ResolveInfoFlutterApiImpl({
+    InstanceManager? instanceManager,
+  }) : _instanceManager = instanceManager ?? JavaObject.globalInstanceManager;
+
+  /// Maintains instances stored to communicate with native language objects.
+  final InstanceManager _instanceManager;
+
+  @override
+  void create(String instanceId) {
+    final ResolveInfo resolveInfo = ResolveInfo.detached();
+    _instanceManager.addHostCreatedInstance(
+      resolveInfo,
+      instanceId,
+    );
+  }
+
+  @override
+  void dispose(String instanceId) {
+    _instanceManager.remove(instanceId);
+  }
 }

--- a/permission_handler_android/lib/src/permission_handler.pigeon.dart
+++ b/permission_handler_android/lib/src/permission_handler.pigeon.dart
@@ -1347,3 +1347,55 @@ abstract class NotificationManagerFlutterApi {
     }
   }
 }
+
+/// Host API for `Environment`.
+///
+/// This class may handle instantiating and adding native object instances that
+/// are attached to a Dart instance or handle method calls on the associated
+/// native class or an instance of the class.
+///
+/// See https://developer.android.com/reference/android/os/Environment.
+class EnvironmentHostApi {
+  /// Constructor for [EnvironmentHostApi].  The [binaryMessenger] named argument is
+  /// available for dependency injection.  If it is left null, the default
+  /// BinaryMessenger will be used which routes to the host platform.
+  EnvironmentHostApi({BinaryMessenger? binaryMessenger})
+      : _binaryMessenger = binaryMessenger;
+  final BinaryMessenger? _binaryMessenger;
+
+  static const MessageCodec<Object?> codec = StandardMessageCodec();
+
+  /// Returns whether the calling app has All Files Access on the primary shared/external storage media.
+  ///
+  /// Declaring the permission [Manifest.permission.manageExternalStorage] is
+  /// not enough to gain the access. To request access, use
+  /// [Settings.actionManageAppAllFilesAccessPermission].
+  ///
+  /// See https://developer.android.com/reference/android/os/Environment#isExternalStorageManager().
+  Future<bool> isExternalStorageManager() async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.permission_handler_android.EnvironmentHostApi.isExternalStorageManager',
+        codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList = await channel.send(null) as List<Object?>?;
+    if (replyList == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyList.length > 1) {
+      throw PlatformException(
+        code: replyList[0]! as String,
+        message: replyList[1] as String?,
+        details: replyList[2],
+      );
+    } else if (replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (replyList[0] as bool?)!;
+    }
+  }
+}

--- a/permission_handler_android/lib/src/permission_handler.pigeon.dart
+++ b/permission_handler_android/lib/src/permission_handler.pigeon.dart
@@ -543,12 +543,12 @@ class UriHostApi {
   /// Returns the instance ID of the created Uri.
   ///
   /// See https://developer.android.com/reference/android/net/Uri#parse(java.lang.String).
-  Future<void> parse(String arg_instanceId, String arg_uriString) async {
+  Future<String> parse(String arg_uriString) async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
         'dev.flutter.pigeon.permission_handler_android.UriHostApi.parse', codec,
         binaryMessenger: _binaryMessenger);
-    final List<Object?>? replyList = await channel
-        .send(<Object?>[arg_instanceId, arg_uriString]) as List<Object?>?;
+    final List<Object?>? replyList =
+        await channel.send(<Object?>[arg_uriString]) as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
         code: 'channel-error',
@@ -560,8 +560,13 @@ class UriHostApi {
         message: replyList[1] as String?,
         details: replyList[2],
       );
+    } else if (replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
     } else {
-      return;
+      return (replyList[0] as String?)!;
     }
   }
 
@@ -598,6 +603,66 @@ class UriHostApi {
       );
     } else {
       return (replyList[0] as String?)!;
+    }
+  }
+}
+
+/// Flutter API for `Uri`.
+///
+/// This class may handle instantiating and adding Dart instances that are
+/// attached to a native instance or receiving callback methods from an
+/// overridden native class.
+///
+/// See https://developer.android.com/reference/android/net/Uri.
+abstract class UriFlutterApi {
+  static const MessageCodec<Object?> codec = StandardMessageCodec();
+
+  /// Create a new Dart instance and add it to the `InstanceManager`.
+  void create(String instanceId);
+
+  /// Dispose of the Dart instance and remove it from the `InstanceManager`.
+  void dispose(String instanceId);
+
+  static void setup(UriFlutterApi? api, {BinaryMessenger? binaryMessenger}) {
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.UriFlutterApi.create',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        channel.setMessageHandler(null);
+      } else {
+        channel.setMessageHandler((Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.UriFlutterApi.create was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_instanceId = (args[0] as String?);
+          assert(arg_instanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.UriFlutterApi.create was null, expected non-null String.');
+          api.create(arg_instanceId!);
+          return;
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.UriFlutterApi.dispose',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        channel.setMessageHandler(null);
+      } else {
+        channel.setMessageHandler((Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.UriFlutterApi.dispose was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_instanceId = (args[0] as String?);
+          assert(arg_instanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.UriFlutterApi.dispose was null, expected non-null String.');
+          api.dispose(arg_instanceId!);
+          return;
+        });
+      }
     }
   }
 }
@@ -1082,6 +1147,166 @@ class PackageManagerHostApi {
       return (replyList[0] as bool?)!;
     }
   }
+
+  /// Retrieve overall information about an application package that is installed on the system.
+  ///
+  /// Use [getPackageInfoWithInfoFlags] when long flags are needed.
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager#getPackageInfo(java.lang.String,%20int).
+  Future<String?> getPackageInfoWithFlags(
+      String arg_instanceId, String arg_packageName, int arg_flags) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.getPackageInfoWithFlags',
+        codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList = await channel
+            .send(<Object?>[arg_instanceId, arg_packageName, arg_flags])
+        as List<Object?>?;
+    if (replyList == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyList.length > 1) {
+      throw PlatformException(
+        code: replyList[0]! as String,
+        message: replyList[1] as String?,
+        details: replyList[2],
+      );
+    } else {
+      return (replyList[0] as String?);
+    }
+  }
+
+  /// Retrieve overall information about an application package that is installed on the system.
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager#getPackageInfo(java.lang.String,%20android.content.pm.PackageManager.PackageInfoFlags).
+  Future<String?> getPackageInfoWithInfoFlags(String arg_instanceId,
+      String arg_packageName, String arg_flagsInstanceId) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.getPackageInfoWithInfoFlags',
+        codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList = await channel.send(
+            <Object?>[arg_instanceId, arg_packageName, arg_flagsInstanceId])
+        as List<Object?>?;
+    if (replyList == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyList.length > 1) {
+      throw PlatformException(
+        code: replyList[0]! as String,
+        message: replyList[1] as String?,
+        details: replyList[2],
+      );
+    } else {
+      return (replyList[0] as String?);
+    }
+  }
+
+  /// Check whether the given feature name is one of the available features as returned by getSystemAvailableFeatures().
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager#hasSystemFeature(java.lang.String).
+  Future<bool> hasSystemFeature(
+      String arg_instanceId, String arg_featureName) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.hasSystemFeature',
+        codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList = await channel
+        .send(<Object?>[arg_instanceId, arg_featureName]) as List<Object?>?;
+    if (replyList == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyList.length > 1) {
+      throw PlatformException(
+        code: replyList[0]! as String,
+        message: replyList[1] as String?,
+        details: replyList[2],
+      );
+    } else if (replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (replyList[0] as bool?)!;
+    }
+  }
+
+  /// Retrieve all activities that can be performed for the given intent.
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager#queryIntentActivities(android.content.Intent,%20int).
+  Future<List<String?>> queryIntentActivitiesWithFlags(
+      String arg_instanceId, String arg_intentInstanceId, int arg_flags) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.queryIntentActivitiesWithFlags',
+        codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList = await channel
+            .send(<Object?>[arg_instanceId, arg_intentInstanceId, arg_flags])
+        as List<Object?>?;
+    if (replyList == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyList.length > 1) {
+      throw PlatformException(
+        code: replyList[0]! as String,
+        message: replyList[1] as String?,
+        details: replyList[2],
+      );
+    } else if (replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (replyList[0] as List<Object?>?)!.cast<String?>();
+    }
+  }
+
+  /// Retrieve all activities that can be performed for the given intent.
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager#queryIntentActivities(android.content.Intent,%20android.content.pm.ResolveInfoFlags).
+  Future<List<String?>> queryIntentActivitiesWithInfoFlags(
+      String arg_instanceId,
+      String arg_intentInstanceId,
+      String arg_flagsInstanceId) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.queryIntentActivitiesWithInfoFlags',
+        codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList = await channel.send(<Object?>[
+      arg_instanceId,
+      arg_intentInstanceId,
+      arg_flagsInstanceId
+    ]) as List<Object?>?;
+    if (replyList == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyList.length > 1) {
+      throw PlatformException(
+        code: replyList[0]! as String,
+        message: replyList[1] as String?,
+        details: replyList[2],
+      );
+    } else if (replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (replyList[0] as List<Object?>?)!.cast<String?>();
+    }
+  }
 }
 
 /// Flutter API for `PackageManager`.
@@ -1396,6 +1621,613 @@ class EnvironmentHostApi {
       );
     } else {
       return (replyList[0] as bool?)!;
+    }
+  }
+}
+
+/// Host API for `PackageInfo`.
+///
+/// This class may handle instantiating and adding native object instances that
+/// are attached to a Dart instance or handle method calls on the associated
+/// native class or an instance of the class.
+///
+/// See https://developer.android.com/reference/android/content/pm/PackageInfo.
+class PackageInfoHostApi {
+  /// Constructor for [PackageInfoHostApi].  The [binaryMessenger] named argument is
+  /// available for dependency injection.  If it is left null, the default
+  /// BinaryMessenger will be used which routes to the host platform.
+  PackageInfoHostApi({BinaryMessenger? binaryMessenger})
+      : _binaryMessenger = binaryMessenger;
+  final BinaryMessenger? _binaryMessenger;
+
+  static const MessageCodec<Object?> codec = StandardMessageCodec();
+
+  /// Array of all <uses-permission> tags included under <manifest>, or null if there were none.
+  ///
+  /// This is only filled in if the flag PackageManager#GET_PERMISSIONS was set.
+  /// This list includes all permissions requested, even those that were not
+  /// granted or known by the system at install time.
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageInfo#requestedPermissions.
+  Future<List<String?>> getRequestedPermissions(String arg_instanceId) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.permission_handler_android.PackageInfoHostApi.getRequestedPermissions',
+        codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList =
+        await channel.send(<Object?>[arg_instanceId]) as List<Object?>?;
+    if (replyList == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyList.length > 1) {
+      throw PlatformException(
+        code: replyList[0]! as String,
+        message: replyList[1] as String?,
+        details: replyList[2],
+      );
+    } else if (replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (replyList[0] as List<Object?>?)!.cast<String?>();
+    }
+  }
+}
+
+/// Flutter API for `PackageInfo`.
+///
+/// This class may handle instantiating and adding Dart instances that are
+/// attached to a native instance or receiving callback methods from an
+/// overridden native class.
+///
+/// See https://developer.android.com/reference/android/content/pm/PackageInfo.
+abstract class PackageInfoFlutterApi {
+  static const MessageCodec<Object?> codec = StandardMessageCodec();
+
+  /// Create a new Dart instance and add it to the `InstanceManager`.
+  void create(String instanceId);
+
+  /// Dispose of the Dart instance and remove it from the `InstanceManager`.
+  void dispose(String instanceId);
+
+  static void setup(PackageInfoFlutterApi? api,
+      {BinaryMessenger? binaryMessenger}) {
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.PackageInfoFlutterApi.create',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        channel.setMessageHandler(null);
+      } else {
+        channel.setMessageHandler((Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageInfoFlutterApi.create was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_instanceId = (args[0] as String?);
+          assert(arg_instanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageInfoFlutterApi.create was null, expected non-null String.');
+          api.create(arg_instanceId!);
+          return;
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.PackageInfoFlutterApi.dispose',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        channel.setMessageHandler(null);
+      } else {
+        channel.setMessageHandler((Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageInfoFlutterApi.dispose was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_instanceId = (args[0] as String?);
+          assert(arg_instanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageInfoFlutterApi.dispose was null, expected non-null String.');
+          api.dispose(arg_instanceId!);
+          return;
+        });
+      }
+    }
+  }
+}
+
+/// Host API for `PackageInfoFlags`.
+///
+/// This class may handle instantiating and adding native object instances that
+/// are attached to a Dart instance or handle method calls on the associated
+/// native class or an instance of the class.
+///
+/// See https://developer.android.com/reference/android/content/pm/PackageManager#PackageInfoFlags.
+class PackageInfoFlagsHostApi {
+  /// Constructor for [PackageInfoFlagsHostApi].  The [binaryMessenger] named argument is
+  /// available for dependency injection.  If it is left null, the default
+  /// BinaryMessenger will be used which routes to the host platform.
+  PackageInfoFlagsHostApi({BinaryMessenger? binaryMessenger})
+      : _binaryMessenger = binaryMessenger;
+  final BinaryMessenger? _binaryMessenger;
+
+  static const MessageCodec<Object?> codec = StandardMessageCodec();
+
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager.PackageInfoFlags#of(long).
+  Future<String> of(int arg_value) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.permission_handler_android.PackageInfoFlagsHostApi.of',
+        codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList =
+        await channel.send(<Object?>[arg_value]) as List<Object?>?;
+    if (replyList == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyList.length > 1) {
+      throw PlatformException(
+        code: replyList[0]! as String,
+        message: replyList[1] as String?,
+        details: replyList[2],
+      );
+    } else if (replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (replyList[0] as String?)!;
+    }
+  }
+}
+
+/// Flutter API for `PackageInfoFlags`.
+///
+/// This class may handle instantiating and adding Dart instances that are
+/// attached to a native instance or receiving callback methods from an
+/// overridden native class.
+///
+/// See https://developer.android.com/reference/android/content/pm/PackageManager#PackageInfoFlags.
+abstract class PackageInfoFlagsFlutterApi {
+  static const MessageCodec<Object?> codec = StandardMessageCodec();
+
+  /// Create a new Dart instance and add it to the `InstanceManager`.
+  void create(String instanceId);
+
+  /// Dispose of the Dart instance and remove it from the `InstanceManager`.
+  void dispose(String instanceId);
+
+  static void setup(PackageInfoFlagsFlutterApi? api,
+      {BinaryMessenger? binaryMessenger}) {
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.PackageInfoFlagsFlutterApi.create',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        channel.setMessageHandler(null);
+      } else {
+        channel.setMessageHandler((Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageInfoFlagsFlutterApi.create was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_instanceId = (args[0] as String?);
+          assert(arg_instanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageInfoFlagsFlutterApi.create was null, expected non-null String.');
+          api.create(arg_instanceId!);
+          return;
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.PackageInfoFlagsFlutterApi.dispose',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        channel.setMessageHandler(null);
+      } else {
+        channel.setMessageHandler((Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageInfoFlagsFlutterApi.dispose was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_instanceId = (args[0] as String?);
+          assert(arg_instanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageInfoFlagsFlutterApi.dispose was null, expected non-null String.');
+          api.dispose(arg_instanceId!);
+          return;
+        });
+      }
+    }
+  }
+}
+
+/// Host API for `ResolveInfoFlags`.
+///
+/// This class may handle instantiating and adding native object instances that
+/// are attached to a Dart instance or handle method calls on the associated
+/// native class or an instance of the class.
+///
+/// See https://developer.android.com/reference/android/content/pm/PackageManager#ResolveInfoFlags.
+class ResolveInfoFlagsHostApi {
+  /// Constructor for [ResolveInfoFlagsHostApi].  The [binaryMessenger] named argument is
+  /// available for dependency injection.  If it is left null, the default
+  /// BinaryMessenger will be used which routes to the host platform.
+  ResolveInfoFlagsHostApi({BinaryMessenger? binaryMessenger})
+      : _binaryMessenger = binaryMessenger;
+  final BinaryMessenger? _binaryMessenger;
+
+  static const MessageCodec<Object?> codec = StandardMessageCodec();
+
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager.ResolveInfoFlags#of(long).
+  Future<String> of(int arg_value) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.permission_handler_android.ResolveInfoFlagsHostApi.of',
+        codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList =
+        await channel.send(<Object?>[arg_value]) as List<Object?>?;
+    if (replyList == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyList.length > 1) {
+      throw PlatformException(
+        code: replyList[0]! as String,
+        message: replyList[1] as String?,
+        details: replyList[2],
+      );
+    } else if (replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (replyList[0] as String?)!;
+    }
+  }
+}
+
+/// Flutter API for `ResolveInfoFlags`.
+///
+/// This class may handle instantiating and adding Dart instances that are
+/// attached to a native instance or receiving callback methods from an
+/// overridden native class.
+///
+/// See https://developer.android.com/reference/android/content/pm/PackageManager#ResolveInfoFlags.
+abstract class ResolveInfoFlagsFlutterApi {
+  static const MessageCodec<Object?> codec = StandardMessageCodec();
+
+  /// Create a new Dart instance and add it to the `InstanceManager`.
+  void create(String instanceId);
+
+  /// Dispose of the Dart instance and remove it from the `InstanceManager`.
+  void dispose(String instanceId);
+
+  static void setup(ResolveInfoFlagsFlutterApi? api,
+      {BinaryMessenger? binaryMessenger}) {
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.ResolveInfoFlagsFlutterApi.create',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        channel.setMessageHandler(null);
+      } else {
+        channel.setMessageHandler((Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.ResolveInfoFlagsFlutterApi.create was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_instanceId = (args[0] as String?);
+          assert(arg_instanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.ResolveInfoFlagsFlutterApi.create was null, expected non-null String.');
+          api.create(arg_instanceId!);
+          return;
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.ResolveInfoFlagsFlutterApi.dispose',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        channel.setMessageHandler(null);
+      } else {
+        channel.setMessageHandler((Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.ResolveInfoFlagsFlutterApi.dispose was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_instanceId = (args[0] as String?);
+          assert(arg_instanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.ResolveInfoFlagsFlutterApi.dispose was null, expected non-null String.');
+          api.dispose(arg_instanceId!);
+          return;
+        });
+      }
+    }
+  }
+}
+
+/// Host API for `ApplicationInfoFlags`.
+///
+/// This class may handle instantiating and adding native object instances that
+/// are attached to a Dart instance or handle method calls on the associated
+/// native class or an instance of the class.
+///
+/// See https://developer.android.com/reference/android/content/pm/PackageManager#ApplicationInfoFlags.
+class ApplicationInfoFlagsHostApi {
+  /// Constructor for [ApplicationInfoFlagsHostApi].  The [binaryMessenger] named argument is
+  /// available for dependency injection.  If it is left null, the default
+  /// BinaryMessenger will be used which routes to the host platform.
+  ApplicationInfoFlagsHostApi({BinaryMessenger? binaryMessenger})
+      : _binaryMessenger = binaryMessenger;
+  final BinaryMessenger? _binaryMessenger;
+
+  static const MessageCodec<Object?> codec = StandardMessageCodec();
+
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager.ApplicationInfoFlags#of(long).
+  Future<String> of(int arg_value) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.permission_handler_android.ApplicationInfoFlagsHostApi.of',
+        codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList =
+        await channel.send(<Object?>[arg_value]) as List<Object?>?;
+    if (replyList == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyList.length > 1) {
+      throw PlatformException(
+        code: replyList[0]! as String,
+        message: replyList[1] as String?,
+        details: replyList[2],
+      );
+    } else if (replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (replyList[0] as String?)!;
+    }
+  }
+}
+
+/// Flutter API for `ApplicationInfoFlags`.
+///
+/// This class may handle instantiating and adding Dart instances that are
+/// attached to a native instance or receiving callback methods from an
+/// overridden native class.
+///
+/// See https://developer.android.com/reference/android/content/pm/PackageManager#ApplicationInfoFlags.
+abstract class ApplicationInfoFlagsFlutterApi {
+  static const MessageCodec<Object?> codec = StandardMessageCodec();
+
+  /// Create a new Dart instance and add it to the `InstanceManager`.
+  void create(String instanceId);
+
+  /// Dispose of the Dart instance and remove it from the `InstanceManager`.
+  void dispose(String instanceId);
+
+  static void setup(ApplicationInfoFlagsFlutterApi? api,
+      {BinaryMessenger? binaryMessenger}) {
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.ApplicationInfoFlagsFlutterApi.create',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        channel.setMessageHandler(null);
+      } else {
+        channel.setMessageHandler((Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.ApplicationInfoFlagsFlutterApi.create was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_instanceId = (args[0] as String?);
+          assert(arg_instanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.ApplicationInfoFlagsFlutterApi.create was null, expected non-null String.');
+          api.create(arg_instanceId!);
+          return;
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.ApplicationInfoFlagsFlutterApi.dispose',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        channel.setMessageHandler(null);
+      } else {
+        channel.setMessageHandler((Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.ApplicationInfoFlagsFlutterApi.dispose was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_instanceId = (args[0] as String?);
+          assert(arg_instanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.ApplicationInfoFlagsFlutterApi.dispose was null, expected non-null String.');
+          api.dispose(arg_instanceId!);
+          return;
+        });
+      }
+    }
+  }
+}
+
+/// Host API for `ComponentInfoFlags`.
+///
+/// This class may handle instantiating and adding native object instances that
+/// are attached to a Dart instance or handle method calls on the associated
+/// native class or an instance of the class.
+///
+/// See https://developer.android.com/reference/android/content/pm/PackageManager#ComponentInfoFlags.
+class ComponentInfoFlagsHostApi {
+  /// Constructor for [ComponentInfoFlagsHostApi].  The [binaryMessenger] named argument is
+  /// available for dependency injection.  If it is left null, the default
+  /// BinaryMessenger will be used which routes to the host platform.
+  ComponentInfoFlagsHostApi({BinaryMessenger? binaryMessenger})
+      : _binaryMessenger = binaryMessenger;
+  final BinaryMessenger? _binaryMessenger;
+
+  static const MessageCodec<Object?> codec = StandardMessageCodec();
+
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager.ComponentInfoFlags#of(long).
+  Future<String> of(int arg_value) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.permission_handler_android.ComponentInfoFlagsHostApi.of',
+        codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList =
+        await channel.send(<Object?>[arg_value]) as List<Object?>?;
+    if (replyList == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyList.length > 1) {
+      throw PlatformException(
+        code: replyList[0]! as String,
+        message: replyList[1] as String?,
+        details: replyList[2],
+      );
+    } else if (replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (replyList[0] as String?)!;
+    }
+  }
+}
+
+/// Flutter API for `ComponentInfoFlags`.
+///
+/// This class may handle instantiating and adding Dart instances that are
+/// attached to a native instance or receiving callback methods from an
+/// overridden native class.
+///
+/// See https://developer.android.com/reference/android/content/pm/PackageManager#ComponentInfoFlags.
+abstract class ComponentInfoFlagsFlutterApi {
+  static const MessageCodec<Object?> codec = StandardMessageCodec();
+
+  /// Create a new Dart instance and add it to the `InstanceManager`.
+  void create(String instanceId);
+
+  /// Dispose of the Dart instance and remove it from the `InstanceManager`.
+  void dispose(String instanceId);
+
+  static void setup(ComponentInfoFlagsFlutterApi? api,
+      {BinaryMessenger? binaryMessenger}) {
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.ComponentInfoFlagsFlutterApi.create',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        channel.setMessageHandler(null);
+      } else {
+        channel.setMessageHandler((Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.ComponentInfoFlagsFlutterApi.create was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_instanceId = (args[0] as String?);
+          assert(arg_instanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.ComponentInfoFlagsFlutterApi.create was null, expected non-null String.');
+          api.create(arg_instanceId!);
+          return;
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.ComponentInfoFlagsFlutterApi.dispose',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        channel.setMessageHandler(null);
+      } else {
+        channel.setMessageHandler((Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.ComponentInfoFlagsFlutterApi.dispose was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_instanceId = (args[0] as String?);
+          assert(arg_instanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.ComponentInfoFlagsFlutterApi.dispose was null, expected non-null String.');
+          api.dispose(arg_instanceId!);
+          return;
+        });
+      }
+    }
+  }
+}
+
+/// Flutter API for `ResolveInfo`.
+///
+/// This class may handle instantiating and adding Dart instances that are
+/// attached to a native instance or receiving callback methods from an
+/// overridden native class.
+///
+/// See https://developer.android.com/reference/android/content/pm/ResolveInfo.
+abstract class ResolveInfoFlutterApi {
+  static const MessageCodec<Object?> codec = StandardMessageCodec();
+
+  /// Create a new Dart instance and add it to the `InstanceManager`.
+  void create(String instanceId);
+
+  /// Dispose of the Dart instance and remove it from the `InstanceManager`.
+  void dispose(String instanceId);
+
+  static void setup(ResolveInfoFlutterApi? api,
+      {BinaryMessenger? binaryMessenger}) {
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.ResolveInfoFlutterApi.create',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        channel.setMessageHandler(null);
+      } else {
+        channel.setMessageHandler((Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.ResolveInfoFlutterApi.create was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_instanceId = (args[0] as String?);
+          assert(arg_instanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.ResolveInfoFlutterApi.create was null, expected non-null String.');
+          api.create(arg_instanceId!);
+          return;
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.ResolveInfoFlutterApi.dispose',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        channel.setMessageHandler(null);
+      } else {
+        channel.setMessageHandler((Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.ResolveInfoFlutterApi.dispose was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_instanceId = (args[0] as String?);
+          assert(arg_instanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.ResolveInfoFlutterApi.dispose was null, expected non-null String.');
+          api.dispose(arg_instanceId!);
+          return;
+        });
+      }
     }
   }
 }

--- a/permission_handler_android/lib/src/permission_handler_android.dart
+++ b/permission_handler_android/lib/src/permission_handler_android.dart
@@ -139,7 +139,7 @@ class PermissionHandlerAndroid extends PermissionHandlerPlatform {
       Intent()
         ..setAction(action)
         ..setData(
-          Uri.parse(
+          await Uri.parse(
             'package:${await _activityManager.applicationContext.getPackageName()}',
           ),
         ),
@@ -153,7 +153,7 @@ class PermissionHandlerAndroid extends PermissionHandlerPlatform {
     final Context applicationContext = _activityManager.applicationContext;
 
     final String packageName = await applicationContext.getPackageName();
-    final Uri uri = Uri.parse('package:$packageName');
+    final Uri uri = await Uri.parse('package:$packageName');
 
     final Intent intent = Intent();
     intent.setAction(Settings.actionApplicationDetailsSettings);

--- a/permission_handler_android/pigeons/android_permission_handler.dart
+++ b/permission_handler_android/pigeons/android_permission_handler.dart
@@ -186,8 +186,7 @@ abstract class UriHostApi {
   /// Returns the instance ID of the created Uri.
   ///
   /// See https://developer.android.com/reference/android/net/Uri#parse(java.lang.String).
-  void parse(
-    String instanceId,
+  String parse(
     String uriString,
   );
 
@@ -202,6 +201,22 @@ abstract class UriHostApi {
   String toStringAsync(
     String instanceId,
   );
+}
+
+/// Flutter API for `Uri`.
+///
+/// This class may handle instantiating and adding Dart instances that are
+/// attached to a native instance or receiving callback methods from an
+/// overridden native class.
+///
+/// See https://developer.android.com/reference/android/net/Uri.
+@FlutterApi()
+abstract class UriFlutterApi {
+  /// Create a new Dart instance and add it to the `InstanceManager`.
+  void create(String instanceId);
+
+  /// Dispose of the Dart instance and remove it from the `InstanceManager`.
+  void dispose(String instanceId);
 }
 
 /// Host API for `Intent`.
@@ -362,6 +377,52 @@ abstract class PackageManagerHostApi {
   ///
   /// See https://developer.android.com/reference/android/content/pm/PackageManager#canRequestPackageInstalls().
   bool canRequestPackageInstalls(String instanceId);
+
+  /// Retrieve overall information about an application package that is installed on the system.
+  ///
+  /// Use [getPackageInfoWithInfoFlags] when long flags are needed.
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager#getPackageInfo(java.lang.String,%20int).
+  String? getPackageInfoWithFlags(
+    String instanceId,
+    String packageName,
+    int flags,
+  );
+
+  /// Retrieve overall information about an application package that is installed on the system.
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager#getPackageInfo(java.lang.String,%20android.content.pm.PackageManager.PackageInfoFlags).
+  String? getPackageInfoWithInfoFlags(
+    String instanceId,
+    String packageName,
+    String flagsInstanceId,
+  );
+
+  /// Check whether the given feature name is one of the available features as returned by getSystemAvailableFeatures().
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager#hasSystemFeature(java.lang.String).
+  bool hasSystemFeature(
+    String instanceId,
+    String featureName,
+  );
+
+  /// Retrieve all activities that can be performed for the given intent.
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager#queryIntentActivities(android.content.Intent,%20int).
+  List<String> queryIntentActivitiesWithFlags(
+    String instanceId,
+    String intentInstanceId,
+    int flags,
+  );
+
+  /// Retrieve all activities that can be performed for the given intent.
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager#queryIntentActivities(android.content.Intent,%20android.content.pm.ResolveInfoFlags).
+  List<String> queryIntentActivitiesWithInfoFlags(
+    String instanceId,
+    String intentInstanceId,
+    String flagsInstanceId,
+  );
 }
 
 /// Flutter API for `PackageManager`.
@@ -467,4 +528,171 @@ abstract class EnvironmentHostApi {
   ///
   /// See https://developer.android.com/reference/android/os/Environment#isExternalStorageManager().
   bool isExternalStorageManager();
+}
+
+/// Host API for `PackageInfo`.
+///
+/// This class may handle instantiating and adding native object instances that
+/// are attached to a Dart instance or handle method calls on the associated
+/// native class or an instance of the class.
+///
+/// See https://developer.android.com/reference/android/content/pm/PackageInfo.
+@HostApi(dartHostTestHandler: 'PackageInfoTestHostApi')
+abstract class PackageInfoHostApi {
+  /// Array of all <uses-permission> tags included under <manifest>, or null if there were none.
+  ///
+  /// This is only filled in if the flag PackageManager#GET_PERMISSIONS was set.
+  /// This list includes all permissions requested, even those that were not
+  /// granted or known by the system at install time.
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageInfo#requestedPermissions.
+  List<String> getRequestedPermissions(String instanceId);
+}
+
+/// Flutter API for `PackageInfo`.
+///
+/// This class may handle instantiating and adding Dart instances that are
+/// attached to a native instance or receiving callback methods from an
+/// overridden native class.
+///
+/// See https://developer.android.com/reference/android/content/pm/PackageInfo.
+@FlutterApi()
+abstract class PackageInfoFlutterApi {
+  /// Create a new Dart instance and add it to the `InstanceManager`.
+  void create(String instanceId);
+
+  /// Dispose of the Dart instance and remove it from the `InstanceManager`.
+  void dispose(String instanceId);
+}
+
+/// Host API for `PackageInfoFlags`.
+///
+/// This class may handle instantiating and adding native object instances that
+/// are attached to a Dart instance or handle method calls on the associated
+/// native class or an instance of the class.
+///
+/// See https://developer.android.com/reference/android/content/pm/PackageManager#PackageInfoFlags.
+@HostApi(dartHostTestHandler: 'PackageInfoFlagsTestHostApi')
+abstract class PackageInfoFlagsHostApi {
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager.PackageInfoFlags#of(long).
+  String of(int value);
+}
+
+/// Flutter API for `PackageInfoFlags`.
+///
+/// This class may handle instantiating and adding Dart instances that are
+/// attached to a native instance or receiving callback methods from an
+/// overridden native class.
+///
+/// See https://developer.android.com/reference/android/content/pm/PackageManager#PackageInfoFlags.
+@FlutterApi()
+abstract class PackageInfoFlagsFlutterApi {
+  /// Create a new Dart instance and add it to the `InstanceManager`.
+  void create(String instanceId);
+
+  /// Dispose of the Dart instance and remove it from the `InstanceManager`.
+  void dispose(String instanceId);
+}
+
+/// Host API for `ResolveInfoFlags`.
+///
+/// This class may handle instantiating and adding native object instances that
+/// are attached to a Dart instance or handle method calls on the associated
+/// native class or an instance of the class.
+///
+/// See https://developer.android.com/reference/android/content/pm/PackageManager#ResolveInfoFlags.
+@HostApi(dartHostTestHandler: 'ResolveInfoFlagsTestHostApi')
+abstract class ResolveInfoFlagsHostApi {
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager.ResolveInfoFlags#of(long).
+  String of(int value);
+}
+
+/// Flutter API for `ResolveInfoFlags`.
+///
+/// This class may handle instantiating and adding Dart instances that are
+/// attached to a native instance or receiving callback methods from an
+/// overridden native class.
+///
+/// See https://developer.android.com/reference/android/content/pm/PackageManager#ResolveInfoFlags.
+@FlutterApi()
+abstract class ResolveInfoFlagsFlutterApi {
+  /// Create a new Dart instance and add it to the `InstanceManager`.
+  void create(String instanceId);
+
+  /// Dispose of the Dart instance and remove it from the `InstanceManager`.
+  void dispose(String instanceId);
+}
+
+/// Host API for `ApplicationInfoFlags`.
+///
+/// This class may handle instantiating and adding native object instances that
+/// are attached to a Dart instance or handle method calls on the associated
+/// native class or an instance of the class.
+///
+/// See https://developer.android.com/reference/android/content/pm/PackageManager#ApplicationInfoFlags.
+@HostApi(dartHostTestHandler: 'ApplicationInfoFlagsTestHostApi')
+abstract class ApplicationInfoFlagsHostApi {
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager.ApplicationInfoFlags#of(long).
+  String of(int value);
+}
+
+/// Flutter API for `ApplicationInfoFlags`.
+///
+/// This class may handle instantiating and adding Dart instances that are
+/// attached to a native instance or receiving callback methods from an
+/// overridden native class.
+///
+/// See https://developer.android.com/reference/android/content/pm/PackageManager#ApplicationInfoFlags.
+@FlutterApi()
+abstract class ApplicationInfoFlagsFlutterApi {
+  /// Create a new Dart instance and add it to the `InstanceManager`.
+  void create(String instanceId);
+
+  /// Dispose of the Dart instance and remove it from the `InstanceManager`.
+  void dispose(String instanceId);
+}
+
+/// Host API for `ComponentInfoFlags`.
+///
+/// This class may handle instantiating and adding native object instances that
+/// are attached to a Dart instance or handle method calls on the associated
+/// native class or an instance of the class.
+///
+/// See https://developer.android.com/reference/android/content/pm/PackageManager#ComponentInfoFlags.
+@HostApi(dartHostTestHandler: 'ComponentInfoFlagsTestHostApi')
+abstract class ComponentInfoFlagsHostApi {
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager.ComponentInfoFlags#of(long).
+  String of(int value);
+}
+
+/// Flutter API for `ComponentInfoFlags`.
+///
+/// This class may handle instantiating and adding Dart instances that are
+/// attached to a native instance or receiving callback methods from an
+/// overridden native class.
+///
+/// See https://developer.android.com/reference/android/content/pm/PackageManager#ComponentInfoFlags.
+@FlutterApi()
+abstract class ComponentInfoFlagsFlutterApi {
+  /// Create a new Dart instance and add it to the `InstanceManager`.
+  void create(String instanceId);
+
+  /// Dispose of the Dart instance and remove it from the `InstanceManager`.
+  void dispose(String instanceId);
+}
+
+/// Flutter API for `ResolveInfo`.
+///
+/// This class may handle instantiating and adding Dart instances that are
+/// attached to a native instance or receiving callback methods from an
+/// overridden native class.
+///
+/// See https://developer.android.com/reference/android/content/pm/ResolveInfo.
+@FlutterApi()
+abstract class ResolveInfoFlutterApi {
+  /// Create a new Dart instance and add it to the `InstanceManager`.
+  void create(String instanceId);
+
+  /// Dispose of the Dart instance and remove it from the `InstanceManager`.
+  void dispose(String instanceId);
 }

--- a/permission_handler_android/pigeons/android_permission_handler.dart
+++ b/permission_handler_android/pigeons/android_permission_handler.dart
@@ -449,3 +449,22 @@ abstract class NotificationManagerFlutterApi {
   /// Dispose of the Dart instance and remove it from the `InstanceManager`.
   void dispose(String instanceId);
 }
+
+/// Host API for `Environment`.
+///
+/// This class may handle instantiating and adding native object instances that
+/// are attached to a Dart instance or handle method calls on the associated
+/// native class or an instance of the class.
+///
+/// See https://developer.android.com/reference/android/os/Environment.
+@HostApi(dartHostTestHandler: 'EnvironmentTestHostApi')
+abstract class EnvironmentHostApi {
+  /// Returns whether the calling app has All Files Access on the primary shared/external storage media.
+  ///
+  /// Declaring the permission [Manifest.permission.manageExternalStorage] is
+  /// not enough to gain the access. To request access, use
+  /// [Settings.actionManageAppAllFilesAccessPermission].
+  ///
+  /// See https://developer.android.com/reference/android/os/Environment#isExternalStorageManager().
+  bool isExternalStorageManager();
+}

--- a/permission_handler_android/test/test_permission_handler.pigeon.dart
+++ b/permission_handler_android/test/test_permission_handler.pigeon.dart
@@ -909,3 +909,47 @@ abstract class NotificationManagerTestHostApi {
     }
   }
 }
+
+/// Host API for `Environment`.
+///
+/// This class may handle instantiating and adding native object instances that
+/// are attached to a Dart instance or handle method calls on the associated
+/// native class or an instance of the class.
+///
+/// See https://developer.android.com/reference/android/os/Environment.
+abstract class EnvironmentTestHostApi {
+  static TestDefaultBinaryMessengerBinding? get _testBinaryMessengerBinding =>
+      TestDefaultBinaryMessengerBinding.instance;
+  static const MessageCodec<Object?> codec = StandardMessageCodec();
+
+  /// Returns whether the calling app has All Files Access on the primary shared/external storage media.
+  ///
+  /// Declaring the permission [Manifest.permission.manageExternalStorage] is
+  /// not enough to gain the access. To request access, use
+  /// [Settings.actionManageAppAllFilesAccessPermission].
+  ///
+  /// See https://developer.android.com/reference/android/os/Environment#isExternalStorageManager().
+  bool isExternalStorageManager();
+
+  static void setup(EnvironmentTestHostApi? api,
+      {BinaryMessenger? binaryMessenger}) {
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.EnvironmentHostApi.isExternalStorageManager',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel,
+                (Object? message) async {
+          // ignore message
+          final bool output = api.isExternalStorageManager();
+          return <Object?>[output];
+        });
+      }
+    }
+  }
+}

--- a/permission_handler_android/test/test_permission_handler.pigeon.dart
+++ b/permission_handler_android/test/test_permission_handler.pigeon.dart
@@ -349,7 +349,7 @@ abstract class UriTestHostApi {
   /// Returns the instance ID of the created Uri.
   ///
   /// See https://developer.android.com/reference/android/net/Uri#parse(java.lang.String).
-  void parse(String instanceId, String uriString);
+  String parse(String uriString);
 
   /// Returns the encoded string representation of this URI.
   ///
@@ -377,14 +377,11 @@ abstract class UriTestHostApi {
           assert(message != null,
               'Argument for dev.flutter.pigeon.permission_handler_android.UriHostApi.parse was null.');
           final List<Object?> args = (message as List<Object?>?)!;
-          final String? arg_instanceId = (args[0] as String?);
-          assert(arg_instanceId != null,
-              'Argument for dev.flutter.pigeon.permission_handler_android.UriHostApi.parse was null, expected non-null String.');
-          final String? arg_uriString = (args[1] as String?);
+          final String? arg_uriString = (args[0] as String?);
           assert(arg_uriString != null,
               'Argument for dev.flutter.pigeon.permission_handler_android.UriHostApi.parse was null, expected non-null String.');
-          api.parse(arg_instanceId!, arg_uriString!);
-          return <Object?>[];
+          final String output = api.parse(arg_uriString!);
+          return <Object?>[output];
         });
       }
     }
@@ -750,6 +747,37 @@ abstract class PackageManagerTestHostApi {
   /// See https://developer.android.com/reference/android/content/pm/PackageManager#canRequestPackageInstalls().
   bool canRequestPackageInstalls(String instanceId);
 
+  /// Retrieve overall information about an application package that is installed on the system.
+  ///
+  /// Use [getPackageInfoWithInfoFlags] when long flags are needed.
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager#getPackageInfo(java.lang.String,%20int).
+  String? getPackageInfoWithFlags(
+      String instanceId, String packageName, int flags);
+
+  /// Retrieve overall information about an application package that is installed on the system.
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager#getPackageInfo(java.lang.String,%20android.content.pm.PackageManager.PackageInfoFlags).
+  String? getPackageInfoWithInfoFlags(
+      String instanceId, String packageName, String flagsInstanceId);
+
+  /// Check whether the given feature name is one of the available features as returned by getSystemAvailableFeatures().
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager#hasSystemFeature(java.lang.String).
+  bool hasSystemFeature(String instanceId, String featureName);
+
+  /// Retrieve all activities that can be performed for the given intent.
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager#queryIntentActivities(android.content.Intent,%20int).
+  List<String?> queryIntentActivitiesWithFlags(
+      String instanceId, String intentInstanceId, int flags);
+
+  /// Retrieve all activities that can be performed for the given intent.
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager#queryIntentActivities(android.content.Intent,%20android.content.pm.ResolveInfoFlags).
+  List<String?> queryIntentActivitiesWithInfoFlags(
+      String instanceId, String intentInstanceId, String flagsInstanceId);
+
   static void setup(PackageManagerTestHostApi? api,
       {BinaryMessenger? binaryMessenger}) {
     {
@@ -771,6 +799,153 @@ abstract class PackageManagerTestHostApi {
           assert(arg_instanceId != null,
               'Argument for dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.canRequestPackageInstalls was null, expected non-null String.');
           final bool output = api.canRequestPackageInstalls(arg_instanceId!);
+          return <Object?>[output];
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.getPackageInfoWithFlags',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel,
+                (Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.getPackageInfoWithFlags was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_instanceId = (args[0] as String?);
+          assert(arg_instanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.getPackageInfoWithFlags was null, expected non-null String.');
+          final String? arg_packageName = (args[1] as String?);
+          assert(arg_packageName != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.getPackageInfoWithFlags was null, expected non-null String.');
+          final int? arg_flags = (args[2] as int?);
+          assert(arg_flags != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.getPackageInfoWithFlags was null, expected non-null int.');
+          final String? output = api.getPackageInfoWithFlags(
+              arg_instanceId!, arg_packageName!, arg_flags!);
+          return <Object?>[output];
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.getPackageInfoWithInfoFlags',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel,
+                (Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.getPackageInfoWithInfoFlags was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_instanceId = (args[0] as String?);
+          assert(arg_instanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.getPackageInfoWithInfoFlags was null, expected non-null String.');
+          final String? arg_packageName = (args[1] as String?);
+          assert(arg_packageName != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.getPackageInfoWithInfoFlags was null, expected non-null String.');
+          final String? arg_flagsInstanceId = (args[2] as String?);
+          assert(arg_flagsInstanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.getPackageInfoWithInfoFlags was null, expected non-null String.');
+          final String? output = api.getPackageInfoWithInfoFlags(
+              arg_instanceId!, arg_packageName!, arg_flagsInstanceId!);
+          return <Object?>[output];
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.hasSystemFeature',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel,
+                (Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.hasSystemFeature was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_instanceId = (args[0] as String?);
+          assert(arg_instanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.hasSystemFeature was null, expected non-null String.');
+          final String? arg_featureName = (args[1] as String?);
+          assert(arg_featureName != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.hasSystemFeature was null, expected non-null String.');
+          final bool output =
+              api.hasSystemFeature(arg_instanceId!, arg_featureName!);
+          return <Object?>[output];
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.queryIntentActivitiesWithFlags',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel,
+                (Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.queryIntentActivitiesWithFlags was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_instanceId = (args[0] as String?);
+          assert(arg_instanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.queryIntentActivitiesWithFlags was null, expected non-null String.');
+          final String? arg_intentInstanceId = (args[1] as String?);
+          assert(arg_intentInstanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.queryIntentActivitiesWithFlags was null, expected non-null String.');
+          final int? arg_flags = (args[2] as int?);
+          assert(arg_flags != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.queryIntentActivitiesWithFlags was null, expected non-null int.');
+          final List<String?> output = api.queryIntentActivitiesWithFlags(
+              arg_instanceId!, arg_intentInstanceId!, arg_flags!);
+          return <Object?>[output];
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.queryIntentActivitiesWithInfoFlags',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel,
+                (Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.queryIntentActivitiesWithInfoFlags was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_instanceId = (args[0] as String?);
+          assert(arg_instanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.queryIntentActivitiesWithInfoFlags was null, expected non-null String.');
+          final String? arg_intentInstanceId = (args[1] as String?);
+          assert(arg_intentInstanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.queryIntentActivitiesWithInfoFlags was null, expected non-null String.');
+          final String? arg_flagsInstanceId = (args[2] as String?);
+          assert(arg_flagsInstanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageManagerHostApi.queryIntentActivitiesWithInfoFlags was null, expected non-null String.');
+          final List<String?> output = api.queryIntentActivitiesWithInfoFlags(
+              arg_instanceId!, arg_intentInstanceId!, arg_flagsInstanceId!);
           return <Object?>[output];
         });
       }
@@ -947,6 +1122,228 @@ abstract class EnvironmentTestHostApi {
                 (Object? message) async {
           // ignore message
           final bool output = api.isExternalStorageManager();
+          return <Object?>[output];
+        });
+      }
+    }
+  }
+}
+
+/// Host API for `PackageInfo`.
+///
+/// This class may handle instantiating and adding native object instances that
+/// are attached to a Dart instance or handle method calls on the associated
+/// native class or an instance of the class.
+///
+/// See https://developer.android.com/reference/android/content/pm/PackageInfo.
+abstract class PackageInfoTestHostApi {
+  static TestDefaultBinaryMessengerBinding? get _testBinaryMessengerBinding =>
+      TestDefaultBinaryMessengerBinding.instance;
+  static const MessageCodec<Object?> codec = StandardMessageCodec();
+
+  /// Array of all <uses-permission> tags included under <manifest>, or null if there were none.
+  ///
+  /// This is only filled in if the flag PackageManager#GET_PERMISSIONS was set.
+  /// This list includes all permissions requested, even those that were not
+  /// granted or known by the system at install time.
+  ///
+  /// See https://developer.android.com/reference/android/content/pm/PackageInfo#requestedPermissions.
+  List<String?> getRequestedPermissions(String instanceId);
+
+  static void setup(PackageInfoTestHostApi? api,
+      {BinaryMessenger? binaryMessenger}) {
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.PackageInfoHostApi.getRequestedPermissions',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel,
+                (Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageInfoHostApi.getRequestedPermissions was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final String? arg_instanceId = (args[0] as String?);
+          assert(arg_instanceId != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageInfoHostApi.getRequestedPermissions was null, expected non-null String.');
+          final List<String?> output =
+              api.getRequestedPermissions(arg_instanceId!);
+          return <Object?>[output];
+        });
+      }
+    }
+  }
+}
+
+/// Host API for `PackageInfoFlags`.
+///
+/// This class may handle instantiating and adding native object instances that
+/// are attached to a Dart instance or handle method calls on the associated
+/// native class or an instance of the class.
+///
+/// See https://developer.android.com/reference/android/content/pm/PackageManager#PackageInfoFlags.
+abstract class PackageInfoFlagsTestHostApi {
+  static TestDefaultBinaryMessengerBinding? get _testBinaryMessengerBinding =>
+      TestDefaultBinaryMessengerBinding.instance;
+  static const MessageCodec<Object?> codec = StandardMessageCodec();
+
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager.PackageInfoFlags#of(long).
+  String of(int value);
+
+  static void setup(PackageInfoFlagsTestHostApi? api,
+      {BinaryMessenger? binaryMessenger}) {
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.PackageInfoFlagsHostApi.of',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel,
+                (Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageInfoFlagsHostApi.of was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final int? arg_value = (args[0] as int?);
+          assert(arg_value != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.PackageInfoFlagsHostApi.of was null, expected non-null int.');
+          final String output = api.of(arg_value!);
+          return <Object?>[output];
+        });
+      }
+    }
+  }
+}
+
+/// Host API for `ResolveInfoFlags`.
+///
+/// This class may handle instantiating and adding native object instances that
+/// are attached to a Dart instance or handle method calls on the associated
+/// native class or an instance of the class.
+///
+/// See https://developer.android.com/reference/android/content/pm/PackageManager#ResolveInfoFlags.
+abstract class ResolveInfoFlagsTestHostApi {
+  static TestDefaultBinaryMessengerBinding? get _testBinaryMessengerBinding =>
+      TestDefaultBinaryMessengerBinding.instance;
+  static const MessageCodec<Object?> codec = StandardMessageCodec();
+
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager.ResolveInfoFlags#of(long).
+  String of(int value);
+
+  static void setup(ResolveInfoFlagsTestHostApi? api,
+      {BinaryMessenger? binaryMessenger}) {
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.ResolveInfoFlagsHostApi.of',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel,
+                (Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.ResolveInfoFlagsHostApi.of was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final int? arg_value = (args[0] as int?);
+          assert(arg_value != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.ResolveInfoFlagsHostApi.of was null, expected non-null int.');
+          final String output = api.of(arg_value!);
+          return <Object?>[output];
+        });
+      }
+    }
+  }
+}
+
+/// Host API for `ApplicationInfoFlags`.
+///
+/// This class may handle instantiating and adding native object instances that
+/// are attached to a Dart instance or handle method calls on the associated
+/// native class or an instance of the class.
+///
+/// See https://developer.android.com/reference/android/content/pm/PackageManager#ApplicationInfoFlags.
+abstract class ApplicationInfoFlagsTestHostApi {
+  static TestDefaultBinaryMessengerBinding? get _testBinaryMessengerBinding =>
+      TestDefaultBinaryMessengerBinding.instance;
+  static const MessageCodec<Object?> codec = StandardMessageCodec();
+
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager.ApplicationInfoFlags#of(long).
+  String of(int value);
+
+  static void setup(ApplicationInfoFlagsTestHostApi? api,
+      {BinaryMessenger? binaryMessenger}) {
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.ApplicationInfoFlagsHostApi.of',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel,
+                (Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.ApplicationInfoFlagsHostApi.of was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final int? arg_value = (args[0] as int?);
+          assert(arg_value != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.ApplicationInfoFlagsHostApi.of was null, expected non-null int.');
+          final String output = api.of(arg_value!);
+          return <Object?>[output];
+        });
+      }
+    }
+  }
+}
+
+/// Host API for `ComponentInfoFlags`.
+///
+/// This class may handle instantiating and adding native object instances that
+/// are attached to a Dart instance or handle method calls on the associated
+/// native class or an instance of the class.
+///
+/// See https://developer.android.com/reference/android/content/pm/PackageManager#ComponentInfoFlags.
+abstract class ComponentInfoFlagsTestHostApi {
+  static TestDefaultBinaryMessengerBinding? get _testBinaryMessengerBinding =>
+      TestDefaultBinaryMessengerBinding.instance;
+  static const MessageCodec<Object?> codec = StandardMessageCodec();
+
+  /// See https://developer.android.com/reference/android/content/pm/PackageManager.ComponentInfoFlags#of(long).
+  String of(int value);
+
+  static void setup(ComponentInfoFlagsTestHostApi? api,
+      {BinaryMessenger? binaryMessenger}) {
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.permission_handler_android.ComponentInfoFlagsHostApi.of',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel,
+                (Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.ComponentInfoFlagsHostApi.of was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final int? arg_value = (args[0] as int?);
+          assert(arg_value != null,
+              'Argument for dev.flutter.pigeon.permission_handler_android.ComponentInfoFlagsHostApi.of was null, expected non-null int.');
+          final String output = api.of(arg_value!);
           return <Object?>[output];
         });
       }


### PR DESCRIPTION
**Requires merge of #1218**.

Ports the necessary Android SDK bits for checking which permissions have been requested.

There is no specific ticket for this issue, but it will be necessary for implementing an Android implementation of the platform interface using the ported Android SDK (which is tracked in https://github.com/orgs/Baseflow/projects/9/views/1?pane=issue&itemId=40148957).

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `next`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
