### PR TITLE
Fix: Correct class name references

### DIFF
--- a/permission_handler_platform_interface/CHANGELOG.md
+++ b/permission_handler_platform_interface/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.2.3
+* Fixed class name references.
+
 ## 4.2.2
 
 * Adds limited access permission for Android 14+.

--- a/permission_handler_platform_interface/lib/src/permissions.dart
+++ b/permission_handler_platform_interface/lib/src/permissions.dart
@@ -98,8 +98,8 @@ class Permission {
   /// - When running Photos (iOS 14+ read & write access level)
   ///
   /// **Android:**
-  /// - Devices running Android 12 (API level 32) or lower: use [Permissions.storage].
-  /// - Devices running Android 13 (API level 33) and above: Should use [Permissions.photos].
+  /// - Devices running Android 12 (API level 32) or lower: use [Permission.storage].
+  /// - Devices running Android 13 (API level 33) and above: Should use [Permission.photos].
   ///
   /// EXAMPLE: in Manifest:
   /// <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32"/>
@@ -110,9 +110,9 @@ class Permission {
   /// if (Platform.isAndroid) {
   ///   final androidInfo = await DeviceInfoPlugin().androidInfo;
   ///   if (androidInfo.version.sdkInt <= 32) {
-  ///     use [Permissions.storage.status]
+  ///     use [Permission.storage.status]
   ///   }  else {
-  ///     use [Permissions.photos.status]
+  ///     use [Permission.photos.status]
   ///   }
   /// }
   static const photos = Permission._(9);


### PR DESCRIPTION
Removed the plural 's' of the class name references at the photos (9) permission description.

## Pre-launch Checklist

- [ ] I made sure the project builds.
- [x] I read the [Contributor Guide]
- [ ] I followed the process outlined there for submitting PRs.
- [x] This PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I rebased onto `main`.
- [x] This PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [ ] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning