### PR TITLE
Drop support for iOS < 11

### DIFF
--- a/permission_handler_apple/CHANGELOG.md
+++ b/permission_handler_apple/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 9.4.7
+
+* Increases minimum supported Flutter version to 3.3.0, and removes code only
+  required for iOS versions prior to iOS 11.
+
 ## 9.4.6
 
 * Adds the ability to handle `CNAuthorizationStatusLimited` introduced in ios18

--- a/permission_handler_apple/ios/Classes/PermissionManager.m
+++ b/permission_handler_apple/ios/Classes/PermissionManager.m
@@ -80,21 +80,11 @@
 }
 
 + (void)openAppSettings:(FlutterResult)result {
-    if (@available(iOS 10, *)) {
-        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]
-                                           options:[[NSDictionary alloc] init]
-                                 completionHandler:^(BOOL success) {
-                                     result([[NSNumber alloc] initWithBool:success]);
-                                 }];
-    } else if (@available(iOS 8.0, *)) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-        BOOL success = [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]];
-        result([[NSNumber alloc] initWithBool:success]);
-#pragma clang diagnostic pop
-    } else {
-        result(@false);    
-    }
+    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]
+                                        options:[[NSDictionary alloc] init]
+                                completionHandler:^(BOOL success) {
+                                    result([[NSNumber alloc] initWithBool:success]);
+                                }];
 }
 
 + (id)createPermissionStrategy:(PermissionGroup)permission {

--- a/permission_handler_apple/ios/Classes/PermissionManager.m
+++ b/permission_handler_apple/ios/Classes/PermissionManager.m
@@ -81,10 +81,10 @@
 
 + (void)openAppSettings:(FlutterResult)result {
     [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]
-                                        options:[[NSDictionary alloc] init]
-                                completionHandler:^(BOOL success) {
-                                    result([[NSNumber alloc] initWithBool:success]);
-                                }];
+                                       options:[[NSDictionary alloc] init]
+                             completionHandler:^(BOOL success) {
+                                 result([[NSNumber alloc] initWithBool:success]);
+                             }];
 }
 
 + (id)createPermissionStrategy:(PermissionGroup)permission {

--- a/permission_handler_apple/ios/Classes/strategies/AssistantPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/AssistantPermissionStrategy.m
@@ -12,12 +12,8 @@
 @implementation AssistantPermissionStrategy
 
 - (PermissionStatus)checkPermissionStatus:(PermissionGroup)permission {
-    if (@available(iOS 10, *)) {
-        INSiriAuthorizationStatus assistantPermission = [INPreferences siriAuthorizationStatus];
-        return [AssistantPermissionStrategy parsePermission:assistantPermission];
-    }
-
-    return PermissionStatusGranted;
+    INSiriAuthorizationStatus assistantPermission = [INPreferences siriAuthorizationStatus];
+    return [AssistantPermissionStrategy parsePermission:assistantPermission];
 }
 
 - (void)checkServiceStatus:(PermissionGroup)permission completionHandler:(ServiceStatusHandler)completionHandler {
@@ -31,14 +27,10 @@
         return;
     }
 
-    if (@available(iOS 10, *)){
-        [INPreferences requestSiriAuthorization:^(INSiriAuthorizationStatus status) {
-            PermissionStatus permissionStatus = [AssistantPermissionStrategy parsePermission:status];
-            completionHandler(permissionStatus);
-        }];
-    } else {
-        completionHandler(PermissionStatusGranted);
-    }
+    [INPreferences requestSiriAuthorization:^(INSiriAuthorizationStatus status) {
+        PermissionStatus permissionStatus = [AssistantPermissionStrategy parsePermission:status];
+        completionHandler(permissionStatus);
+    }];
 }
 
 + (PermissionStatus)parsePermission:(INSiriAuthorizationStatus)assistantPermission API_AVAILABLE(ios(10)){

--- a/permission_handler_apple/ios/Classes/strategies/BluetoothPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/BluetoothPermissionStrategy.m
@@ -61,10 +61,9 @@
 }
 
 - (void)handleCheckServiceStatusCallback:(CBCentralManager *)centralManager {
-    if (@available(iOS 10, *)) {
-        ServiceStatus serviceStatus = [centralManager state] == CBManagerStatePoweredOn ? ServiceStatusEnabled : ServiceStatusDisabled;
-        _serviceStatusHandler(serviceStatus);
-    }
+    ServiceStatus serviceStatus = [centralManager state] == CBManagerStatePoweredOn ? ServiceStatusEnabled : ServiceStatusDisabled;
+    _serviceStatusHandler(serviceStatus);
+
     #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     ServiceStatus serviceStatus = [centralManager state] == CBCentralManagerStatePoweredOn ? ServiceStatusEnabled : ServiceStatusDisabled;
     _serviceStatusHandler(serviceStatus);

--- a/permission_handler_apple/ios/Classes/strategies/BluetoothPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/BluetoothPermissionStrategy.m
@@ -63,10 +63,6 @@
 - (void)handleCheckServiceStatusCallback:(CBCentralManager *)centralManager {
     ServiceStatus serviceStatus = [centralManager state] == CBManagerStatePoweredOn ? ServiceStatusEnabled : ServiceStatusDisabled;
     _serviceStatusHandler(serviceStatus);
-
-    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    serviceStatus = [centralManager state] == CBCentralManagerStatePoweredOn ? ServiceStatusEnabled : ServiceStatusDisabled;
-    _serviceStatusHandler(serviceStatus);
 }
 
 - (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler errorHandler:(PermissionErrorHandler)errorHandler {

--- a/permission_handler_apple/ios/Classes/strategies/BluetoothPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/BluetoothPermissionStrategy.m
@@ -65,7 +65,7 @@
     _serviceStatusHandler(serviceStatus);
 
     #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    ServiceStatus serviceStatus = [centralManager state] == CBCentralManagerStatePoweredOn ? ServiceStatusEnabled : ServiceStatusDisabled;
+    serviceStatus = [centralManager state] == CBCentralManagerStatePoweredOn ? ServiceStatusEnabled : ServiceStatusDisabled;
     _serviceStatusHandler(serviceStatus);
 }
 

--- a/permission_handler_apple/ios/Classes/strategies/ContactPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/ContactPermissionStrategy.m
@@ -25,11 +25,7 @@
         return;
     }
 
-    if (@available(iOS 9.0, *)) {
-        [ContactPermissionStrategy requestPermissionsFromContactStore:completionHandler];
-    } else {
-        [ContactPermissionStrategy requestPermissionsFromAddressBook:completionHandler];
-    }
+    [ContactPermissionStrategy requestPermissionsFromContactStore:completionHandler];
 }
 
 + (PermissionStatus)permissionStatus {
@@ -48,7 +44,7 @@
             case CNAuthorizationStatusLimited:
                 return PermissionStatusLimited;
         }
