### PR TITLE
[LocationPermission] Fix warning UI unresponsive in mainthread when c…

### DIFF
--- a/permission_handler_apple/ios/Classes/strategies/LocationPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/LocationPermissionStrategy.m
@@ -36,7 +36,13 @@ NSString *const UserDefaultPermissionRequestedKey = @"org.baseflow.permission_ha
 }
 
 - (void)checkServiceStatus:(PermissionGroup)permission completionHandler:(ServiceStatusHandler)completionHandler {
-    completionHandler([CLLocationManager locationServicesEnabled] ? ServiceStatusEnabled : ServiceStatusDisabled);
+    dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        BOOL isEnabled = [CLLocationManager locationServicesEnabled];
+
+        dispatch_async(dispatch_get_main_queue(), ^(void) {
+            completionHandler(isEnabled ? ServiceStatusEnabled : ServiceStatusDisabled);
+        });
+    });
 }
 
 - (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler errorHandler:(PermissionErrorHandler)errorHandler {


### PR DESCRIPTION
…alling locationServicesEnabled

Fix Xcode warning when checking Location Services Enabled/Disabled

This PR fix this issue: [1002](https://github.com/Baseflow/flutter-permission-handler/issues/1002)

## Pre-launch Checklist

- [ x] I made sure the project builds.
- [x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x ] I updated `CHANGELOG.md` to add a description of the change.
- [ x] I updated/added relevant documentation (doc comments with `///`).
- [ x] I rebased onto `main`.
- [ x] I added new tests to check the change I am making, or this PR does not need tests.
- [x ] I made sure all existing and new tests are passing.
- [ x] I ran `dart format .` and committed any changes.
- [x ] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
