### PR TITLE
Depend on the min SDK version of Flutter installation

### DIFF
--- a/.github/workflows/permission_handler_android.yaml
+++ b/.github/workflows/permission_handler_android.yaml
@@ -33,6 +33,12 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
 
+      # Make sure JAVA version 17 is installed on build agent.
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin' # See 'Supported distributions' for available options
+          java-version: '17'
+           
       # Make sure the stable version of Flutter is available
       - uses: subosito/flutter-action@v2
         with:

--- a/permission_handler_android/CHANGELOG.md
+++ b/permission_handler_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 12.0.13
+
+* Updates the Android min SDK to use `flutter.minSdkVersion` which is set to the minimum Android SDK supported by the installed Flutter version of the app developer.
+
 ## 12.0.12
 
 * Fixes permission status returned from `Permission.photos.request()` or `Permission.videos.request()` when limited access selected

--- a/permission_handler_android/CHANGELOG.md
+++ b/permission_handler_android/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 12.0.13
 
-* Updates the Android min SDK to use `flutter.minSdkVersion` which is set to the minimum Android SDK supported by the installed Flutter version of the app developer.
+* Updates the Android min SDK to 19 (from 16).
+* Migrates example app away from deprecated imperative apply in gradle (see: https://docs.flutter.dev/release/breaking-changes/flutter-gradle-plugin-apply)
 
 ## 12.0.12
 

--- a/permission_handler_android/CHANGELOG.md
+++ b/permission_handler_android/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 12.0.13
 
 * Updates the Android min SDK to 19 (from 16).
-* Migrates example app away from deprecated imperative apply in gradle (see: https://docs.flutter.dev/release/breaking-changes/flutter-gradle-plugin-apply)
+* Migrates example app away from deprecated imperative apply in gradle (see: https://docs.flutter.dev/release/breaking-changes/flutter-gradle-plugin-apply).
 
 ## 12.0.12
 

--- a/permission_handler_android/android/build.gradle
+++ b/permission_handler_android/android/build.gradle
@@ -34,6 +34,6 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion flutter.minSdkVersion
     }
 }

--- a/permission_handler_android/android/build.gradle
+++ b/permission_handler_android/android/build.gradle
@@ -34,6 +34,6 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion flutter.minSdkVersion
+        minSdkVersion 19
     }
 }

--- a/permission_handler_android/example/android/app/build.gradle
+++ b/permission_handler_android/example/android/app/build.gradle
@@ -1,3 +1,8 @@
+plugins {
+    id "com.android.application"
+    id "dev.flutter.flutter-gradle-plugin"
+}
+
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
@@ -20,9 +25,6 @@ def flutterVersionName = localProperties.getProperty('flutter.versionName')
 if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
-
-apply plugin: 'com.android.application'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     namespace 'com.baseflow.permissionhandler.example'

--- a/permission_handler_android/example/android/build.gradle
+++ b/permission_handler_android/example/android/build.gradle
@@ -1,14 +1,3 @@
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
-    }
-}
-
 allprojects {
     repositories {
         google()
@@ -19,6 +8,8 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
+}
+subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/permission_handler_android/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/permission_handler_android/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip

--- a/permission_handler_android/example/android/settings.gradle
+++ b/permission_handler_android/example/android/settings.gradle
@@ -1,15 +1,24 @@
-include ':app'
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }()
 
-def flutterProjectRoot = rootProject.projectDir.parentFile.toPath()
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
-def plugins = new Properties()
-def pluginsFile = new File(flutterProjectRoot.toFile(), '.flutter-plugins')
-if (pluginsFile.exists()) {
-    pluginsFile.withReader('UTF-8') { reader -> plugins.load(reader) }
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
 }
 
-plugins.each { name, path ->
-    def pluginDirectory = flutterProjectRoot.resolve(path).resolve('android').toFile()
-    include ":$name"
-    project(":$name").projectDir = pluginDirectory
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "8.1.0" apply false
 }
+
+include ":app"

--- a/permission_handler_android/pubspec.yaml
+++ b/permission_handler_android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: permission_handler_android
 description: Permission plugin for Flutter. This plugin provides the Android API to request and check permissions.
 homepage: https://github.com/baseflow/flutter-permission-handler
-version: 12.0.12
+version: 12.0.13
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
Updates the minimum supported Android SDK version to 19 (from 16). 

Also migrates the example app away from the use of imperative plugin apply in Gradle (see: https://docs.flutter.dev/release/breaking-changes/flutter-gradle-plugin-apply).

Solves #1396 

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