-    } else if (@available(iOS 9.0, *)) {
+    } else {
         CNAuthorizationStatus status = [CNContactStore authorizationStatusForEntityType:CNEntityTypeContacts];
 
         switch (status) {
@@ -62,22 +58,6 @@
                 return PermissionStatusGranted;
             default:
                 return PermissionStatusGranted;
-        }
-    } else {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-        ABAuthorizationStatus status = ABAddressBookGetAuthorizationStatus();
-
-        switch (status) {
-            case kABAuthorizationStatusNotDetermined:
-                return PermissionStatusDenied;
-            case kABAuthorizationStatusRestricted:
-                return PermissionStatusRestricted;
-            case kABAuthorizationStatusDenied:
-                return PermissionStatusPermanentlyDenied;
-            case kABAuthorizationStatusAuthorized:
-                return PermissionStatusGranted;
-#pragma clang diagnostic pop
         }
     }
 

--- a/permission_handler_apple/ios/Classes/strategies/LocationPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/LocationPermissionStrategy.m
@@ -199,6 +199,19 @@ NSString *const UserDefaultPermissionRequestedKey = @"org.baseflow.permission_ha
         case kCLAuthorizationStatusAuthorizedAlways:
             return PermissionStatusGranted;
     }
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
+    switch (authorizationStatus) {
+        case kCLAuthorizationStatusAuthorized:
+            return PermissionStatusGranted;
+        default:
+            return PermissionStatusDenied;
+    }
+
+#pragma clang diagnostic pop
+
 }
 
 @end

