### PR TITLE
Improved the iOS Setup section in permission_handler/README.md

### DIFF
--- a/permission_handler/README.md
+++ b/permission_handler/README.md
@@ -57,13 +57,14 @@ In general, it's sufficient to add permission only to the `main` version.
 Add permission to your `Info.plist` file.
 [Here](https://github.com/Baseflow/flutter-permission-handler/blob/master/permission_handler/example/ios/Runner/Info.plist)'s an example `Info.plist` with a complete list of all possible permissions.
 
-> IMPORTANT: ~~You will have to include all permission options when you want to submit your App.~~ This is because the `permission_handler` plugin touches all different SDKs and because the static code analyzer (run by Apple upon App submission) detects this and will assert if it cannot find a matching permission option in the `Info.plist`. More information about this can be found [here](https://github.com/Baseflow/flutter-permission-handler/issues/26).
+> IMPORTANT: ~~You will have to include all permission options when you want to submit your App. This is because the `permission_handler` plugin touches all different SDKs and because the static code analyzer (run by Apple upon App submission) detects this and will assert if it cannot find a matching permission option in the `Info.plist`. More information about this can be found [here](https://github.com/Baseflow/flutter-permission-handler/issues/26).~~
+ This has been fixed since version 8.0.0, now permission_handler by default excludes all permissions and developers only have to enable those that the app really needs.
 
 The <kbd>permission_handler</kbd> plugin use [macros](https://github.com/Baseflow/flutter-permission-handler/blob/master/permission_handler_apple/ios/Classes/PermissionHandlerEnums.h) to control whether a permission is enabled.
 
 You must list the permission you want to use in your application:
 
-1. Add the following to your `Podfile` file:
+1. Add the following to your `Podfile`'s `post_install` block:
 
   ```ruby
   post_install do |installer|
@@ -73,7 +74,8 @@ You must list the permission you want to use in your application:
       target.build_configurations.each do |config|
         # You can remove unused permissions here
         # for more information: https://github.com/Baseflow/flutter-permission-handler/blob/main/permission_handler_apple/ios/Classes/PermissionHandlerEnums.h
-        # e.g. when you don't need camera permission, just add 'PERMISSION_CAMERA=0'
+        # When you don't need a permission, just change its value to 0
+        # e.g. 'PERMISSION_CAMERA=0' instead of 'PERMISSION_CAMERA=1'
         config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [
           '$(inherited)',
 
@@ -136,16 +138,18 @@ You must list the permission you want to use in your application:
   end
   ```
 
-2. Remove the `#` character in front of the permission you want to use. For example, if you need access to the calendar make sure the code looks like this:
+2. For the permissions you *want* to use, keep them as is. For example, if you need access to the calendar make sure the code looks like this:
 
    ```ruby
            ## dart: PermissionGroup.calendar
            'PERMISSION_EVENTS=1',
    ```
+3. When you **DON'T** need a permission, change its value to `0` e.g. `'PERMISSION_CAMERA=0'` instead of `'PERMISSION_CAMERA=1'`
 
-3. Delete the corresponding permission description in `Info.plist`
-   e.g. when you don't need camera permission, just delete 'NSCameraUsageDescription'
-   The following lists the relationship between `Permission` and `The key of Info.plist`:
+3. And delete the corresponding permission description in `Info.plist`
+   e.g. when you don't need camera permission, just delete `'NSCameraUsageDescription'`
+
+The following lists the relationship between `Permission` and `The key of Info.plist`:
 
 | Permission                                                                                  | Info.plist                                                                                                     | Macro                                  |
 |---------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|----------------------------------------|


### PR DESCRIPTION
After version 8.0.0, permission_handler no longer uses all permissions on iOS (only required permissions selected by the developers) but this was not explained clearly in the README. Due to this, I struggled for a few hours to understand how to setup the permissions properly, but eventually I solved my problem after searching through older issues. I think it is quite necessary to improve the documentation so that future developers won't have to go through this.

Fixed this issue, which can be closed now: https://github.com/Baseflow/flutter-permission-handler/issues/1170

Note: This is only a minor document improvement, I did not change any code at all

P.S. I have no idea why the check failed, I did literally nothing to the code ;-;

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.
