### PR TITLE
Handle contacts limited permission

### DIFF
--- a/.github/workflows/permission_handler.yaml
+++ b/.github/workflows/permission_handler.yaml
@@ -6,15 +6,15 @@ name: permission_handler
 # events but only for the main branch
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
-    - 'permission_handler/**'
-    - '.github/workflows/permission_handler.yaml'
+      - "permission_handler/**"
+      - ".github/workflows/permission_handler.yaml"
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths:
-    - 'permission_handler/**'
-    - '.github/workflows/permission_handler.yaml'
+      - "permission_handler/**"
+      - ".github/workflows/permission_handler.yaml"
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -22,14 +22,10 @@ jobs:
     name: App facing package
 
     # The type of runner that the job will run on
-    #
-    # TODO(mvanbeusekom): Manually set to macOS 13 to support Xcode 15 and iOS 17 SDKs.
-    # Currently `macos-latest` is based on macOS 12 and doesn't support iOS 17 SDK. This
-    # should be moved back to `macos-latest` when GitHub Actions images are updated.
-    runs-on: macos-13
+    runs-on: macos-latest
 
     env:
-      source-directory: ./permission_handler 
+      source-directory: ./permission_handler
       example-directory: ./permission_handler/example
 
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -47,13 +43,13 @@ jobs:
       # Make sure JAVA version 17 is installed on build agent.
       - uses: actions/setup-java@v3
         with:
-          distribution: 'temurin' # See 'Supported distributions' for available options
-          java-version: '17'
+          distribution: "temurin" # See 'Supported distributions' for available options
+          java-version: "17"
 
       # Make sure the stable version of Flutter is available
       - uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
+          channel: "stable"
 
       # Download all Flutter packages
       - name: Download dependencies
@@ -64,7 +60,7 @@ jobs:
       - name: Run Dart Format
         run: dart format --set-exit-if-changed .
         working-directory: ${{env.source-directory}}
-     
+
       # Run Flutter Analyzer
       - name: Run Flutter Analyzer
         run: flutter analyze

--- a/.github/workflows/permission_handler.yaml
+++ b/.github/workflows/permission_handler.yaml
@@ -22,7 +22,11 @@ jobs:
     name: App facing package
 
     # The type of runner that the job will run on
-    runs-on: macos-latest
+    #
+    # TODO(mvanbeusekom): Manually set to macOS 15 to support Xcode 16 and iOS 18 SDKs.
+    # Currently `macos-latest` is based on macOS 14 and doesn't support iOS 18 SDK. This
+    # should be moved back to `macos-latest` when GitHub Actions images are updated.
+    runs-on: macos-15 
 
     env:
       source-directory: ./permission_handler
@@ -32,13 +36,6 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
-
-      # Override current Xcode version with version 15.0.1.
-      #
-      # TODO(mvanbeusekom): Remove when the macos-latest image supports version 15.0.1
-      # out of the box (see https://github.com/actions/runner-images/blob/main/README.md).
-      - name: Select Xcode version
-        run: sudo xcode-select -s '/Applications/Xcode_15.0.1.app/Contents/Developer'
 
       # Make sure JAVA version 17 is installed on build agent.
       - uses: actions/setup-java@v3

--- a/.github/workflows/permission_handler_apple.yaml
+++ b/.github/workflows/permission_handler_apple.yaml
@@ -22,11 +22,7 @@ jobs:
     name: Apple platform package
 
     # The type of runner that the job will run on
-    #
-    # TODO(mvanbeusekom): Manually set to macOS 13 to support Xcode 15 and iOS 17 SDKs.
-    # Currently `macos-latest` is based on macOS 12 and doesn't support iOS 17 SDK. This
-    # should be moved back to `macos-latest` when GitHub Actions images are updated.
-    runs-on: macos-13
+    runs-on: macos-latest
 
     env:
       source-directory: ./permission_handler_apple