--- a/permission_handler_apple/ios/Classes/strategies/LocationPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/LocationPermissionStrategy.m
@@ -174,37 +174,20 @@ NSString *const UserDefaultPermissionRequestedKey = @"org.baseflow.permission_ha
 
 
 + (PermissionStatus)determinePermissionStatus:(PermissionGroup)permission authorizationStatus:(CLAuthorizationStatus)authorizationStatus {
-    if (@available(iOS 8.0, *)) {
-        if (permission == PermissionGroupLocationAlways) {
-            switch (authorizationStatus) {
-                case kCLAuthorizationStatusNotDetermined:
-                    return PermissionStatusDenied;
-                case kCLAuthorizationStatusRestricted:
-                    return PermissionStatusRestricted;
-                case kCLAuthorizationStatusAuthorizedWhenInUse:
-                case kCLAuthorizationStatusDenied:
-                    return PermissionStatusPermanentlyDenied;
-                case kCLAuthorizationStatusAuthorizedAlways:
-                    return PermissionStatusGranted;
-            }
-        }
-        
+    if (permission == PermissionGroupLocationAlways) {
         switch (authorizationStatus) {
             case kCLAuthorizationStatusNotDetermined:
                 return PermissionStatusDenied;
             case kCLAuthorizationStatusRestricted:
                 return PermissionStatusRestricted;
+            case kCLAuthorizationStatusAuthorizedWhenInUse:
             case kCLAuthorizationStatusDenied:
                 return PermissionStatusPermanentlyDenied;
-            case kCLAuthorizationStatusAuthorizedWhenInUse:
             case kCLAuthorizationStatusAuthorizedAlways:
                 return PermissionStatusGranted;
         }
     }
     
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-
     switch (authorizationStatus) {
         case kCLAuthorizationStatusNotDetermined:
             return PermissionStatusDenied;
@@ -212,14 +195,10 @@ NSString *const UserDefaultPermissionRequestedKey = @"org.baseflow.permission_ha
             return PermissionStatusRestricted;
         case kCLAuthorizationStatusDenied:
             return PermissionStatusPermanentlyDenied;
-        case kCLAuthorizationStatusAuthorized:
+        case kCLAuthorizationStatusAuthorizedWhenInUse:
+        case kCLAuthorizationStatusAuthorizedAlways:
             return PermissionStatusGranted;
-        default:
-            return PermissionStatusDenied;
     }
-
-#pragma clang diagnostic pop
-
 }
 
 @end

--- a/permission_handler_apple/ios/Classes/strategies/MediaLibraryPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/MediaLibraryPermissionStrategy.m
@@ -24,24 +24,15 @@
         return;
     }
 
-    if (@available(iOS 9.3, *)) {
-        [MPMediaLibrary requestAuthorization:^(MPMediaLibraryAuthorizationStatus status) {
-            completionHandler([MediaLibraryPermissionStrategy determinePermissionStatus:status]);
-        }];
-    } else {
-        completionHandler(PermissionStatusPermanentlyDenied);
-        return;
-    }
+    [MPMediaLibrary requestAuthorization:^(MPMediaLibraryAuthorizationStatus status) {
+        completionHandler([MediaLibraryPermissionStrategy determinePermissionStatus:status]);
+    }];
 }
 
 + (PermissionStatus)permissionStatus {
-    if (@available(iOS 9.3, *)) {
-        MPMediaLibraryAuthorizationStatus status = [MPMediaLibrary authorizationStatus];
+    MPMediaLibraryAuthorizationStatus status = [MPMediaLibrary authorizationStatus];
 
-        return [MediaLibraryPermissionStrategy determinePermissionStatus:status];
-    }
-
-    return PermissionStatusDenied;
+    return [MediaLibraryPermissionStrategy determinePermissionStatus:status];
 }
 
 + (PermissionStatus)determinePermissionStatus:(MPMediaLibraryAuthorizationStatus)authorizationStatus  API_AVAILABLE(ios(9.3)){

--- a/permission_handler_apple/ios/Classes/strategies/SensorPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/SensorPermissionStrategy.m
@@ -13,12 +13,10 @@
 }
 
 - (void)checkServiceStatus:(PermissionGroup)permission completionHandler:(ServiceStatusHandler)completionHandler {
-    if (@available(iOS 11.0, *)) {
-        completionHandler([CMMotionActivityManager isActivityAvailable]
-          ? ServiceStatusEnabled
-          : ServiceStatusDisabled
-        );
-    }
+    completionHandler([CMMotionActivityManager isActivityAvailable]
+        ? ServiceStatusEnabled
+        : ServiceStatusDisabled
+    );
     
     completionHandler(ServiceStatusDisabled);
 }
@@ -31,46 +29,38 @@
         return;
     }
     
-    if (@available(iOS 11.0, *)) {
-        CMMotionActivityManager *motionManager = [[CMMotionActivityManager alloc] init];
-        
-        NSDate *today = [NSDate new];
-        [motionManager queryActivityStartingFromDate:today toDate:today toQueue:[NSOperationQueue mainQueue] withHandler:^(NSArray<CMMotionActivity *> *__nullable activities, NSError *__nullable error) {
-            PermissionStatus status = [SensorPermissionStrategy permissionStatus];
-            completionHandler(status);
-        }];
-    } else {
-        completionHandler(PermissionStatusDenied);
-    }
+    CMMotionActivityManager *motionManager = [[CMMotionActivityManager alloc] init];
     
