### PR TITLE
Add the use of NSUserDefaults to privacy manifest.

### DIFF
--- a/permission_handler_apple/CHANGELOG.md
+++ b/permission_handler_apple/CHANGELOG.md
@@ -1,6 +1,12 @@
+## 9.4.2
+
+* Updates the privacy manifest to include the use of the `NSUserDefaults` API. 
+The permission_handler stores a boolean value to track if permission to always 
+access the device location has been requested.
+
 ## 9.4.1
 
-* Adds privacy manifest.
+* Adds empty privacy manifest.
 
 ## 9.4.0
 

--- a/permission_handler_apple/ios/Resources/PrivacyInfo.xcprivacy
+++ b/permission_handler_apple/ios/Resources/PrivacyInfo.xcprivacy
@@ -5,7 +5,16 @@
     <key>NSPrivacyTrackingDomains</key>
     <array/>
     <key>NSPrivacyAccessedAPITypes</key>
-    <array/>
+    <array>
+    <dict>
+        <key>NSPrivacyAccessedAPIType</key>
+        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+        <key>NSPrivacyAccessedAPITypeReasons</key>
+        <array>
+            <string>1C8F.1</string>
+        </array>
+    </dict>
+	</array>
     <key>NSPrivacyCollectedDataTypes</key>
     <array/>
     <key>NSPrivacyTracking</key>

--- a/permission_handler_apple/pubspec.yaml
+++ b/permission_handler_apple/pubspec.yaml
@@ -2,7 +2,7 @@ name: permission_handler_apple
 description: Permission plugin for Flutter. This plugin provides the iOS API to request and check permissions.
 repository: https://github.com/baseflow/flutter-permission-handler
 issue_tracker: https://github.com/Baseflow/flutter-permission-handler/issues
-version: 9.4.1
+version: 9.4.2
 
 
 environment:


### PR DESCRIPTION
Updates the privacy manifest to include the use of the `NSUserDefaults` API. 
The permission_handler stores a boolean value to track if permission to always 
access the device location has been requested.

Resolves #1292

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
