### PR TITLE
Add `photosAddOnly` setup for iOS to Podfile in README

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Adds `PermissionGroup.photosAddOnly` to the README.
 
 ## 11.1.0
+
 * Adds support for iOS 17+ [Calendar access levels](https://developer.apple.com/documentation/technotes/tn3152-migrating-to-the-latest-calendar-access-levels).
 * Deprecates `Permission.calendar`. Use `Permission.calendarWriteOnly` to request a write-only access to the calendar. For full access to calendar use `Permission.calendarFullAccess`.
 * For `Permission.calendarFullAccess` on iOS 17+ use `PERMISSION_EVENTS_FULL_ACCESS` in Podfile instead of  `PERMISSION_EVENTS`.

--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 11.1.1
+
 * Adds `PermissionGroup.photosAddOnly` to the README.
 
 ## 11.1.0

--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.1.1
+* Adds `PermissionGroup.photosAddOnly` to the README.
+
 ## 11.1.0
 * Adds support for iOS 17+ [Calendar access levels](https://developer.apple.com/documentation/technotes/tn3152-migrating-to-the-latest-calendar-access-levels).
 * Deprecates `Permission.calendar`. Use `Permission.calendarWriteOnly` to request a write-only access to the calendar. For full access to calendar use `Permission.calendarFullAccess`.

--- a/permission_handler/README.md
+++ b/permission_handler/README.md
@@ -107,6 +107,9 @@ You must list the permission you want to use in your application:
            ## dart: PermissionGroup.photos
            # 'PERMISSION_PHOTOS=1',
 
+           ## dart: PermissionGroup.photosAddOnly
+           # 'PERMISSION_PHOTOS_ADD_ONLY=1',
+
            ## dart: [PermissionGroup.location, PermissionGroup.locationAlways, PermissionGroup.locationWhenInUse]
            # 'PERMISSION_LOCATION=1',
 
@@ -157,6 +160,7 @@ You must list the permission you want to use in your application:
 | PermissionGroup.microphone                                                                | NSMicrophoneUsageDescription                                                                                  | PERMISSION_MICROPHONE                |
 | PermissionGroup.speech                                                                    | NSSpeechRecognitionUsageDescription                                                                           | PERMISSION_SPEECH_RECOGNIZER         |
 | PermissionGroup.photos                                                                    | NSPhotoLibraryUsageDescription                                                                                | PERMISSION_PHOTOS                    |
+| PermissionGroup.photosAddOnly                                                             | NSPhotoLibraryAddUsageDescription                                                                             | PERMISSION_PHOTOS_ADD_ONLY           |
 | PermissionGroup.location, PermissionGroup.locationAlways, PermissionGroup.locationWhenInUse | NSLocationUsageDescription, NSLocationAlwaysAndWhenInUseUsageDescription, NSLocationWhenInUseUsageDescription | PERMISSION_LOCATION                  |
 | PermissionGroup.notification                                                              | PermissionGroupNotification                                                                                   | PERMISSION_NOTIFICATIONS             |
 | PermissionGroup.mediaLibrary                                                              | NSAppleMusicUsageDescription, kTCCServiceMedia

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -2,7 +2,7 @@ name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
 repository: https://github.com/baseflow/flutter-permission-handler
 issue_tracker: https://github.com/Baseflow/flutter-permission-handler/issues
-version: 11.1.0
+version: 11.1.1
 
 environment:
   sdk: ">=2.15.0 <4.0.0"

--- a/permission_handler_apple/CHANGELOG.md
+++ b/permission_handler_apple/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 9.2.1
+* Updates plist key from `NSPhotoLibraryUsageDescription` to `NSPhotoLibraryAddUsageDescription`.
+
 ## 9.2.0
 * Adds the support for `Permission.calendarWriteOnly` and `Permission.calendarFullAccess` permissions which are introduced in iOS 17+.
 

--- a/permission_handler_apple/CHANGELOG.md
+++ b/permission_handler_apple/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 9.2.1
+
 * Updates plist key from `NSPhotoLibraryUsageDescription` to `NSPhotoLibraryAddUsageDescription`.
 
 ## 9.2.0

--- a/permission_handler_apple/CHANGELOG.md
+++ b/permission_handler_apple/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Updates plist key from `NSPhotoLibraryUsageDescription` to `NSPhotoLibraryAddUsageDescription`.
 
 ## 9.2.0
+
 * Adds the support for `Permission.calendarWriteOnly` and `Permission.calendarFullAccess` permissions which are introduced in iOS 17+.
 
 ## 9.1.4

--- a/permission_handler_apple/ios/Classes/PermissionHandlerEnums.h
+++ b/permission_handler_apple/ios/Classes/PermissionHandlerEnums.h
@@ -55,7 +55,7 @@
 #endif
 
 // ios: PermissionGroupPhotosAddOnly
-// Info.plist: NSPhotoLibraryUsageDescription
+// Info.plist: NSPhotoLibraryAddUsageDescription
 // dart: PermissionGroup.photosAddOnly
 #ifndef PERMISSION_PHOTOS_ADD_ONLY
     #define PERMISSION_PHOTOS_ADD_ONLY 0

--- a/permission_handler_apple/pubspec.yaml
+++ b/permission_handler_apple/pubspec.yaml
@@ -2,7 +2,7 @@ name: permission_handler_apple
 description: Permission plugin for Flutter. This plugin provides the iOS API to request and check permissions.
 repository: https://github.com/baseflow/flutter-permission-handler
 issue_tracker: https://github.com/Baseflow/flutter-permission-handler/issues
-version: 9.2.0
+version: 9.2.1
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
*Replace this paragraph with a short description of what issue this pull request (PR) solves and provide a description of the change.  Consider including before/after screenshots.*

The to be commented out comment for only adding photos to the library under iOS (NSPhotoLibraryAddUsageDescription) was missing in the README.

*List at least one fixed issue.*
#980

## Pre-launch Checklist

- [ ] I made sure the project builds.
- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I rebased onto `main`.
- [ ] I added new tests to check the change I am making, or this PR does not need tests.
- [ ] I made sure all existing and new tests are passing.
- [ ] I ran `dart format .` and committed any changes.
- [ ] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
