### PR TITLE
Fix typo in comment for full calendar access

### DIFF
--- a/permission_handler_apple/CHANGELOG.md
+++ b/permission_handler_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 9.4.1
+
+* Fix typo in comment for full calendar access.
+
 ## 9.4.0
 
 * Adds a new permission `Permission.backgroundRefresh` to check the background refresh permission status.

--- a/permission_handler_apple/ios/Classes/PermissionHandlerEnums.h
+++ b/permission_handler_apple/ios/Classes/PermissionHandlerEnums.h
@@ -117,7 +117,7 @@
 #endif
 
 // ios: PermissionGroupCalendarFullAccess
-// Info.plist: [NSCalendarFullAccessUsageDescription]
+// Info.plist: [NSCalendarsFullAccessUsageDescription]
 // dart: PermissionGroup.calendarFullAccess
 #ifndef PERMISSION_EVENTS_FULL_ACCESS
     #define PERMISSION_EVENTS_FULL_ACCESS 0

--- a/permission_handler_apple/pubspec.yaml
+++ b/permission_handler_apple/pubspec.yaml
@@ -2,7 +2,7 @@ name: permission_handler_apple
 description: Permission plugin for Flutter. This plugin provides the iOS API to request and check permissions.
 repository: https://github.com/baseflow/flutter-permission-handler
 issue_tracker: https://github.com/Baseflow/flutter-permission-handler/issues
-version: 9.4.0
+version: 9.4.1
 
 
 environment:


### PR DESCRIPTION
A typo in the enum file can lead to confusing bugs if plugin users paste that into their plist. This PR fixes that typo.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
