### PR TITLE
fix: isolate permission callbacks by permission type

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 12.0.2
+
+- Fixes issue where permission callbacks would fire for incorrect permissions by isolating callbacks per permission instance.
+
 ## 12.0.1
 
 - Updates the correspondence between permission groups and the key values of Info.plist in the README.md.

--- a/permission_handler/lib/permission_handler.dart
+++ b/permission_handler/lib/permission_handler.dart
@@ -24,56 +24,57 @@ Future<bool> openAppSettings() => _handler.openAppSettings();
 /// Actions that can be executed on a permission.
 extension PermissionActions on Permission {
   /// Callback for when permission is denied.
-  static FutureOr<void>? Function()? _onDenied;
+  static final Map<Permission, FutureOr<void>? Function()?> _onDenied = {};
 
   /// Callback for when permission is granted.
-  static FutureOr<void>? Function()? _onGranted;
+  static final Map<Permission, FutureOr<void>? Function()?> _onGranted = {};
 
   /// Callback for when permission is permanently denied.
-  static FutureOr<void>? Function()? _onPermanentlyDenied;
+  static final Map<Permission, FutureOr<void>? Function()?>
+      _onPermanentlyDenied = {};
 
   /// Callback for when permission is restricted.
-  static FutureOr<void>? Function()? _onRestricted;
+  static final Map<Permission, FutureOr<void>? Function()?> _onRestricted = {};
 
   /// Callback for when permission is limited.
-  static FutureOr<void>? Function()? _onLimited;
+  static final Map<Permission, FutureOr<void>? Function()?> _onLimited = {};
 
   /// Callback for when permission is Provisional.
-  static FutureOr<void>? Function()? _onProvisional;
+  static final Map<Permission, FutureOr<void>? Function()?> _onProvisional = {};
 
   /// Method to set a callback for when permission is denied.
   Permission onDeniedCallback(FutureOr<void>? Function()? callback) {
-    _onDenied = callback;
+    _onDenied[this] = callback;
     return this;
   }
 
   /// Method to set a callback for when permission is granted.
   Permission onGrantedCallback(FutureOr<void>? Function()? callback) {
-    _onGranted = callback;
+    _onGranted[this] = callback;
     return this;
   }
 
   /// Method to set a callback for when permission is permanently denied.
   Permission onPermanentlyDeniedCallback(FutureOr<void>? Function()? callback) {
-    _onPermanentlyDenied = callback;
+    _onPermanentlyDenied[this] = callback;
     return this;
   }
 
   /// Method to set a callback for when permission is restricted.
   Permission onRestrictedCallback(FutureOr<void>? Function()? callback) {
-    _onRestricted = callback;
+    _onRestricted[this] = callback;
     return this;
   }
 
   /// Method to set a callback for when permission is limited.
   Permission onLimitedCallback(FutureOr<void>? Function()? callback) {
-    _onLimited = callback;
+    _onLimited[this] = callback;
     return this;
   }
 
   /// Method to set a callback for when permission is provisional.
   Permission onProvisionalCallback(FutureOr<void>? Function()? callback) {
-    _onProvisional = callback;
+    _onProvisional[this] = callback;
     return this;
   }
 
@@ -109,17 +110,17 @@ extension PermissionActions on Permission {
         (await [this].request())[this] ?? PermissionStatus.denied;
 
     if (permissionStatus.isDenied) {
-      _onDenied?.call();
+      _onDenied[this]?.call();
     } else if (permissionStatus.isGranted) {
-      _onGranted?.call();
+      _onGranted[this]?.call();
     } else if (permissionStatus.isPermanentlyDenied) {
-      _onPermanentlyDenied?.call();
+      _onPermanentlyDenied[this]?.call();
     } else if (permissionStatus.isRestricted) {
-      _onRestricted?.call();
+      _onRestricted[this]?.call();
     } else if (permissionStatus.isLimited) {
-      _onLimited?.call();
+      _onLimited[this]?.call();
     } else if (permissionStatus.isProvisional) {
-      _onProvisional?.call();
+      _onProvisional[this]?.call();
     }
 
     return permissionStatus;

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -2,7 +2,7 @@ name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
 repository: https://github.com/baseflow/flutter-permission-handler
 issue_tracker: https://github.com/Baseflow/flutter-permission-handler/issues
-version: 12.0.1
+version: 12.0.2
 
 environment:
   sdk: ^3.5.0


### PR DESCRIPTION
Callbacks were stored as static variables shared across all Permission instances, causing callbacks to fire for wrong permissions. Changed to use Maps keyed by Permission to ensure each permission has its own isolated callbacks.

Fixes issue where Permission.locationWhenInUse callbacks would trigger when any other permission changed state.

https://github.com/Baseflow/flutter-permission-handler/issues/1414


<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
