### PR TITLE
Removes  references to Android v1 embedding.

### DIFF
--- a/permission_handler_android/CHANGELOG.md
+++ b/permission_handler_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 12.0.6
+
+* Removes deprecated support for Android V1 embedding as support will be removed from Flutter (see [flutter/flutter#144726](https://github.com/flutter/flutter/pull/144726)).
+
+
 ## 12.0.5
 
 * Upgrades Gradle and Android Gradle plugin.

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
@@ -30,30 +30,6 @@ public final class PermissionHandlerPlugin implements FlutterPlugin, ActivityAwa
     @Nullable
     private MethodCallHandlerImpl methodCallHandler;
 
-    /**
-     * Registers a plugin implementation that uses the stable {@code io.flutter.plugin.common}
-     * package.
-     *
-     * <p>Calling this automatically initializes the plugin. However plugins initialized this way
-     * won't react to changes in activity or context, unlike {@link PermissionHandlerPlugin}.
-     */
-    @SuppressWarnings("deprecation")
-    public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
-        final PermissionHandlerPlugin plugin = new PermissionHandlerPlugin();
-
-        plugin.pluginRegistrar = registrar;
-        plugin.permissionManager = new PermissionManager(registrar.context());
-        plugin.registerListeners();
-
-        plugin.startListening(registrar.context(), registrar.messenger());
-
-        if (registrar.activeContext() instanceof Activity) {
-            plugin.startListeningToActivity(
-                registrar.activity()
-            );
-        }
-    }
-
     @Override
     public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
         this.permissionManager = new PermissionManager(binding.getApplicationContext());

--- a/permission_handler_android/pubspec.yaml
+++ b/permission_handler_android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: permission_handler_android
 description: Permission plugin for Flutter. This plugin provides the Android API to request and check permissions.
 homepage: https://github.com/baseflow/flutter-permission-handler
-version: 12.0.5
+version: 12.0.6
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
The Flutter team is removing references to the Android V1 embedding from their code base (see flutter/flutter#144726). This would mean that code still containing references to the Android V1 embedding will no longer compile. 

This PR removes references to Android V1 embedding from the permission_handler_android plugin.

- flutter/flutter#144726

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
