### PR TITLE
Remove additional Android v1 embedding class reference.

### DIFF
--- a/permission_handler_android/CHANGELOG.md
+++ b/permission_handler_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 12.0.7
+
+* Removes additional Android v1 embedding class reference.
+
 ## 12.0.6
 
 * Removes deprecated support for Android V1 embedding as support will be removed from Flutter (see [flutter/flutter#144726](https://github.com/flutter/flutter/pull/144726)).

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionHandlerPlugin.java
@@ -22,9 +22,6 @@ public final class PermissionHandlerPlugin implements FlutterPlugin, ActivityAwa
 
     private MethodChannel methodChannel;
 
-    @SuppressWarnings("deprecation")
-    @Nullable private io.flutter.plugin.common.PluginRegistry.Registrar pluginRegistrar;
-
     @Nullable private ActivityPluginBinding pluginBinding;
 
     @Nullable
@@ -109,10 +106,7 @@ public final class PermissionHandlerPlugin implements FlutterPlugin, ActivityAwa
     }
 
     private void registerListeners() {
-        if (this.pluginRegistrar != null) {
-            this.pluginRegistrar.addActivityResultListener(this.permissionManager);
-            this.pluginRegistrar.addRequestPermissionsResultListener(this.permissionManager);
-        } else if (pluginBinding != null) {
+        if (pluginBinding != null) {
             this.pluginBinding.addActivityResultListener(this.permissionManager);
             this.pluginBinding.addRequestPermissionsResultListener(this.permissionManager);
         }

--- a/permission_handler_android/pubspec.yaml
+++ b/permission_handler_android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: permission_handler_android
 description: Permission plugin for Flutter. This plugin provides the Android API to request and check permissions.
 homepage: https://github.com/baseflow/flutter-permission-handler
-version: 12.0.6
+version: 12.0.7
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
Follow up to https://github.com/Baseflow/flutter-permission-handler/pull/1318.

Tested with `flutter run --debug` with the changes from https://github.com/flutter/engine/pull/52022 applied locally.

*List at least one fixed issue.*

https://github.com/Baseflow/flutter-permission-handler/issues/1335

## Pre-launch Checklist

- [x] I made sure the project builds.
- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [ ] I made sure all existing and new tests are passing.
- [ ] I ran `dart format .` and committed any changes.
- [ ] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
