### PR TITLE
docs(README): Update the correspondence between permission groups and the key values of Info.plist

### DIFF
--- a/permission_handler/README.md
+++ b/permission_handler/README.md
@@ -127,7 +127,7 @@ You must list the permission you want to use in your application:
           ## dart: PermissionGroup.criticalAlerts
           'PERMISSION_CRITICAL_ALERTS=1',
 
-          ## dart: PermissionGroup.criticalAlerts
+          ## dart: PermissionGroup.assistant
           'PERMISSION_ASSISTANT=1',
         ]
 
@@ -147,23 +147,28 @@ You must list the permission you want to use in your application:
    e.g. when you don't need camera permission, just delete 'NSCameraUsageDescription'
    The following lists the relationship between `Permission` and `The key of Info.plist`:
 
-| Permission                                                                                  | Info.plist                                                                                                    | Macro                                |
-|---------------------------------------------------------------------------------------------| ------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
-| PermissionGroup.calendar (< iOS 17)                                                         | NSCalendarsUsageDescription                                                                                   | PERMISSION_EVENTS                    |
-| PermissionGroup.calendarWriteOnly (iOS 17+)                                                 | NSCalendarsWriteOnlyAccessUsageDescription                                                                    | PERMISSION_EVENTS                    |
-| PermissionGroup.calendarFullAccess  (iOS 17+)                                               | NSCalendarsFullAccessUsageDescription                                                                         | PERMISSION_EVENTS_FULL_ACCESS        |
-| PermissionGroup.reminders                                                                   | NSRemindersUsageDescription                                                                                   | PERMISSION_REMINDERS                 |
-| PermissionGroup.contacts                                                                    | NSContactsUsageDescription                                                                                    | PERMISSION_CONTACTS                  |
-| PermissionGroup.camera                                                                      | NSCameraUsageDescription                                                                                      | PERMISSION_CAMERA                    |
-| PermissionGroup.microphone                                                                  | NSMicrophoneUsageDescription                                                                                  | PERMISSION_MICROPHONE                |
-| PermissionGroup.speech                                                                      | NSSpeechRecognitionUsageDescription                                                                           | PERMISSION_SPEECH_RECOGNIZER         |
-| PermissionGroup.photos                                                                      | NSPhotoLibraryUsageDescription                                                                                | PERMISSION_PHOTOS                    |
-| PermissionGroup.photosAddOnly                                                               | NSPhotoLibraryAddUsageDescription                                                                             | PERMISSION_PHOTOS_ADD_ONLY           |
-| PermissionGroup.location, PermissionGroup.locationAlways, PermissionGroup.locationWhenInUse | NSLocationUsageDescription, NSLocationAlwaysAndWhenInUseUsageDescription, NSLocationWhenInUseUsageDescription | PERMISSION_LOCATION                  |
-| PermissionGroup.locationWhenInUse                                                           | NSLocationWhenInUseUsageDescription                                                                           | PERMISSION_LOCATION_WHENINUSE        |
-| PermissionGroup.notification                                                                | PermissionGroupNotification                                                                                   | PERMISSION_NOTIFICATIONS             |
-| PermissionGroup.mediaLibrary                                                                | NSAppleMusicUsageDescription, kTCCServiceMedia                                                                |
-PERMISSION_MEDIA_LIBRARY             |
+| Permission                                                                                  | Info.plist                                                                                                     | Macro                                  |
+|---------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|----------------------------------------|
+| PermissionGroup.calendar (< iOS 17)                                                         | NSCalendarsUsageDescription                                                                                    | PERMISSION_EVENTS                      |
+| PermissionGroup.calendarWriteOnly (iOS 17+)                                                 | NSCalendarsWriteOnlyAccessUsageDescription                                                                     | PERMISSION_EVENTS                      |
+| PermissionGroup.calendarFullAccess  (iOS 17+)                                               | NSCalendarsFullAccessUsageDescription                                                                          | PERMISSION_EVENTS_FULL_ACCESS          |
+| PermissionGroup.reminders                                                                   | NSRemindersUsageDescription                                                                                    | PERMISSION_REMINDERS                   |
+| PermissionGroup.contacts                                                                    | NSContactsUsageDescription                                                                                     | PERMISSION_CONTACTS                    |
+| PermissionGroup.camera                                                                      | NSCameraUsageDescription                                                                                       | PERMISSION_CAMERA                      |
+| PermissionGroup.microphone                                                                  | NSMicrophoneUsageDescription                                                                                   | PERMISSION_MICROPHONE                  |
+| PermissionGroup.speech                                                                      | NSSpeechRecognitionUsageDescription                                                                            | PERMISSION_SPEECH_RECOGNIZER           |
+| PermissionGroup.photos                                                                      | NSPhotoLibraryUsageDescription                                                                                 | PERMISSION_PHOTOS                      |
+| PermissionGroup.photosAddOnly                                                               | NSPhotoLibraryAddUsageDescription                                                                              | PERMISSION_PHOTOS_ADD_ONLY             |
+| PermissionGroup.location, PermissionGroup.locationAlways, PermissionGroup.locationWhenInUse | NSLocationUsageDescription, NSLocationAlwaysAndWhenInUseUsageDescription, NSLocationWhenInUseUsageDescription  | PERMISSION_LOCATION                    |
+| PermissionGroup.locationWhenInUse                                                           | NSLocationWhenInUseUsageDescription                                                                            | PERMISSION_LOCATION_WHENINUSE          |
+| PermissionGroup.notification                                                                | PermissionGroupNotification                                                                                    | PERMISSION_NOTIFICATIONS               |
+| PermissionGroup.mediaLibrary                                                                | NSAppleMusicUsageDescription, kTCCServiceMedia                                                                 | PERMISSION_MEDIA_LIBRARY               |
+| PermissionGroup.sensors                                                                     | NSMotionUsageDescription                                                                                       | PermissionGroupSensors                 |
+| PermissionGroup.bluetooth                                                                   | NSBluetoothAlwaysUsageDescription, NSBluetoothPeripheralUsageDescription                                       | PermissionGroupBluetooth               |
+| PermissionGroup.appTrackingTransparency                                                     | NSUserTrackingUsageDescription                                                                                 | PermissionGroupAppTrackingTransparency |
+| PermissionGroup.criticalAlerts                                                              | UNAuthorizationOptionCriticalAlert                                                                             | PermissionGroupCriticalAlerts          |
+| PermissionGroup.assistant                                                                   | NSSiriUsageDescription                                                                                         | PermissionGroupAssistant               |
+
 
 4. Clean & Rebuild
 

--- a/permission_handler_apple/example/ios/Podfile
+++ b/permission_handler_apple/example/ios/Podfile
@@ -95,7 +95,7 @@ post_install do |installer|
         ## dart: PermissionGroup.criticalAlerts
         'PERMISSION_CRITICAL_ALERTS=1',
 
-        ## dart: PermissionGroup.criticalAlerts
+        ## dart: PermissionGroup.assistant
         'PERMISSION_ASSISTANT=1',
       ]
 


### PR DESCRIPTION
docs(README): Update the correspondence between permission groups and the key values of Info.plist

- The correspondence table between permission groups and Info.plist key values has been updated in the README file
- Several new mapping relationships for permission groups have been added, including sensors, bluetooth, appTrackingTransparency, criticalAlerts, and assistant
- Corrected the macro definitions of some permission groups

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
