### PR TITLE
Adds iOS privacy manifest.

### DIFF
--- a/permission_handler_apple/CHANGELOG.md
+++ b/permission_handler_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 9.4.1
+
+* Adds privacy manifest.
+
 ## 9.4.0
 
 * Adds a new permission `Permission.backgroundRefresh` to check the background refresh permission status.

--- a/permission_handler_apple/ios/Resources/PrivacyInfo.xcprivacy
+++ b/permission_handler_apple/ios/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
+    <key>NSPrivacyTracking</key>
+    <false/>
+</dict>
+</plist>

--- a/permission_handler_apple/ios/permission_handler_apple.podspec
+++ b/permission_handler_apple/ios/permission_handler_apple.podspec
@@ -18,5 +18,6 @@ Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Andro
 
   s.ios.deployment_target = '8.0'
   s.static_framework = true
+  s.resource_bundles = {'permission_handler_apple_privacy' => ['Resources/PrivacyInfo.xcprivacy']}
 end
 

--- a/permission_handler_apple/pubspec.yaml
+++ b/permission_handler_apple/pubspec.yaml
@@ -2,7 +2,7 @@ name: permission_handler_apple
 description: Permission plugin for Flutter. This plugin provides the iOS API to request and check permissions.
 repository: https://github.com/baseflow/flutter-permission-handler
 issue_tracker: https://github.com/Baseflow/flutter-permission-handler/issues
-version: 9.4.0
+version: 9.4.1
 
 
 environment:


### PR DESCRIPTION
Adds the required privacy manifest to the iOS implementation.

Because the permission_handler_apple package doesn't collect any privacy data, the privacy manifest can be empty. 

Note that we are following the standard Flutter / Cocoapods implementation which has the following caveat:

> The large caveat is that we do not currently know if this actually works. This is the method of inclusion that seems to be [the consensus among people using Cocoapods](https://github.com/CocoaPods/CocoaPods/issues/10325), as bundling it directly as a `resource` causes problems for clients who do not use `use_frameworks`. (In theory it seems like a manifest would not actually be *required* in that case since there is no framework, but it has the potential to actually stomp top-level resources.) Hopefully the automated analysis that Apple will eventually roll out will tolerate the file being bundled in a resource bundle in the framework rather than a top-level manifest file. If not, however, it's not clear how Cocoapods can be supported, so we can adopt this common approach for now under the assumption that eventually tooling will adapt to the reality of the ecosystem, and revisit the exact bundling later if necessary. 

Source: https://github.com/flutter/packages/commit/c5349bc9a5be1cbef9c13571d9d6d2b506240b20

Solves #1280 

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
