### PR TITLE
Adds support for when in use only.

### DIFF
--- a/permission_handler_apple/CHANGELOG.md
+++ b/permission_handler_apple/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 9.4.3
+
+* Adds the `PERMISSION_LOCATION_WHENINUSE` marco, which can be used instead of
+the `PERMISSION_LOCATION` macro and only enable the `requestWhenInUseAuthorization`
+and remove the `requestAlwaysAuthorization` when requesting location permission.
+* Improves error handling when `Info.plist` doesn't contain the correct declarations.
+* Adds support for the `NSLocationAlwaysAndWhenInUseUsageDescription` property list
+key.
+
 ## 9.4.2
 
 * Updates the privacy manifest to include the use of the `NSUserDefaults` API. 

--- a/permission_handler_apple/example/ios/Podfile
+++ b/permission_handler_apple/example/ios/Podfile
@@ -69,8 +69,13 @@ post_install do |installer|
         ## dart: PermissionGroup.photos
         'PERMISSION_PHOTOS=1',
 
+        ## The 'PERMISSION_LOCATION' macro enables the `locationWhenInUse` and `locationAlways` permission. If
+        ## the application only requires `locationWhenInUse`, only specify the `PERMISSION_LOCATION_WHENINUSE`
+        ## macro.
+        ##
         ## dart: [PermissionGroup.location, PermissionGroup.locationAlways, PermissionGroup.locationWhenInUse]
         'PERMISSION_LOCATION=1',
+        'PERMISSION_LOCATION_WHENINUSE=0',
 
         ## dart: PermissionGroup.notification
         'PERMISSION_NOTIFICATIONS=1',

--- a/permission_handler_apple/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/permission_handler_apple/example/ios/Runner.xcodeproj/project.pbxproj
@@ -141,6 +141,7 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				D38B08CB85942E5D11545EE3 /* [CP] Embed Pods Frameworks */,
+				A7B07F67421488A414C73AAD /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -157,7 +158,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
@@ -251,6 +252,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		A7B07F67421488A414C73AAD /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 		D38B08CB85942E5D11545EE3 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/permission_handler_apple/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/permission_handler_apple/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/permission_handler_apple/ios/Classes/PermissionHandlerPlugin.m
+++ b/permission_handler_apple/ios/Classes/PermissionHandlerPlugin.m
@@ -47,7 +47,11 @@
              }
              
              self->_methodResult = nil;