--- a/.github/workflows/permission_handler_apple.yaml
+++ b/.github/workflows/permission_handler_apple.yaml
@@ -6,15 +6,15 @@ name: permission_handler_apple
 # events but only for the main branch
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
-    - 'permission_handler_apple/**'
-    - '.github/workflows/permission_handler_apple.yaml'
+      - "permission_handler_apple/**"
+      - ".github/workflows/permission_handler_apple.yaml"
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths:
-    - 'permission_handler_apple/**'
-    - '.github/workflows/permission_handler_apple.yaml'
+      - "permission_handler_apple/**"
+      - ".github/workflows/permission_handler_apple.yaml"
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -22,28 +22,25 @@ jobs:
     name: Apple platform package
 
     # The type of runner that the job will run on
-    runs-on: macos-latest
+    #
+    # TODO(mvanbeusekom): Manually set to macOS 15 to support Xcode 16 and iOS 18 SDKs.
+    # Currently `macos-latest` is based on macOS 14 and doesn't support iOS 18 SDK. This
+    # should be moved back to `macos-latest` when GitHub Actions images are updated.
+    runs-on: macos-15
 
     env:
       source-directory: ./permission_handler_apple
-      example-directory: ./permission_handler_apple/example 
+      example-directory: ./permission_handler_apple/example
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
 
-      # Override current Xcode version with version 15.0.1.
-      #
-      # TODO(mvanbeusekom): Remove when the macos-latest image supports version 15.0.1
-      # out of the box (see https://github.com/actions/runner-images/blob/main/README.md).
-      - name: Select Xcode version
-        run: sudo xcode-select -s '/Applications/Xcode_15.0.1.app/Contents/Developer'
-      
       # Make sure the stable version of Flutter is available
       - uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
+          channel: "stable"
 
       # Download all Flutter packages
       - name: Download dependencies
@@ -64,4 +61,3 @@ jobs:
       - name: Run iOS build
         run: flutter build ios --no-codesign --release
         working-directory: ${{env.example-directory}}
-        

--- a/permission_handler/example/lib/main.dart
+++ b/permission_handler/example/lib/main.dart
@@ -5,24 +5,32 @@ import 'package:flutter/material.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 void main() {
-  runApp(BaseflowPluginExample(
+  runApp(
+    BaseflowPluginExample(
       pluginName: 'Permission Handler',
       githubURL: 'https://github.com/Baseflow/flutter-permission-handler',
       pubDevURL: 'https://pub.dev/packages/permission_handler',
-      pages: [PermissionHandlerWidget.createPage()]));
+      pages: [PermissionHandlerWidget.createPage()],
+    ),
+  );
 }
 
 ///Defines the main theme color
 final MaterialColor themeMaterialColor =
     BaseflowPluginExample.createMaterialColor(
-        const Color.fromRGBO(48, 49, 60, 1));
+      const Color.fromRGBO(48, 49, 60, 1),
+    );
 
 /// A Flutter application demonstrating the functionality of this plugin
 class PermissionHandlerWidget extends StatefulWidget {
+  const PermissionHandlerWidget._();
+
   /// Create a page containing the functionality of this plugin
   static ExamplePage createPage() {
     return ExamplePage(
-        Icons.location_on, (context) => PermissionHandlerWidget());
+      Icons.location_on,
+      (context) => const PermissionHandlerWidget._(),
+    );
   }
 
   @override
