### PR TITLE
Increase minimum version to iOS 9

### DIFF
--- a/permission_handler_apple/CHANGELOG.md
+++ b/permission_handler_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 9.4.7
+
+* Increases minimum iOS version to 9.0 in podspec to match minimum Flutter version.
+
 ## 9.4.6
 
 * Adds the ability to handle `CNAuthorizationStatusLimited` introduced in ios18

--- a/permission_handler_apple/ios/Classes/PermissionManager.m
+++ b/permission_handler_apple/ios/Classes/PermissionManager.m
@@ -86,12 +86,6 @@
                                  completionHandler:^(BOOL success) {
                                      result([[NSNumber alloc] initWithBool:success]);
                                  }];
-    } else if (@available(iOS 8.0, *)) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-        BOOL success = [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]];
-        result([[NSNumber alloc] initWithBool:success]);
-#pragma clang diagnostic pop
     } else {
         result(@false);    
     }

--- a/permission_handler_apple/ios/Classes/strategies/LocationPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/LocationPermissionStrategy.m
@@ -174,36 +174,19 @@ NSString *const UserDefaultPermissionRequestedKey = @"org.baseflow.permission_ha
 
 
 + (PermissionStatus)determinePermissionStatus:(PermissionGroup)permission authorizationStatus:(CLAuthorizationStatus)authorizationStatus {
-    if (@available(iOS 8.0, *)) {
-        if (permission == PermissionGroupLocationAlways) {
-            switch (authorizationStatus) {
-                case kCLAuthorizationStatusNotDetermined:
-                    return PermissionStatusDenied;
-                case kCLAuthorizationStatusRestricted:
-                    return PermissionStatusRestricted;
-                case kCLAuthorizationStatusAuthorizedWhenInUse:
-                case kCLAuthorizationStatusDenied:
-                    return PermissionStatusPermanentlyDenied;
-                case kCLAuthorizationStatusAuthorizedAlways:
-                    return PermissionStatusGranted;
-            }
-        }
-        
+    if (permission == PermissionGroupLocationAlways) {
         switch (authorizationStatus) {
             case kCLAuthorizationStatusNotDetermined:
                 return PermissionStatusDenied;
             case kCLAuthorizationStatusRestricted:
                 return PermissionStatusRestricted;
+            case kCLAuthorizationStatusAuthorizedWhenInUse:
             case kCLAuthorizationStatusDenied:
                 return PermissionStatusPermanentlyDenied;
-            case kCLAuthorizationStatusAuthorizedWhenInUse:
             case kCLAuthorizationStatusAuthorizedAlways:
                 return PermissionStatusGranted;
         }
     }
-    
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
     switch (authorizationStatus) {
         case kCLAuthorizationStatusNotDetermined:
@@ -212,14 +195,10 @@ NSString *const UserDefaultPermissionRequestedKey = @"org.baseflow.permission_ha
             return PermissionStatusRestricted;
         case kCLAuthorizationStatusDenied:
             return PermissionStatusPermanentlyDenied;
-        case kCLAuthorizationStatusAuthorized:
+        case kCLAuthorizationStatusAuthorizedWhenInUse:
+        case kCLAuthorizationStatusAuthorizedAlways:
             return PermissionStatusGranted;
-        default:
-            return PermissionStatusDenied;
     }
-
-#pragma clang diagnostic pop
-
 }
 
 @end

--- a/permission_handler_apple/ios/permission_handler_apple.podspec
+++ b/permission_handler_apple/ios/permission_handler_apple.podspec
@@ -16,7 +16,7 @@ Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Andro
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
 
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '9.0'
   s.static_framework = true
   s.resource_bundles = {'permission_handler_apple_privacy' => ['Resources/PrivacyInfo.xcprivacy']}
 end

--- a/permission_handler_apple/pubspec.yaml
+++ b/permission_handler_apple/pubspec.yaml
@@ -2,7 +2,7 @@ name: permission_handler_apple
 description: Permission plugin for Flutter. This plugin provides the iOS API to request and check permissions.
 repository: https://github.com/baseflow/flutter-permission-handler
 issue_tracker: https://github.com/Baseflow/flutter-permission-handler/issues
-version: 9.4.6
+version: 9.4.7
 
 environment:
   sdk: ">=2.15.0 <4.0.0"


### PR DESCRIPTION
permission_handler_apple supports Flutter > 2.8.0, which had a minimum iOS requirement of iOS 9. 

https://github.com/Baseflow/flutter-permission-handler/blob/441c53c4e02ac9b6417f758495a4b04618c6e600/permission_handler_apple/pubspec.yaml#L9

Increase the podspec version to iOS 9. Remove the iOS 8 and 9 availability checks. 

Fixes https://github.com/Baseflow/flutter-permission-handler/issues/1455

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
