### PR TITLE
fix compile error with web 1.0 #1363

### DIFF
--- a/permission_handler_html/CHANGELOG.md
+++ b/permission_handler_html/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3+2
+
+- `web: 1.0.0` compatibility: `PermissionDescriptor` was removed in web package.
+
 ## 0.1.3+1
 
 - Fixes the PermissionDescriptor Error when getting the permission status.

--- a/permission_handler_html/lib/web_delegate.dart
+++ b/permission_handler_html/lib/web_delegate.dart
@@ -63,7 +63,7 @@ class WebDelegate {
   Future<PermissionStatus> _permissionStatusState(
       String webPermissionName, web.Permissions? permissions) async {
     final webPermissionStatus = await permissions
-        ?.query(web.PermissionDescriptor(name: webPermissionName))
+        ?.query(_PermissionDescriptor(name: webPermissionName))
         .toDart;
     return _toPermissionStatus(webPermissionStatus?.state);
   }
@@ -227,4 +227,12 @@ class WebDelegate {
       rethrow;
     }
   }
+}
+
+// copied from https://github.com/dart-lang/web/commit/7604578eb538c471d438608673c037121d95dba5#diff-6f4c7956b6e25b547b16fc561e54d5e7d520d2c79a59ace4438c60913cc2b1a2L35-L40
+extension type _PermissionDescriptor._(JSObject _) implements JSObject {
+  external factory _PermissionDescriptor({required String name});
+
+  external set name(String value);
+  external String get name;
 }

--- a/permission_handler_html/pubspec.yaml
+++ b/permission_handler_html/pubspec.yaml
@@ -1,11 +1,11 @@
 name: permission_handler_html
 description: Permission plugin for Flutter. This plugin provides the web API to request and check permissions.
-version: 0.1.3+1
+version: 0.1.3+2
 
 homepage: https://github.com/baseflow/flutter-permission-handler
 
 environment:
-  sdk: ">=3.0.5 <4.0.0"
+  sdk: ">=3.3.0 <4.0.0"
   flutter: ">=3.16.0"
 
 dependencies:


### PR DESCRIPTION
web 1.0.0 removed `PermissionDescriptor`: https://github.com/dart-lang/web/commit/7604578eb538c471d438608673c037121d95dba5#diff-6f4c7956b6e25b547b16fc561e54d5e7d520d2c79a59ace4438c60913cc2b1a2L35-L40 - I have simply copied it over to this project.

* Fixes #1363