@@ -35,40 +43,42 @@ class _PermissionHandlerWidgetState extends State<PermissionHandlerWidget> {
   Widget build(BuildContext context) {
     return Center(
       child: ListView(
-          children: Permission.values
-              .where((permission) {
-                if (Platform.isIOS) {
-                  return permission != Permission.unknown &&
-                      permission != Permission.phone &&
-                      permission != Permission.sms &&
-                      permission != Permission.ignoreBatteryOptimizations &&
-                      permission != Permission.accessMediaLocation &&
-                      permission != Permission.activityRecognition &&
-                      permission != Permission.manageExternalStorage &&
-                      permission != Permission.systemAlertWindow &&
-                      permission != Permission.requestInstallPackages &&
-                      permission != Permission.accessNotificationPolicy &&
-                      permission != Permission.bluetoothScan &&
-                      permission != Permission.bluetoothAdvertise &&
-                      permission != Permission.bluetoothConnect &&
-                      permission != Permission.nearbyWifiDevices &&
-                      permission != Permission.videos &&
-                      permission != Permission.audio &&
-                      permission != Permission.scheduleExactAlarm &&
-                      permission != Permission.sensorsAlways;
-                } else {
-                  return permission != Permission.unknown &&
-                      permission != Permission.mediaLibrary &&
-                      permission != Permission.photosAddOnly &&
-                      permission != Permission.reminders &&
-                      permission != Permission.bluetooth &&
-                      permission != Permission.appTrackingTransparency &&
-                      permission != Permission.criticalAlerts &&
-                      permission != Permission.assistant;
-                }
-              })
-              .map((permission) => PermissionWidget(permission))
-              .toList()),
+        children:
+            Permission.values
+                .where((permission) {
+                  if (Platform.isIOS) {
+                    return permission != Permission.unknown &&
+                        permission != Permission.phone &&
+                        permission != Permission.sms &&
+                        permission != Permission.ignoreBatteryOptimizations &&
+                        permission != Permission.accessMediaLocation &&
+                        permission != Permission.activityRecognition &&
+                        permission != Permission.manageExternalStorage &&
+                        permission != Permission.systemAlertWindow &&
+                        permission != Permission.requestInstallPackages &&
+                        permission != Permission.accessNotificationPolicy &&
+                        permission != Permission.bluetoothScan &&
+                        permission != Permission.bluetoothAdvertise &&
+                        permission != Permission.bluetoothConnect &&
+                        permission != Permission.nearbyWifiDevices &&
+                        permission != Permission.videos &&
+                        permission != Permission.audio &&
+                        permission != Permission.scheduleExactAlarm &&
+                        permission != Permission.sensorsAlways;
+                  } else {
+                    return permission != Permission.unknown &&
+                        permission != Permission.mediaLibrary &&
+                        permission != Permission.photosAddOnly &&
+                        permission != Permission.reminders &&
+                        permission != Permission.bluetooth &&
+                        permission != Permission.appTrackingTransparency &&
+                        permission != Permission.criticalAlerts &&
+                        permission != Permission.assistant;
+                  }
+                })
+                .map((permission) => PermissionWidget(permission))
+                .toList(),
+      ),
     );
   }
 }
@@ -76,18 +86,18 @@ class _PermissionHandlerWidgetState extends State<PermissionHandlerWidget> {
 /// Permission widget containing information about the passed [Permission]
 class PermissionWidget extends StatefulWidget {
   /// Constructs a [PermissionWidget] for the supplied [Permission]
-  const PermissionWidget(this._permission);
+  const PermissionWidget(this.permission, {super.key});
 
-  final Permission _permission;
+  /// The [Permission] for which this widget is rendered.
+  final Permission permission;
 
   @override
-  _PermissionState createState() => _PermissionState(_permission);
+  _PermissionState createState() => _PermissionState();
 }
 
 class _PermissionState extends State<PermissionWidget> {
-  _PermissionState(this._permission);
+  _PermissionState();
 
-  final Permission _permission;
   PermissionStatus _permissionStatus = PermissionStatus.denied;
 
   @override
@@ -98,7 +108,7 @@ class _PermissionState extends State<PermissionWidget> {
   }
 
   void _listenForPermissionStatus() async {
-    final status = await _permission.status;
+    final status = await widget.permission.status;
     setState(() => _permissionStatus = status);
   }
 
@@ -119,44 +129,45 @@ class _PermissionState extends State<PermissionWidget> {
   Widget build(BuildContext context) {
     return ListTile(
       title: Text(
-        _permission.toString(),
+        widget.permission.toString(),
         style: Theme.of(context).textTheme.bodyLarge,
       ),
       subtitle: Text(
         _permissionStatus.toString(),
         style: TextStyle(color: getPermissionColor()),
       ),
-      trailing: (_permission is PermissionWithService)
-          ? IconButton(
-              icon: const Icon(
-                Icons.info,
-                color: Colors.white,
-              ),
-              onPressed: () {
-                checkServiceStatus(
-                    context, _permission as PermissionWithService);
-              })
-          : null,
+      trailing:
+          (widget.permission is PermissionWithService)
+              ? IconButton(
+                icon: const Icon(Icons.info, color: Colors.white),
+                onPressed: () {
+                  checkServiceStatus(
+                    context,
+                    widget.permission as PermissionWithService,
+                  );
+                },
+              )
+              : null,
       onTap: () {
-        requestPermission(_permission);
+        requestPermission(widget.permission);
       },
     );
   }
 
   void checkServiceStatus(
-      BuildContext context, PermissionWithService permission) async {
-    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-      content: Text((await permission.serviceStatus).toString()),
-    ));
+    BuildContext context,
+    PermissionWithService permission,
+  ) async {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text((await permission.serviceStatus).toString())),
+    );
   }
 
   Future<void> requestPermission(Permission permission) async {
     final status = await permission.request();
 
     setState(() {
-      print(status);
       _permissionStatus = status;
-      print(_permissionStatus);
     });
   }
 }

