### PR TITLE
Updates android compileSDK and targetSDK to 35

### DIFF
--- a/permission_handler_android/CHANGELOG.md
+++ b/permission_handler_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 12.0.14
+
+* Updates the Android compileSDK and targetSDK from 34 to 35
+
 ## 12.0.13
 
 * Updates the Android min SDK to 19 (from 16).

--- a/permission_handler_android/android/build.gradle
+++ b/permission_handler_android/android/build.gradle
@@ -26,7 +26,7 @@ android {
     if (project.android.hasProperty("namespace")) {
       namespace 'com.baseflow.permissionhandler'
     }
-    compileSdk 34
+    compileSdk 35
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/permission_handler_android/example/android/app/build.gradle
+++ b/permission_handler_android/example/android/app/build.gradle
@@ -28,13 +28,13 @@ if (flutterVersionName == null) {
 
 android {
     namespace 'com.baseflow.permissionhandler.example'
-    compileSdk 34
+    compileSdk 35
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.baseflow.permissionhandler.example"
         minSdkVersion flutter.minSdkVersion
-        targetSdkVersion 34
+        targetSdkVersion 35
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }


### PR DESCRIPTION
Updates compileSDK and targetSDK from 34 to 35.

## Pre-launch Checklist

- [ ] I made sure the project builds.
- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I rebased onto `main`.
- [ ] I added new tests to check the change I am making, or this PR does not need tests.
- [ ] I made sure all existing and new tests are passing.
- [ ] I ran `dart format .` and committed any changes.
- [ ] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
