### PR TITLE
Support iOS 17 calendar permissions (Windows)

### DIFF
--- a/permission_handler_windows/CHANGELOG.md
+++ b/permission_handler_windows/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.0
+
+* Implements the `Permission.calendarWriteOnly` and `Permission.calendarFullAccess` permissions.
+* Bumps `permission_handler_platform_interface` to version `4.0.0`.
+
 ## 0.1.3
 
 * Adds the new Android 13 permission "BODY_SENSORS_BACKGROUND" to PermissionHandlerEnums.h.

--- a/permission_handler_windows/pubspec.yaml
+++ b/permission_handler_windows/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler_windows
 description: Permission plugin for Flutter. This plugin provides the Windows API to request and check permissions.
-version: 0.1.3
+version: 0.2.0
 homepage: https://github.com/baseflow/flutter-permission-handler
 
 flutter:
@@ -13,7 +13,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  permission_handler_platform_interface: ^3.11.0
+  permission_handler_platform_interface: ^4.0.0
 
 dev_dependencies:
   flutter_test:

--- a/permission_handler_windows/windows/permission_constants.h
+++ b/permission_handler_windows/windows/permission_constants.h
@@ -46,7 +46,9 @@ public:
         VIDEOS = 32,
         AUDIO = 33,
         SCHEDULE_EXACT_ALARM = 34,
-        SENSORS_ALWAYS = 35
+        SENSORS_ALWAYS = 35,
+        CALENDAR_WRITE_ONLY = 36,
+        CALENDAR_FULL_ACCESS = 37
     };
 
     //PERMISSION_STATUS


### PR DESCRIPTION
This is the PR for updating the Windows package. It is part of @MilosKarakas's PR #1151.

iOS 17.0 introduces the notion of write-only and full-access calendar permissions. This PR builds on an earlier PR to the platform interface that makes this distinction (#1183, #1193), implementing the new permissions on Windows. Note that on Windows permissions are always given.

Fixes #1108.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
