### PR TITLE
Update version permission_handler_apple.podspec to avoid confusion

### DIFF
--- a/permission_handler_apple/ios/permission_handler_apple.podspec
+++ b/permission_handler_apple/ios/permission_handler_apple.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'permission_handler_apple'
-  s.version          = '9.1.1'
+  s.version          = '9.3.0'
   s.summary          = 'Permission plugin for Flutter.'
   s.description      = <<-DESC
 Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.


### PR DESCRIPTION
Updated version in the podspec file as it seems like this bump was overlooked after 9.1.1 release. Bumping as it was confusing for me use the latest version of the plugin and still seeing `9.1.1` in the podfile.lock of iOS part of the project I am working on.

Probably, this would need a bump to `9.3.1` for the next release, but as I don't know about plans on which version goes next bumping only to the latest at the moment.

Note, I didn't check most of points in the provided checklist as this change doesn't really affects anything from functionality point.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I rebased onto `main`.
- [ ] I added new tests to check the change I am making, or this PR does not need tests.
- [ ] I made sure all existing and new tests are passing.
- [ ] I ran `dart format .` and committed any changes.
- [ ] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
