### PR TITLE
Fix issue 1360

### DIFF
--- a/permission_handler_android/CHANGELOG.md
+++ b/permission_handler_android/CHANGELOG.md
@@ -1,8 +1,14 @@
+## 12.0.10
+
+* Fixes a bug that causes a `NullPointerException` when the application is restarted after being killed by Android during the request of special permissions (like, `Permission.ignoreBatteryOptimizations`, `Permission.systemAlertWindow`, `Permission.accessNotificationPolicy`, `Permission.scheduleExactAlarm` and `Permission.manageExternalStorage`).
+
 ## 12.0.9
-* Added Make the status return of the READ_MEDIA_VISUAL_USER_SELECTED permission more accurate.
+
+* Makes the status returned when requesting the READ_MEDIA_VISUAL_USER_SELECTED permission more accurate.
+
 ## 12.0.8
 
-* Added support for limited photo and video permission on Android. 
+* Adds support for limited photo and video permission on Android. 
 
 ## 12.0.7
 

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
@@ -74,6 +74,15 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
             return false;
         }
 
+        // The [onActivityResult] with a [requestResult] that is `null` when the Application was
+        // terminated while not in the foreground with a permission request in progress (e.g. when
+        // Android decides to kill apps while requesting one of the special permissions). In these
+        // cases we should casually return and make sure the `pendingRequestCount` is set to `0`.
+        if (requestResults == null) {
+            pendingRequestCount = 0;
+            return false;
+        }
+
         int status, permission;
 
         if (requestCode == PermissionConstants.PERMISSION_CODE_IGNORE_BATTERY_OPTIMIZATIONS) {

--- a/permission_handler_android/pubspec.yaml
+++ b/permission_handler_android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: permission_handler_android
 description: Permission plugin for Flutter. This plugin provides the Android API to request and check permissions.
 homepage: https://github.com/baseflow/flutter-permission-handler
-version: 12.0.9
+version: 12.0.10
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
Fixes a bug that causes a `NullPointerException` when the application is restarted after being killed by Android during the request of special permissions (like, `Permission.ignoreBatteryOptimizations`, `Permission.systemAlertWindow`, `Permission.accessNotificationPolicy`, `Permission.scheduleExactAlarm` and `Permission.manageExternalStorage`).

- Fixes #1360 
- Fixes #968 
- Fixes #807
- Closes #1346 

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
