### PR TITLE
Fix: Return correct permission status for Android's limited media access

### DIFF
--- a/permission_handler_android/CHANGELOG.md
+++ b/permission_handler_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 12.0.12
+
+* Fixes permission status returned from `Permission.photos.request()` or `Permission.videos.request()` when limited access selected
+
 ## 12.0.11
 
 * Adds `TargetApi` annotation to `getManifestNames` method in `PermissionUtils.java`.

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
@@ -260,6 +260,12 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
                 }
 
                 requestResults.put(permission, permissionStatus);
+            // [grantResults] can only contain PermissionConstants.PERMISSION_STATUS_GRANTED or PermissionConstants.PERMISSION_STATUS_DENIED status.
+            // But these permissions can have status PermissionConstants.PERMISSION_STATUS_LIMITED, so we need to recheck status
+            } else if (permission == PermissionConstants.PERMISSION_GROUP_PHOTOS || permission == PermissionConstants.PERMISSION_GROUP_VIDEOS) {
+                requestResults.put(
+                    permission,
+                    determinePermissionStatus(permission));
             } else if (!requestResults.containsKey(permission)) {
                 requestResults.put(
                     permission,

--- a/permission_handler_android/pubspec.yaml
+++ b/permission_handler_android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: permission_handler_android
 description: Permission plugin for Flutter. This plugin provides the Android API to request and check permissions.
 homepage: https://github.com/baseflow/flutter-permission-handler
-version: 12.0.11
+version: 12.0.12
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
This PR fixes the issue https://github.com/Baseflow/flutter-permission-handler/issues/1243

Before fix when selecting 'Selected Photos Access enabled' on Android 14 the code
`await Permission.photos.request();`
returned `PermissionStatus.denied`. After fix it returns `PermissionStatus.limited`

## Pre-launch Checklist

- [X] I made sure the project builds.
- [X] I read the [Contributor Guide](https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [X] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning), or this PR is does not need version changes.
- [X] I updated `CHANGELOG.md` to add a description of the change.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I rebased onto `main`.
- [X] I added new tests to check the change I am making, or this PR does not need tests.
- [X] I made sure all existing and new tests are passing.
- [X] I ran `dart format .` and committed any changes.
- [X] I ran `flutter analyze` and fixed any errors.