### PR TITLE
Bug fix for WASM compilation

### DIFF
--- a/permission_handler_html/CHANGELOG.md
+++ b/permission_handler_html/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3+5
+
+- wasm compatibility: Changed way how `window.navigator.mediaDevices` is accessed
+
 ## 0.1.3+4
 
 - Fixes a bug causing the application to crash when running on HTTP protocol (not HTTPS or localhost) and the `window.navigator.mediaDevices` property is `null`.

--- a/permission_handler_html/lib/permission_handler_html.dart
+++ b/permission_handler_html/lib/permission_handler_html.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:js_interop_unsafe';
-import 'dart:js_util' as js_util;
 
 import 'package:web/web.dart' as web;
 
@@ -12,10 +11,12 @@ import 'web_delegate.dart';
 
 /// Platform implementation of the permission_handler Flutter plugin.
 class WebPermissionHandler extends PermissionHandlerPlatform {
-  static final web.MediaDevices? _devices = 
-     js_util.hasProperty(web.window.navigator, 'mediaDevices') 
-          ? js_util.getProperty(web.window.navigator, 'mediaDevices') 
-          : null;
+  static final web.MediaDevices? _devices = (() {
+    if (!web.window.navigator.has('mediaDevices')) {
+      return null;
+    }
+    return web.window.navigator.mediaDevices;
+  })();
   static final web.Geolocation _geolocation = web.window.navigator.geolocation;
   static final web.Permissions? _htmlPermissions = (() {
     // Using unsafe interop to check availability of `permissions`.

--- a/permission_handler_html/pubspec.yaml
+++ b/permission_handler_html/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler_html
 description: Permission plugin for Flutter. This plugin provides the web API to request and check permissions.
-version: 0.1.3+4
+version: 0.1.3+5
 
 homepage: https://github.com/baseflow/flutter-permission-handler
 


### PR DESCRIPTION
To fix https://github.com/Baseflow/flutter-permission-handler/issues/1409 I have changed the way how "mediaDevices" is loaded to make it compatible with WASM. Basically I am just using the same method now that was used for "permissions" a few lines below. It still seems to work fine for me regarding the bug https://github.com/Baseflow/flutter-permission-handler/issues/1386 .
