### PR TITLE
Fix possible-nil return type of EventPermissionStrategy#getEntityType

### DIFF
--- a/permission_handler_apple/CHANGELOG.md
+++ b/permission_handler_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 9.3.1
+
+* Fix potentially-nil return type of EventPermissionStrategy#getEntityType.
+
 ## 9.3.0
 
 * Adds support to request authorization to access SiriKit via the `Permission.assistant` permission.

--- a/permission_handler_apple/ios/Classes/strategies/EventPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/EventPermissionStrategy.m
@@ -133,13 +133,11 @@
 }
 
 + (EKEntityType)getEntityType:(PermissionGroup)permission {
-    if (permission == PermissionGroupCalendar || permission == PermissionGroupCalendarFullAccess || permission == PermissionGroupCalendarWriteOnly) {
-        return EKEntityTypeEvent;
-    } else if (permission == PermissionGroupReminders) {
+    if (permission == PermissionGroupReminders) {
         return EKEntityTypeReminder;
     }
 
-    return nil;
+    return EKEntityTypeEvent;
 }
 
 @end

--- a/permission_handler_apple/pubspec.yaml
+++ b/permission_handler_apple/pubspec.yaml
@@ -2,7 +2,7 @@ name: permission_handler_apple
 description: Permission plugin for Flutter. This plugin provides the iOS API to request and check permissions.
 repository: https://github.com/baseflow/flutter-permission-handler
 issue_tracker: https://github.com/Baseflow/flutter-permission-handler/issues
-version: 9.3.0
+version: 9.3.1
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
This method is causing a compilation warning: -Wint-conversion.

Even ignoring the warning, the nil value would not be tolerated and is never actually returned.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.
