### PR TITLE
Resolve unhandled exception on iOS

### DIFF
--- a/permission_handler_platform_interface/CHANGELOG.md
+++ b/permission_handler_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.2.1
+
+* Resolves an error that occurred when calling the `shouldShowRequestPermissionRationale` on iOS.
+
 ## 4.2.0
 
 * Adds a new permission `Permission.backgroundRefresh` to check the background refresh permission status on iOS & macOS platforms. This is a no-op on all other platforms.

--- a/permission_handler_platform_interface/lib/src/method_channel/method_channel_permission_handler.dart
+++ b/permission_handler_platform_interface/lib/src/method_channel/method_channel_permission_handler.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 import '../../permission_handler_platform_interface.dart';
@@ -88,6 +89,10 @@ class MethodChannelPermissionHandler extends PermissionHandlerPlatform {
   @override
   Future<bool> shouldShowRequestPermissionRationale(
       Permission permission) async {
+    if (defaultTargetPlatform != TargetPlatform.android) {
+      return false;
+    }
+
     final shouldShowRationale = await _methodChannel.invokeMethod(
         'shouldShowRequestPermissionRationale', permission.value);
 

--- a/permission_handler_platform_interface/pubspec.yaml
+++ b/permission_handler_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the permission_handler plugin.
 homepage: https://github.com/baseflow/flutter-permission-handler/tree/master/permission_handler_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 4.2.0
+version: 4.2.1
 
 dependencies:
   flutter:


### PR DESCRIPTION
Resolves the `Unhandled Exception: type 'int' is not a subtype of type 'FutureOr'` that occurred when calling the `shouldShowRequestPermissionRationale` on iOS.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
