### PR TITLE
Rename build step to reflect correct platform

### DIFF
--- a/.github/workflows/permission_handler_apple.yaml
+++ b/.github/workflows/permission_handler_apple.yaml
@@ -54,7 +54,7 @@ jobs:
         working-directory: ${{env.source-directory}}
 
       # Build iOS version of the example App
-      - name: Run Android build
+      - name: Run iOS build
         run: flutter build ios --no-codesign --release
         working-directory: ${{env.example-directory}}
         


### PR DESCRIPTION
The current build step for iOS is named "Run Android build". This PR renames the step to reflect the correct platform and avoid confusion.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
