### PR TITLE
Bug fix for the DartError: TypeError: null: type 'Null' is not a subtype of type 'JSObject'

### DIFF
--- a/permission_handler_html/CHANGELOG.md
+++ b/permission_handler_html/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3+4
+
+- http compatibility: Don't crash on missing `window.navigator.mediaDevices` property
+
 ## 0.1.3+3
 
 - Safari < 16 compatibility: Don't crash on missing `window.navigator.permissions` property

--- a/permission_handler_html/lib/permission_handler_html.dart
+++ b/permission_handler_html/lib/permission_handler_html.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:js_interop_unsafe';
+import 'dart:js_util' as js_util;
 
 import 'package:web/web.dart' as web;
 
@@ -11,7 +12,10 @@ import 'web_delegate.dart';
 
 /// Platform implementation of the permission_handler Flutter plugin.
 class WebPermissionHandler extends PermissionHandlerPlatform {
-  static final web.MediaDevices _devices = web.window.navigator.mediaDevices;
+  static final web.MediaDevices? _devices = 
+     js_util.hasProperty(web.window.navigator, 'mediaDevices') 
+          ? js_util.getProperty(web.window.navigator, 'mediaDevices') 
+          : null;
   static final web.Geolocation _geolocation = web.window.navigator.geolocation;
   static final web.Permissions? _htmlPermissions = (() {
     // Using unsafe interop to check availability of `permissions`.

--- a/permission_handler_html/pubspec.yaml
+++ b/permission_handler_html/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler_html
 description: Permission plugin for Flutter. This plugin provides the web API to request and check permissions.
-version: 0.1.3+3
+version: 0.1.3+4
 
 homepage: https://github.com/baseflow/flutter-permission-handler
 


### PR DESCRIPTION
This PR fixes the bug mentioned here:

https://github.com/Baseflow/flutter-permission-handler/issues/1386

It seems that "mediaDevices" is only available when using https or localhost, but not when using e.g. http://0.0.0.0. Thus it is necessary to check if "mediaDevices" exists before accessing it.