### PR TITLE
Fix: PermissionDescriptor Error while checking the permission status on web

### DIFF
--- a/permission_handler_html/CHANGELOG.md
+++ b/permission_handler_html/CHANGELOG.md
@@ -1,21 +1,25 @@
+## 0.1.2+1
+
+- Fixed the PermissionDescriptor Error when getting the permission status
+
 ## 0.1.2
 
-* Migrate to package:web and adding wasm support.
+- Migrate to package:web and adding wasm support.
 
 ## 0.1.1
 
-* Updates the dependency on `permission_handler_platform_interface` to version 4.1.0 (SiriKit support is only available for iOS and macOS).
+- Updates the dependency on `permission_handler_platform_interface` to version 4.1.0 (SiriKit support is only available for iOS and macOS).
 
 ## 0.1.0+2
 
-* Fixes plugin initialization for non-https web app.
-* Fixes location permission name.
-* Improves error handling in the example app.
+- Fixes plugin initialization for non-https web app.
+- Fixes location permission name.
+- Improves error handling in the example app.
 
 ## 0.1.0+1
 
-* Updates `permission_handler_platform_interface` dependency to version `^4.0.2`.
+- Updates `permission_handler_platform_interface` dependency to version `^4.0.2`.
 
 ## 0.1.0
 
-* Adds an initial implementation of Web support for the permission_handler plugin with camera, notifications, and microphone permissions available.
+- Adds an initial implementation of Web support for the permission_handler plugin with camera, notifications, and microphone permissions available.

--- a/permission_handler_html/lib/web_delegate.dart
+++ b/permission_handler_html/lib/web_delegate.dart
@@ -62,8 +62,9 @@ class WebDelegate {
 
   Future<PermissionStatus> _permissionStatusState(
       String webPermissionName, web.Permissions? permissions) async {
-    final webPermissionStatus =
-        await permissions?.query({'name': webPermissionName}.toJSBox).toDart;
+    final webPermissionStatus = await permissions
+        ?.query(web.PermissionDescriptor(name: webPermissionName))
+        .toDart;
     return _toPermissionStatus(webPermissionStatus?.state);
   }
 

--- a/permission_handler_html/pubspec.yaml
+++ b/permission_handler_html/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler_html
 description: Permission plugin for Flutter. This plugin provides the web API to request and check permissions.
-version: 0.1.2
+version: 0.1.2+1
 homepage: https://github.com/baseflow/flutter-permission-handler
 
 environment:


### PR DESCRIPTION
While migrating to the `package:web`, `PermissionDescriptior` was not passed when checking the permission status causing it to throw an exception and not give the expected output i.e. the status of the requested permission.

Before this fix, following error was thrown when checking the permission status:
<img width="1203" alt="Screenshot 2024-08-07 at 6 08 25 PM" src="https://github.com/user-attachments/assets/33cc463a-b933-4037-b41e-fbdbab345a42">

After the fix, the permission status is shown accurately:
<img width="1191" alt="Screenshot 2024-08-07 at 6 09 21 PM" src="https://github.com/user-attachments/assets/d7ccf5e2-3407-472f-bbc4-9e92e3cee2b3">

This PR fixes issue #1353 .

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