--- a/permission_handler/example/pubspec.yaml
+++ b/permission_handler/example/pubspec.yaml
@@ -2,7 +2,7 @@ name: permission_handler_example
 description: Demonstrates how to use the permission_handler plugin.
 
 environment:
-  sdk: ">=2.15.0 <4.0.0"
+  sdk: ^3.7.0
 
 dependencies:
   baseflow_plugin_template: ^2.1.1

--- a/permission_handler/lib/permission_handler.dart
+++ b/permission_handler/lib/permission_handler.dart
@@ -140,8 +140,8 @@ extension PermissionCheckShortcuts on Permission {
   /// *Only supported on iOS.*
   Future<bool> get isRestricted => status.isRestricted;
 
-  /// User has authorized this application for limited photo library access.
-  /// *Only supported on iOS.(iOS14+)*
+  /// User has authorized this application for limited access.
+  /// *Only supported on iOS.(iOS14+ for photos, ios18+ for contacts)*
   Future<bool> get isLimited => status.isLimited;
 
   /// Returns `true` when permissions are denied permanently.

--- a/permission_handler_apple/CHANGELOG.md
+++ b/permission_handler_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 9.4.6
+
+* Adds the ability to handle `CNAuthorizationStatusLimited` introduced in ios18
+
 ## 9.4.5
 
 * Fixes issue #1002, Xcode warning of the unresponsive of main thread when checking isLocationEnabled.

--- a/permission_handler_apple/example/lib/main.dart
+++ b/permission_handler_apple/example/lib/main.dart
@@ -3,24 +3,32 @@ import 'package:flutter/material.dart';
 import 'package:permission_handler_platform_interface/permission_handler_platform_interface.dart';
 
 void main() {
-  runApp(BaseflowPluginExample(
+  runApp(
+    BaseflowPluginExample(
       pluginName: 'Permission Handler',
       githubURL: 'https://github.com/Baseflow/flutter-permission-handler',
       pubDevURL: 'https://pub.dev/packages/permission_handler',
-      pages: [PermissionHandlerWidget.createPage()]));
+      pages: [PermissionHandlerWidget.createPage()],
+    ),
+  );
 }
 
 ///Defines the main theme color
 final MaterialColor themeMaterialColor =
     BaseflowPluginExample.createMaterialColor(
-        const Color.fromRGBO(48, 49, 60, 1));
+      const Color.fromRGBO(48, 49, 60, 1),
+    );
 
 /// A Flutter application demonstrating the functionality of this plugin
 class PermissionHandlerWidget extends StatefulWidget {
+  const PermissionHandlerWidget._();
+
   /// Create a page containing the functionality of this plugin
   static ExamplePage createPage() {
     return ExamplePage(
-        Icons.location_on, (context) => PermissionHandlerWidget());
+      Icons.location_on,
+      (context) => const PermissionHandlerWidget._(),
+    );
   }
 
   @override
