### PR TITLE
fix: add undetermined permission status to handle notification permission request when app is moved to background

### DIFF
--- a/permission_handler_apple/CHANGELOG.md
+++ b/permission_handler_apple/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 9.4.6
+* Adds `PermissionStatus.undetermined` to handle notification permission when the iOS app is moved to the background while the permission dialog is open, previously is returning `PermissionStatus.permanentlyDenied`.
+
 ## 9.4.5
 
 * Fixes issue #1002, Xcode warning of the unresponsive of main thread when checking isLocationEnabled.

--- a/permission_handler_apple/ios/Classes/PermissionHandlerEnums.h
+++ b/permission_handler_apple/ios/Classes/PermissionHandlerEnums.h
@@ -173,6 +173,7 @@ typedef NS_ENUM(int, PermissionStatus) {
     PermissionStatusLimited = 3,
     PermissionStatusPermanentlyDenied = 4,
     PermissionStatusProvisional = 5,
+    PermissionStatusUndetermined = 6
 };
 
 typedef NS_ENUM(int, ServiceStatus) {

--- a/permission_handler_apple/pubspec.yaml
+++ b/permission_handler_apple/pubspec.yaml
@@ -2,7 +2,7 @@ name: permission_handler_apple
 description: Permission plugin for Flutter. This plugin provides the iOS API to request and check permissions.
 repository: https://github.com/baseflow/flutter-permission-handler
 issue_tracker: https://github.com/Baseflow/flutter-permission-handler/issues
-version: 9.4.5
+version: 9.4.6
 
 environment:
   sdk: ">=2.15.0 <4.0.0"

--- a/permission_handler_platform_interface/CHANGELOG.md
+++ b/permission_handler_platform_interface/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.2.4
+* Fixes an issue where the request for notification permission returns `permanentlyDenied` when the iOS app is moved to the background while the permission dialog is open.
+
 ## 4.2.3
 
 * Fixes class name references in the API documentation.

--- a/permission_handler_platform_interface/lib/src/permission_status.dart
+++ b/permission_handler_platform_interface/lib/src/permission_status.dart
@@ -41,6 +41,9 @@ enum PermissionStatus {
   ///
   /// *Only supported on iOS (iOS12+).*
   provisional,
+
+  /// The user does not perform any actions to the requested feature.
+  undetermined,
 }
 
 /// Conversion extension methods for the [PermissionStatus] type.
@@ -60,6 +63,8 @@ extension PermissionStatusValue on PermissionStatus {
         return 4;
       case PermissionStatus.provisional:
         return 5;
+      case PermissionStatus.undetermined:
+        return 6;
       default:
         throw UnimplementedError();
     }
@@ -74,6 +79,7 @@ extension PermissionStatusValue on PermissionStatus {
       PermissionStatus.limited,
       PermissionStatus.permanentlyDenied,
       PermissionStatus.provisional,
+      PermissionStatus.undetermined,
     ][value];
   }
 }
@@ -119,6 +125,9 @@ extension PermissionStatusGetters on PermissionStatus {
   ///
   /// *Only supported on iOS (iOS12+).*
   bool get isProvisional => this == PermissionStatus.provisional;
+
+  /// If the user has not perform any action to the requested feature.
+  bool get isUndetermined => this == PermissionStatus.undetermined;
 }
 
 /// Utility getter extensions for the `Future<PermissionStatus>` type.
@@ -162,4 +171,7 @@ extension FuturePermissionStatusGetters on Future<PermissionStatus> {
   ///
   /// *Only supported on iOS (iOS12+).*
   Future<bool> get isProvisional async => (await this).isProvisional;
+
+  /// If the user has not perform any action to the requested feature.
+  Future<bool> get isUndetermined async => (await this).isUndetermined;
 }

--- a/permission_handler_platform_interface/pubspec.yaml
+++ b/permission_handler_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the permission_handler plugin.
 homepage: https://github.com/baseflow/flutter-permission-handler/tree/master/permission_handler_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 4.2.3
+version: 4.2.4
 
 dependencies:
   flutter:

--- a/permission_handler_platform_interface/test/src/permission_status_test.dart
+++ b/permission_handler_platform_interface/test/src/permission_status_test.dart
@@ -3,10 +3,10 @@ import 'package:permission_handler_platform_interface/permission_handler_platfor
 
 void main() {
   group('PermissionStatus', () {
-    test('PermissionStatus should contain 6 options', () {
+    test('PermissionStatus should contain 7 options', () {
       const values = PermissionStatus.values;
 
-      expect(values.length, 6);
+      expect(values.length, 7);
     });
 
     test('PermissionStatus enum should have items in correct index', () {
@@ -18,6 +18,7 @@ void main() {
       expect(values[3], PermissionStatus.limited);
       expect(values[4], PermissionStatus.permanentlyDenied);
       expect(values[5], PermissionStatus.provisional);
+      expect(values[6], PermissionStatus.undetermined);
     });
   });
 
@@ -29,6 +30,7 @@ void main() {
       expect(PermissionStatus.limited.value, 3);
       expect(PermissionStatus.permanentlyDenied.value, 4);
       expect(PermissionStatus.provisional.value, 5);
+      expect(PermissionStatus.undetermined.value, 6);
     });
 
     test(
@@ -44,6 +46,8 @@ void main() {
           PermissionStatus.permanentlyDenied);
       expect(
           PermissionStatusValue.statusByValue(5), PermissionStatus.provisional);
+      expect(PermissionStatusValue.statusByValue(6),
+          PermissionStatus.undetermined);
     });
   });
 
@@ -55,6 +59,7 @@ void main() {
       expect(PermissionStatus.limited.isLimited, true);
       expect(PermissionStatus.permanentlyDenied.isPermanentlyDenied, true);
       expect(PermissionStatus.provisional.isProvisional, true);
+      expect(PermissionStatus.undetermined.isUndetermined, true);
     });
 
     test('Getters should return false if statement is not met', () {
@@ -64,6 +69,7 @@ void main() {
       expect(PermissionStatus.limited.isDenied, false);
       expect(PermissionStatus.permanentlyDenied.isDenied, false);
       expect(PermissionStatus.provisional.isDenied, false);
+      expect(PermissionStatus.undetermined.isDenied, false);
     });
   });
 
@@ -81,6 +87,8 @@ void main() {
           true);
       expect(
           await mockFuture(PermissionStatus.provisional).isProvisional, true);
+      expect(
+          await mockFuture(PermissionStatus.undetermined).isUndetermined, true);
     });
 
     test('Getters should return false if statement is not met', () async {
@@ -91,6 +99,8 @@ void main() {
       expect(
           await mockFuture(PermissionStatus.permanentlyDenied).isDenied, false);
       expect(await mockFuture(PermissionStatus.provisional).isDenied, false);
+      expect(
+          await mockFuture(PermissionStatus.provisional).isUndetermined, false);
     });
   });
 


### PR DESCRIPTION
Replace this paragraph with a short description of what issue this pull request (PR) solves and provide a description of the change. Consider including before/after screenshots.

List at least one fixed issue.
- https://github.com/Baseflow/flutter-permission-handler/issues/1423

## Pre-launch Checklist

- [X] I made sure the project builds.
- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [X] I updated `CHANGELOG.md` to add a description of the change.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I rebased onto `main`.
- [X] I added new tests to check the change I am making, or this PR does not need tests.
- [X] I made sure all existing and new tests are passing.
- [X] I ran `dart format .` and committed any changes.
- [X] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
