### PR TITLE
fix(README): iOS instructions outdated

### DIFF
--- a/permission_handler/README.md
+++ b/permission_handler/README.md
@@ -136,14 +136,7 @@ You must list the permission you want to use in your application:
   end
   ```
 
-2. Remove the `#` character in front of the permission you want to use. For example, if you need access to the calendar make sure the code looks like this:
-
-   ```ruby
-           ## dart: PermissionGroup.calendar
-           'PERMISSION_EVENTS=1',
-   ```
-
-3. Delete the corresponding permission description in `Info.plist`
+2. Delete the corresponding permission description in `Info.plist`
    e.g. when you don't need camera permission, just delete 'NSCameraUsageDescription'
    The following lists the relationship between `Permission` and `The key of Info.plist`:
 
@@ -170,7 +163,7 @@ You must list the permission you want to use in your application:
 | PermissionGroup.assistant                                                                   | NSSiriUsageDescription                                                                                         | PermissionGroupAssistant               |
 
 
-4. Clean & Rebuild
+3. Clean & Rebuild
 
 </details>
 


### PR DESCRIPTION
Updated README to remove outdated instructions and renumber steps.

Basically there's no commented permission with the current instructions. I remember a time ago you had to uncomment them if you copied them from the instructions.

- Fixed outdated iOS config step.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