@@ -33,29 +41,31 @@ class _PermissionHandlerWidgetState extends State<PermissionHandlerWidget> {
   Widget build(BuildContext context) {
     return Center(
       child: ListView(
-          children: Permission.values
-              .where((permission) {
-                return permission != Permission.unknown &&
-                    permission != Permission.phone &&
-                    permission != Permission.sms &&
-                    permission != Permission.ignoreBatteryOptimizations &&
-                    permission != Permission.accessMediaLocation &&
-                    permission != Permission.activityRecognition &&
-                    permission != Permission.manageExternalStorage &&
-                    permission != Permission.systemAlertWindow &&
-                    permission != Permission.requestInstallPackages &&
-                    permission != Permission.accessNotificationPolicy &&
-                    permission != Permission.bluetoothScan &&
-                    permission != Permission.bluetoothAdvertise &&
-                    permission != Permission.bluetoothConnect &&
-                    permission != Permission.nearbyWifiDevices &&
-                    permission != Permission.videos &&
-                    permission != Permission.audio &&
-                    permission != Permission.scheduleExactAlarm &&
-                    permission != Permission.sensorsAlways;
-              })
-              .map((permission) => PermissionWidget(permission))
-              .toList()),
+        children:
+            Permission.values
+                .where((permission) {
+                  return permission != Permission.unknown &&
+                      permission != Permission.phone &&
+                      permission != Permission.sms &&
+                      permission != Permission.ignoreBatteryOptimizations &&
+                      permission != Permission.accessMediaLocation &&
+                      permission != Permission.activityRecognition &&
+                      permission != Permission.manageExternalStorage &&
+                      permission != Permission.systemAlertWindow &&
+                      permission != Permission.requestInstallPackages &&
+                      permission != Permission.accessNotificationPolicy &&
+                      permission != Permission.bluetoothScan &&
+                      permission != Permission.bluetoothAdvertise &&
+                      permission != Permission.bluetoothConnect &&
+                      permission != Permission.nearbyWifiDevices &&
+                      permission != Permission.videos &&
+                      permission != Permission.audio &&
+                      permission != Permission.scheduleExactAlarm &&
+                      permission != Permission.sensorsAlways;
+                })
+                .map((permission) => PermissionWidget(permission))
+                .toList(),
+      ),
     );
   }
 }
@@ -63,18 +73,16 @@ class _PermissionHandlerWidgetState extends State<PermissionHandlerWidget> {
 /// Permission widget containing information about the passed [Permission]
 class PermissionWidget extends StatefulWidget {
   /// Constructs a [PermissionWidget] for the supplied [Permission]
-  const PermissionWidget(this._permission);
+  const PermissionWidget(this.permission, {super.key});
 
-  final Permission _permission;
+  /// The [Permission] that this widget is rendered for.
+  final Permission permission;
 
   @override
-  State<PermissionWidget> createState() => _PermissionState(_permission);
+  State<PermissionWidget> createState() => _PermissionState();
 }
 
 class _PermissionState extends State<PermissionWidget> {
-  _PermissionState(this._permission);
-
-  final Permission _permission;
   final PermissionHandlerPlatform _permissionHandler =
       PermissionHandlerPlatform.instance;
   PermissionStatus _permissionStatus = PermissionStatus.denied;
@@ -87,7 +95,9 @@ class _PermissionState extends State<PermissionWidget> {
   }
 
   void _listenForPermissionStatus() async {
-    final status = await _permissionHandler.checkPermissionStatus(_permission);
+    final status = await _permissionHandler.checkPermissionStatus(
+      widget.permission,
+    );
     setState(() => _permissionStatus = status);
   }
 
@@ -108,45 +118,49 @@ class _PermissionState extends State<PermissionWidget> {
   Widget build(BuildContext context) {
     return ListTile(
       title: Text(
-        _permission.toString(),
+        widget.permission.toString(),
         style: Theme.of(context).textTheme.bodyLarge,
       ),
       subtitle: Text(
         _permissionStatus.toString(),
         style: TextStyle(color: getPermissionColor()),
       ),
-      trailing: (_permission is PermissionWithService)
-          ? IconButton(
-              icon: const Icon(
-                Icons.info,
-                color: Colors.white,
-              ),
-              onPressed: () {
-                checkServiceStatus(
-                    context, _permission as PermissionWithService);
-              })
-          : null,
+      trailing:
+          (widget.permission is PermissionWithService)
+              ? IconButton(
+                icon: const Icon(Icons.info, color: Colors.white),
+                onPressed: () {
+                  checkServiceStatus(
+                    context,
+                    widget.permission as PermissionWithService,
+                  );
+                },
+              )
+              : null,
       onTap: () {
-        requestPermission(_permission);
+        requestPermission(widget.permission);
       },
     );
   }
 
   void checkServiceStatus(
-      BuildContext context, PermissionWithService permission) async {
-    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-      content: Text(
-          (await _permissionHandler.checkServiceStatus(permission)).toString()),
-    ));
+    BuildContext context,
+    PermissionWithService permission,
+  ) async {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          (await _permissionHandler.checkServiceStatus(permission)).toString(),
+        ),
+      ),
+    );
   }
 
   Future<void> requestPermission(Permission permission) async {
     final status = await _permissionHandler.requestPermissions([permission]);
 
     setState(() {
-      print(status);
       _permissionStatus = status[permission] ?? PermissionStatus.denied;
-      print(_permissionStatus);
     });
   }
 }

