### PR TITLE
refactor: Avoid creating a new EKEventStore every time that the permission is requested

### DIFF
--- a/permission_handler_apple/CHANGELOG.md
+++ b/permission_handler_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 9.4.6
+
+* refactor: Avoid creating a new EKEventStore every time that the permission is requested
+
 ## 9.4.5
 
 * Fixes issue #1002, Xcode warning of the unresponsive of main thread when checking isLocationEnabled.

--- a/permission_handler_apple/ios/Classes/strategies/EventPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/EventPermissionStrategy.m
@@ -9,6 +9,17 @@
 
 @implementation EventPermissionStrategy
 
++ (EKEventStore *)sharedEventStore {
+    static EKEventStore *sharedEventStore = nil;
+    static dispatch_once_t onceToken;
+    
+    dispatch_once(&onceToken, ^{
+        sharedEventStore = [[EKEventStore alloc] init];
+    });
+    
+    return sharedEventStore;
+}
+
 - (PermissionStatus)checkPermissionStatus:(PermissionGroup)permission {
     return [EventPermissionStrategy permissionStatus:permission];
 }
@@ -49,11 +60,9 @@
         #endif
     }
 
-    EKEventStore *eventStore = [[EKEventStore alloc] init];
-
     if (@available(iOS 17.0, *)) {
         if (permission == PermissionGroupCalendar || permission == PermissionGroupCalendarFullAccess) {
-            [eventStore requestFullAccessToEventsWithCompletion:^(BOOL granted, NSError *error) {
+            [[EventPermissionStrategy sharedEventStore] requestFullAccessToEventsWithCompletion:^(BOOL granted, NSError *error) {
                 if (granted) {
                     completionHandler(PermissionStatusGranted);
                 } else {
@@ -61,7 +70,7 @@
                 }
             }];
         } else if (permission == PermissionGroupCalendarWriteOnly) {
-            [eventStore requestWriteOnlyAccessToEventsWithCompletion:^(BOOL granted, NSError *error) {
+            [[EventPermissionStrategy sharedEventStore] requestWriteOnlyAccessToEventsWithCompletion:^(BOOL granted, NSError *error) {
                 if (granted) {
                     completionHandler(PermissionStatusGranted);
                 } else {
@@ -69,7 +78,7 @@
                 }
             }];
         } else if (permission == PermissionGroupReminders) {
-            [eventStore requestFullAccessToRemindersWithCompletion:^(BOOL granted, NSError *error) {
+            [[EventPermissionStrategy sharedEventStore] requestFullAccessToRemindersWithCompletion:^(BOOL granted, NSError *error) {
                 if (granted) {
                     completionHandler(PermissionStatusGranted);
                 } else {
@@ -80,7 +89,7 @@
     } else {
         EKEntityType entityType = [EventPermissionStrategy getEntityType:permission];
 
-        [eventStore requestAccessToEntityType:entityType completion:^(BOOL granted, NSError *error) {
+        [[EventPermissionStrategy sharedEventStore] requestAccessToEntityType:entityType completion:^(BOOL granted, NSError *error) {
             if (granted) {
                 completionHandler(PermissionStatusGranted);
             } else {

--- a/permission_handler_apple/pubspec.yaml
+++ b/permission_handler_apple/pubspec.yaml
@@ -2,7 +2,7 @@ name: permission_handler_apple
 description: Permission plugin for Flutter. This plugin provides the iOS API to request and check permissions.
 repository: https://github.com/baseflow/flutter-permission-handler
 issue_tracker: https://github.com/Baseflow/flutter-permission-handler/issues
-version: 9.4.5
+version: 9.4.6
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
*refactor: Avoid creating a new EKEventStore every time that the permission is requested*

- #1306 

## Pre-launch Checklist

- [X] I made sure the project builds.
- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [X] I updated `CHANGELOG.md` to add a description of the change.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I rebased onto `main`.
- [X] I added new tests to check the change I am making, or this PR does not need tests.
- [X] I made sure all existing and new tests are passing.
- [X] I ran `dart format .` and committed any changes.
- [X] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
