### PR TITLE
Release PluginBinding instance when activity is detached.

### DIFF
--- a/permission_handler_android/CHANGELOG.md
+++ b/permission_handler_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 12.0.2
+
+* Fixes bug where Android activity is leaked when embedded in native Android application.
+
 ## 12.0.1
 
 * Fixes a bug where the `ignoreBatteryOptimizations` permission didn't report the correct status when the permission is requested and granted.

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
@@ -75,7 +75,7 @@ public final class PermissionHandlerPlugin implements FlutterPlugin, ActivityAwa
             binding.getActivity()
         );
 
-        this.pluginBinding = binding;
+        pluginBinding = binding;
         registerListeners();
     }
 
@@ -87,8 +87,8 @@ public final class PermissionHandlerPlugin implements FlutterPlugin, ActivityAwa
     @Override
     public void onDetachedFromActivity() {
         stopListeningToActivity();
-
         deregisterListeners();
+        pluginBinding = null;
     }
 
     @Override

--- a/permission_handler_android/pubspec.yaml
+++ b/permission_handler_android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: permission_handler_android
 description: Permission plugin for Flutter. This plugin provides the Android API to request and check permissions.
 homepage: https://github.com/baseflow/flutter-permission-handler
-version: 12.0.1
+version: 12.0.2
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
The plugin keeps hold of the `PluginBinding` instance once an `Activity` is attached, but never releases the instance when the `Activity` is detached from the plugin. This will cause the `Activity` to be leaked (as described in issue #1256). This PR will release the `PluginBinding` instance when the `onDetachedFromActivity` method is called, making sure the handle to the `Activity` is released, which prevents leaking the `Activity`.

Fixes #1259 

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