--- a/permission_handler_apple/example/pubspec.yaml
+++ b/permission_handler_apple/example/pubspec.yaml
@@ -2,7 +2,7 @@ name: permission_handler_apple_example
 description: Demonstrates how to use the permission_handler_apple plugin.
 
 environment:
-  sdk: ">=2.15.0 <3.0.0"
+  sdk: ^3.7.0
 
 dependencies:
   baseflow_plugin_template: ^2.1.1

--- a/permission_handler_apple/ios/Classes/strategies/ContactPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/ContactPermissionStrategy.m
@@ -45,6 +45,8 @@
                 return PermissionStatusPermanentlyDenied;
             case CNAuthorizationStatusAuthorized:
                 return PermissionStatusGranted;
+            case CNAuthorizationStatusLimited:
+                return PermissionStatusLimited;
         }
 
     } else {
@@ -73,7 +75,8 @@
 
     [contactStore requestAccessForEntityType:CNEntityTypeContacts completionHandler:^(BOOL granted, NSError *__nullable error) {
         if (granted) {
-            completionHandler(PermissionStatusGranted);
+            const PermissionStatus updatedStatus = [self permissionStatus];
+            completionHandler(updatedStatus);
         } else {
             completionHandler(PermissionStatusPermanentlyDenied);
         }

--- a/permission_handler_apple/ios/Classes/strategies/ContactPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/ContactPermissionStrategy.m
@@ -33,7 +33,7 @@
 }
 
 + (PermissionStatus)permissionStatus {
-    if (@available(iOS 9.0, *)) {
+    if (@available(iOS 18.0, *)) {
         CNAuthorizationStatus status = [CNContactStore authorizationStatusForEntityType:CNEntityTypeContacts];
 
         switch (status) {
@@ -48,7 +48,21 @@
             case CNAuthorizationStatusLimited:
                 return PermissionStatusLimited;
         }
+    } else if (@available(iOS 9.0, *)) {
+        CNAuthorizationStatus status = [CNContactStore authorizationStatusForEntityType:CNEntityTypeContacts];
 
+        switch (status) {
+            case CNAuthorizationStatusNotDetermined:
+                return PermissionStatusDenied;
+            case CNAuthorizationStatusRestricted:
+                return PermissionStatusRestricted;
+            case CNAuthorizationStatusDenied:
+                return PermissionStatusPermanentlyDenied;
+            case CNAuthorizationStatusAuthorized:
+                return PermissionStatusGranted;
+            default:
+                return PermissionStatusGranted;
+        }
     } else {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"

--- a/permission_handler_apple/pubspec.yaml
+++ b/permission_handler_apple/pubspec.yaml
@@ -2,7 +2,7 @@ name: permission_handler_apple
 description: Permission plugin for Flutter. This plugin provides the iOS API to request and check permissions.
 repository: https://github.com/baseflow/flutter-permission-handler
 issue_tracker: https://github.com/Baseflow/flutter-permission-handler/issues
-version: 9.4.5
+version: 9.4.6
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
The package wasn't currently handling the new `CNAuthorizationStatusLimited` introduce in ios18. Older versions of ios will remain unchanged. Here's a screen recording showcasing the change

- ios 17.2

https://github.com/user-attachments/assets/4ec5422a-cd72-4c14-bf5e-3a7227148e38

- ios 18.0

https://github.com/user-attachments/assets/2a6c5c56-dc16-41b9-977e-1167462d8d7a



*List at least one fixed issue.*
- https://github.com/Baseflow/flutter-permission-handler/issues/1387
- https://github.com/Baseflow/flutter-permission-handler/issues/1376

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
