### PR TITLE
Added limited access permission for android 14+

### DIFF
--- a/permission_handler_platform_interface/CHANGELOG.md
+++ b/permission_handler_platform_interface/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.2.2
+* Adds limited access permission for Android 14+.
+
 ## 4.2.1
 
 * Resolves an error that occurred when calling the `shouldShowRequestPermissionRationale` on iOS.

--- a/permission_handler_platform_interface/lib/src/permission_status.dart
+++ b/permission_handler_platform_interface/lib/src/permission_status.dart
@@ -19,7 +19,7 @@ enum PermissionStatus {
   /// The user has authorized this application for limited access. So far this
   /// is only relevant for the Photo Library picker.
   ///
-  /// *Only supported on iOS (iOS14+).*
+  /// *Only supported on iOS (iOS14+) and Android (Android 14+)*
   limited,
 
   /// Permission to the requested feature is permanently denied, the permission

--- a/permission_handler_platform_interface/lib/src/permissions.dart
+++ b/permission_handler_platform_interface/lib/src/permissions.dart
@@ -411,7 +411,7 @@ class Permission {
     'calendarWriteOnly',
     'calendarFullAccess',
     'assistant',
-    'backgroundRefresh'
+    'backgroundRefresh',
   ];
 
   @override

--- a/permission_handler_platform_interface/pubspec.yaml
+++ b/permission_handler_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the permission_handler plugin.
 homepage: https://github.com/baseflow/flutter-permission-handler/tree/master/permission_handler_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 4.2.1
+version: 4.2.2
 
 dependencies:
   flutter:


### PR DESCRIPTION
Patch update for the PR #1347, includes changes required in `permission_handler_platform_interface`.

*List at least one fixed issue.*

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