+    NSDate *today = [NSDate new];
+    [motionManager queryActivityStartingFromDate:today toDate:today toQueue:[NSOperationQueue mainQueue] withHandler:^(NSArray<CMMotionActivity *> *__nullable activities, NSError *__nullable error) {
+        PermissionStatus status = [SensorPermissionStrategy permissionStatus];
+        completionHandler(status);
+    }];
+
 }
 
 + (PermissionStatus)permissionStatus {
-    if (@available(iOS 11.0, *)) {
-        CMAuthorizationStatus status = [CMMotionActivityManager authorizationStatus];
-        PermissionStatus permissionStatus;
-        
-        switch (status) {
-            case CMAuthorizationStatusNotDetermined:
-                permissionStatus = PermissionStatusDenied;
-                break;
-            case CMAuthorizationStatusRestricted:
-                permissionStatus = PermissionStatusRestricted;
-                break;
-            case CMAuthorizationStatusDenied:
-                permissionStatus = PermissionStatusPermanentlyDenied;
-                break;
-            case CMAuthorizationStatusAuthorized:
-                permissionStatus = PermissionStatusGranted;
-                break;
-            default:
-                permissionStatus = PermissionStatusGranted;
-        }
-        
-        return permissionStatus;
+    CMAuthorizationStatus status = [CMMotionActivityManager authorizationStatus];
+    PermissionStatus permissionStatus;
+    
+    switch (status) {
+        case CMAuthorizationStatusNotDetermined:
+            permissionStatus = PermissionStatusDenied;
+            break;
+        case CMAuthorizationStatusRestricted:
+            permissionStatus = PermissionStatusRestricted;
+            break;
+        case CMAuthorizationStatusDenied:
+            permissionStatus = PermissionStatusPermanentlyDenied;
+            break;
+        case CMAuthorizationStatusAuthorized:
+            permissionStatus = PermissionStatusGranted;
+            break;
+        default:
+            permissionStatus = PermissionStatusGranted;
     }
     
-    return PermissionStatusDenied;
+    return permissionStatus;
 }
 
 @end

--- a/permission_handler_apple/ios/Classes/strategies/SensorPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/SensorPermissionStrategy.m
@@ -17,8 +17,6 @@
         ? ServiceStatusEnabled
         : ServiceStatusDisabled
     );
-    
-    completionHandler(ServiceStatusDisabled);
 }
 
 - (void)requestPermission:(PermissionGroup)permission completionHandler:(PermissionStatusHandler)completionHandler errorHandler:(PermissionErrorHandler)errorHandler {

--- a/permission_handler_apple/ios/Classes/strategies/SpeechPermissionStrategy.m
+++ b/permission_handler_apple/ios/Classes/strategies/SpeechPermissionStrategy.m
@@ -24,23 +24,15 @@
         return;
     }
     
-    if (@available(iOS 10.0, *)) {
-        [SFSpeechRecognizer requestAuthorization:^(SFSpeechRecognizerAuthorizationStatus authorizationStatus) {
-            completionHandler([SpeechPermissionStrategy determinePermissionStatus:authorizationStatus]);
-        }];
-    } else {
-        completionHandler(PermissionStatusDenied);
-    }
+    [SFSpeechRecognizer requestAuthorization:^(SFSpeechRecognizerAuthorizationStatus authorizationStatus) {
+        completionHandler([SpeechPermissionStrategy determinePermissionStatus:authorizationStatus]);
+    }];
 }
 
 + (PermissionStatus)permissionStatus {
-    if (@available(iOS 10.0, *)) {
-        SFSpeechRecognizerAuthorizationStatus status = [SFSpeechRecognizer authorizationStatus];
-        
-        return [SpeechPermissionStrategy determinePermissionStatus:status];
-    }
+    SFSpeechRecognizerAuthorizationStatus status = [SFSpeechRecognizer authorizationStatus];
     
-    return PermissionStatusDenied;
+    return [SpeechPermissionStrategy determinePermissionStatus:status];
 }
 
 + (PermissionStatus)determinePermissionStatus:(SFSpeechRecognizerAuthorizationStatus)authorizationStatus  API_AVAILABLE(ios(10.0)){

--- a/permission_handler_apple/pubspec.yaml
+++ b/permission_handler_apple/pubspec.yaml
@@ -2,11 +2,11 @@ name: permission_handler_apple
 description: Permission plugin for Flutter. This plugin provides the iOS API to request and check permissions.
 repository: https://github.com/baseflow/flutter-permission-handler
 issue_tracker: https://github.com/Baseflow/flutter-permission-handler/issues
-version: 9.4.6
+version: 9.4.7
 
 environment:
-  sdk: ">=2.15.0 <4.0.0"
-  flutter: ">=2.8.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 flutter:
   plugin:


### PR DESCRIPTION
iOS versions < 11 haven't been supported since Flutter 3.3, which is over two years old. Even that version is too old to be able to ship to the App store with (as it lacks a privacy manifest), so there is no clear value in continuing to support versions even older than that.

This updates the Flutter SDK constraint to 3.3, where iOS 11 became the minimum, and removes all `@available` checks related to iOS 11 or earlier, as well as any fallback code that only ran on versions older than that.

Fixes https://github.com/Baseflow/flutter-permission-handler/issues/1455

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