-         }];
+        } errorHandler:^(NSString *errorCode, NSString *errorDescription) {
+            self->_methodResult([FlutterError errorWithCode:errorCode message:errorDescription details:nil]);
+            self->_methodResult = nil;
+        }
+];
         
     } else if ([@"shouldShowRequestPermissionRationale" isEqualToString:call.method]) {
         result(@false);

--- a/permission_handler_apple/ios/Classes/PermissionManager.h
+++ b/permission_handler_apple/ios/Classes/PermissionManager.h
@@ -35,7 +35,7 @@ typedef void (^PermissionRequestCompletion)(NSDictionary *permissionRequestResul
 @interface PermissionManager : NSObject
 
 - (instancetype)initWithStrategyInstances;
-- (void)requestPermissions:(NSArray *)permissions completion:(PermissionRequestCompletion)completion;
+- (void)requestPermissions:(NSArray *)permissions completion:(PermissionRequestCompletion)completion errorHandler:(PermissionErrorHandler)errorHandler;
 
 + (void)checkPermissionStatus:(enum PermissionGroup)permission result:(FlutterResult)result;
 + (void)checkServiceStatus:(enum PermissionGroup)permission result:(FlutterResult)result;

--- a/permission_handler_apple/ios/Classes/strategies/AppTrackingTransparencyPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/AppTrackingTransparencyPermissionStrategy.m
@@ -24,7 +24,7 @@
     completionHandler(ServiceStatusNotApplicable);
 }
 
-- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {
+- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler errorHandler:(PermissionErrorHandler)errorHandler{
     PermissionStatus status = [self checkPermissionStatus:permission];
     if (status != PermissionStatusDenied) {
         completionHandler(status);

--- a/permission_handler_apple/ios/Classes/strategies/AssistantPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/AssistantPermissionStrategy.m
@@ -24,7 +24,7 @@
     completionHandler(ServiceStatusNotApplicable);
 }
 
-- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {
+- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler errorHandler:(PermissionErrorHandler)errorHandler {
     PermissionStatus status = [self checkPermissionStatus:permission];
     if (status != PermissionStatusDenied) {
         completionHandler(status);

--- a/permission_handler_apple/ios/Classes/strategies/AudioVideoPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/AudioVideoPermissionStrategy.m
@@ -26,7 +26,7 @@
     completionHandler(ServiceStatusNotApplicable);
 }
 
-- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {
+- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler errorHandler:(PermissionErrorHandler)errorHandler {
     PermissionStatus status = [self checkPermissionStatus:permission];
 
     if (status != PermissionStatusDenied) {

--- a/permission_handler_apple/ios/Classes/strategies/BackgroundRefreshStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/BackgroundRefreshStrategy.m
@@ -17,7 +17,7 @@
     completionHandler(ServiceStatusNotApplicable);
 }
 
-- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler { 
+- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler errorHandler:(PermissionErrorHandler)errorHandler { 
     completionHandler([BackgroundRefreshStrategy permissionStatus]);
 }
 

--- a/permission_handler_apple/ios/Classes/strategies/BluetoothPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/BluetoothPermissionStrategy.m
@@ -70,7 +70,7 @@
     _serviceStatusHandler(serviceStatus);
 }
 
-- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {
+- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler errorHandler:(PermissionErrorHandler)errorHandler {
     [self initManagerIfNeeded];
     PermissionStatus status = [self checkPermissionStatus:permission];
     

--- a/permission_handler_apple/ios/Classes/strategies/ContactPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/ContactPermissionStrategy.m
@@ -17,7 +17,7 @@
     completionHandler(ServiceStatusNotApplicable);
 }
 
-- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {
+- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler errorHandler:(PermissionErrorHandler)errorHandler {
     PermissionStatus status = [self checkPermissionStatus:permission];
 
     if (status != PermissionStatusDenied) {

--- a/permission_handler_apple/ios/Classes/strategies/CriticalAlertsPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/CriticalAlertsPermissionStrategy.m
@@ -19,7 +19,7 @@
     completionHandler(ServiceStatusNotApplicable);
 }
 
-- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {
+- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler errorHandler:(PermissionErrorHandler)errorHandler {
   PermissionStatus status = [self checkPermissionStatus:permission];
   if (status != PermissionStatusDenied) {
     completionHandler(status);

--- a/permission_handler_apple/ios/Classes/strategies/EventPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/EventPermissionStrategy.m
@@ -17,7 +17,7 @@
     completionHandler(ServiceStatusNotApplicable);
 }
 
-- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {
+- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler errorHandler:(PermissionErrorHandler)errorHandler {
     PermissionStatus permissionStatus = [self checkPermissionStatus:permission];
     
     if (permissionStatus != PermissionStatusDenied) {

--- a/permission_handler_apple/ios/Classes/strategies/LocationPermissionStrategy.h
+++ b/permission_handler_apple/ios/Classes/strategies/LocationPermissionStrategy.h
@@ -6,7 +6,7 @@
 #import <Foundation/Foundation.h>
 #import "PermissionStrategy.h"
 
-#if PERMISSION_LOCATION
+#if PERMISSION_LOCATION || PERMISSION_LOCATION_WHENINUSE || PERMISSION_LOCATION_ALWAYS
 
 #import <CoreLocation/CoreLocation.h>
 

--- a/permission_handler_apple/ios/Classes/strategies/LocationPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/LocationPermissionStrategy.m
@@ -64,14 +64,14 @@ NSString *const UserDefaultPermissionRequestedKey = @"org.baseflow.permission_ha
         } else if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"] != nil) {
             [_locationManager requestWhenInUseAuthorization];
         } else {
-            errorHandler(@"MISSING_USAGE_DESCRIPTION", @"To use location in iOS8 you need to define at least NSLocationWhenInUseUsageDescription and optionally NSLocationAlwaysAndWhenInUseUsageDescription in the app bundle's Info.plist file");
+            errorHandler(@"MISSING_USAGE_DESCRIPTION", @"To use location from iOS8 you need to define at least NSLocationWhenInUseUsageDescription and optionally NSLocationAlwaysAndWhenInUseUsageDescription in the app bundle's Info.plist file");
             return;
         }
 #else
         if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"] != nil ) {
             [_locationManager requestWhenInUseAuthorization];
         } else {
-            errorHandler(@"MISSING_USAGE_DESCRIPTION", @"To use location in iOS8 you need to define at least NSLocationWhenInUseUsageDescription and optionally NSLocationAlwaysAndWhenInUseUsageDescription in the app bundle's Info.plist file");
+            errorHandler(@"MISSING_USAGE_DESCRIPTION", @"To use location from iOS8 you need to define at least NSLocationWhenInUseUsageDescription and optionally NSLocationAlwaysAndWhenInUseUsageDescription in the app bundle's Info.plist file");
             return;
         }
 #endif
@@ -87,7 +87,7 @@ NSString *const UserDefaultPermissionRequestedKey = @"org.baseflow.permission_ha
             [_locationManager requestAlwaysAuthorization];
             [[NSUserDefaults standardUserDefaults] setBool:TRUE forKey:UserDefaultPermissionRequestedKey];
         } else {
-            errorHandler(@"MISSING_USAGE_DESCRIPTION", @"To always use location in iOS8 you need to define at least NSLocationWhenInUseUsageDescription and optionally NSLocationAlwaysAndWhenInUseUsageDescription in the app bundle's Info.plist file");
+            errorHandler(@"MISSING_USAGE_DESCRIPTION", @"To always use location from iOS8 you need to define at least NSLocationWhenInUseUsageDescription and optionally NSLocationAlwaysAndWhenInUseUsageDescription in the app bundle's Info.plist file");
             return;
         }
 #endif
@@ -95,7 +95,7 @@ NSString *const UserDefaultPermissionRequestedKey = @"org.baseflow.permission_ha
         if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"] != nil ) {
             [_locationManager requestWhenInUseAuthorization];
         } else {
-            errorHandler(@"MISSING_USAGE_DESCRIPTION", @"To use location in iOS8 you need to define at least NSLocationWhenInUseUsageDescription and optionally NSLocationAlwaysAndWhenInUseUsageDescription in the app bundle's Info.plist file");
+            errorHandler(@"MISSING_USAGE_DESCRIPTION", @"To use location from iOS8 you need to define at least NSLocationWhenInUseUsageDescription and optionally NSLocationAlwaysAndWhenInUseUsageDescription in the app bundle's Info.plist file");
             return;
         }
     }

--- a/permission_handler_apple/ios/Classes/strategies/MediaLibraryPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/MediaLibraryPermissionStrategy.m
@@ -17,7 +17,7 @@
     completionHandler(ServiceStatusNotApplicable);
 }
 
-- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {
+- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler errorHandler:(PermissionErrorHandler)errorHandler {
     PermissionStatus status = [self checkPermissionStatus:permission];
     if (status != PermissionStatusDenied) {
         completionHandler(status);

--- a/permission_handler_apple/ios/Classes/strategies/NotificationPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/NotificationPermissionStrategy.m
@@ -19,7 +19,7 @@
     completionHandler(ServiceStatusNotApplicable);
 }
 
-- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {
+- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler  errorHandler:(PermissionErrorHandler)errorHandler {
   PermissionStatus status = [self checkPermissionStatus:permission];
   if (@available(iOS 12.0, *)) {
     if (status != PermissionStatusDenied && status != PermissionStatusProvisional) {

--- a/permission_handler_apple/ios/Classes/strategies/PermissionStrategy.h
+++ b/permission_handler_apple/ios/Classes/strategies/PermissionStrategy.h
@@ -8,11 +8,12 @@
 
 typedef void (^ServiceStatusHandler)(ServiceStatus serviceStatus);
 typedef void (^PermissionStatusHandler)(PermissionStatus permissionStatus);
+typedef void (^PermissionErrorHandler)(NSString* errorCode, NSString* errorDescription);
 
 @protocol PermissionStrategy <NSObject>
 - (PermissionStatus)checkPermissionStatus:(PermissionGroup)permission;
 
 - (void)checkServiceStatus:(PermissionGroup)permission completionHandler:(ServiceStatusHandler)completionHandler;
 
-- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler;
+- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler errorHandler:(PermissionErrorHandler)errorHandler;
 @end

--- a/permission_handler_apple/ios/Classes/strategies/PhonePermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/PhonePermissionStrategy.m
@@ -24,7 +24,7 @@
   completionHandler([self canDevicePlaceAPhoneCall] ? ServiceStatusEnabled : ServiceStatusDisabled);
 }
 
-- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {
+- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler errorHandler:(PermissionErrorHandler)errorHandler {
   completionHandler(PermissionStatusPermanentlyDenied);
 }
 

--- a/permission_handler_apple/ios/Classes/strategies/PhotoPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/PhotoPermissionStrategy.m
@@ -28,7 +28,7 @@
     completionHandler(ServiceStatusNotApplicable);
 }
 
-- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {
+- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler errorHandler:(PermissionErrorHandler)errorHandler {
     PermissionStatus status = [self checkPermissionStatus:permission];
 
     if (status != PermissionStatusDenied) {

--- a/permission_handler_apple/ios/Classes/strategies/SensorPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/SensorPermissionStrategy.m
@@ -23,7 +23,7 @@
     completionHandler(ServiceStatusDisabled);
 }
 
-- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {
+- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler errorHandler:(PermissionErrorHandler)errorHandler {
     PermissionStatus status = [self checkPermissionStatus:permission];
     
     if (status != PermissionStatusDenied) {

--- a/permission_handler_apple/ios/Classes/strategies/SpeechPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/SpeechPermissionStrategy.m
@@ -16,7 +16,7 @@
     completionHandler(ServiceStatusNotApplicable);
 }
 
-- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {
+- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler errorHandler:(PermissionErrorHandler)errorHandler {
     PermissionStatus status = [self checkPermissionStatus:permission];
     
     if (status != PermissionStatusDenied) {

--- a/permission_handler_apple/ios/Classes/strategies/StoragePermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/StoragePermissionStrategy.m
@@ -17,7 +17,7 @@
     completionHandler(ServiceStatusNotApplicable);
 }
 
-- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {
+- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler errorHandler:(PermissionErrorHandler)errorHandler {
     completionHandler([StoragePermissionStrategy permissionStatus]);
 }
 

--- a/permission_handler_apple/ios/Classes/strategies/UnknownPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/UnknownPermissionStrategy.m
@@ -16,7 +16,7 @@
     completionHandler(ServiceStatusDisabled);
 }
 
-- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler {
+- (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler errorHandler:(PermissionErrorHandler)errorHandler {
     completionHandler(PermissionStatusPermanentlyDenied);
 }
 @end

--- a/permission_handler_apple/pubspec.yaml
+++ b/permission_handler_apple/pubspec.yaml
@@ -2,7 +2,7 @@ name: permission_handler_apple
 description: Permission plugin for Flutter. This plugin provides the iOS API to request and check permissions.
 repository: https://github.com/baseflow/flutter-permission-handler
 issue_tracker: https://github.com/Baseflow/flutter-permission-handler/issues
-version: 9.4.2
+version: 9.4.3
 
 
 environment:


### PR DESCRIPTION
* Adds the `PERMISSION_LOCATION_WHENINUSE` marco, which can be used instead of
the `PERMISSION_LOCATION` macro and only enable the `requestWhenInUseAuthorization`
and remove the `requestAlwaysAuthorization` when requesting location permission.
* Improves error handling when `Info.plist` doesn't contain the correct declarations.
* Adds support for the `NSLocationAlwaysAndWhenInUseUsageDescription` property list
key.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
