### PR TITLE
Fix/ios background permission reset

### DIFF
--- a/permission_handler_apple/CHANGELOG.md
+++ b/permission_handler_apple/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 9.4.8
 
 * Fixed iOS permission request state not being reset when app enters background, causing subsequent requests to fail with `ERROR_ALREADY_REQUESTING_PERMISSIONS`.
 

--- a/permission_handler_apple/CHANGELOG.md
+++ b/permission_handler_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Fixed iOS permission request state not being reset when app enters background, causing subsequent requests to fail with `ERROR_ALREADY_REQUESTING_PERMISSIONS`.
+
 ## 9.4.7
 
 * Increases minimum supported Flutter version to 3.3.0, and removes code only

--- a/permission_handler_apple/ios/Classes/PermissionHandlerPlugin.m
+++ b/permission_handler_apple/ios/Classes/PermissionHandlerPlugin.m
@@ -21,6 +21,13 @@
                                      binaryMessenger:[registrar messenger]];
     PermissionManager *permissionManager = [[PermissionManager alloc] initWithStrategyInstances];
     PermissionHandlerPlugin *instance = [[PermissionHandlerPlugin alloc] initWithPermissionManager:permissionManager];
+
+    [[NSNotificationCenter defaultCenter] 
+        addObserver:instance
+        selector:@selector(handleApplicationDidEnterBackground:)
+        name:UIApplicationDidEnterBackgroundNotification
+        object:nil];
+
     [registrar addMethodCallDelegate:instance channel:channel];
 }
 
@@ -60,6 +67,25 @@
     } else {
         result(FlutterMethodNotImplemented);
     }
+}
+
+- (void)handleApplicationDidEnterBackground:(NSNotification *)notification {
+    if (_methodResult != nil) {
+        #ifdef DEBUG
+                NSLog(@"[PermissionHandler] App backgrounded with pending permission request. Cancelling request.");
+        #endif
+        
+        _methodResult([FlutterError 
+            errorWithCode:@"REQUEST_INTERRUPTED" 
+            message:@"Permission request was interrupted because the app entered background" 
+            details:nil]);
+        
+        _methodResult = nil;
+    }
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 @end


### PR DESCRIPTION
**Issue**
IOS permission request state not being reset when app enters background, causing subsequent requests to fail with ERROR_ALREADY_REQUESTING_PERMISSIONS.

Video : https://github.com/user-attachments/assets/0f78390a-cbd3-4362-87c8-2874ae4ac620

**Changes:**
- Added background notification observer to reset state in PermissionHandlerPlugin.m
- Properly cleanup observer in dealloc

### Reproduction Steps (Before Fix)
1. Call `await Permission.location.request()`
2. When iOS system permission dialog appears, block screen
3. Return to app
4. Call `await Permission.location.request()` again
5. **Result:** Exception thrown: `ERROR_ALREADY_REQUESTING_PERMISSIONS`

### Expected Behavior
If the app is backgrounded during a permission request:
- The pending Flutter callback should be completed with an error (`REQUEST_INTERRUPTED`)
- The internal state should be reset (`_methodResult = nil`)
- Subsequent permission requests should work normally without throwing `ERROR_ALREADY_REQUESTING_PERMISSIONS`
- The user should be able to retry the permission request when they return to the app


### Actual Behavior (Before Fix)
- The pending Flutter callback is never completed (Future hangs indefinitely)
- The internal state remains set (`_methodResult != nil`)
- All subsequent permission requests immediately fail with `ERROR_ALREADY_REQUESTING_PERMISSIONS`
- The app becomes unusable for any permission-related functionality until restarted


### Solution
- Register observer for `UIApplicationDidEnterBackgroundNotification` when plugin initializes
- When app backgrounds with a pending request, complete the Flutter callback with `REQUEST_INTERRUPTED` error and reset internal state

### After Fix
Same reproduction steps now work correctly:
1. Call `await Permission.location.request()`
2. Block Screen → App backgrounds
3. Return to app
4. Call `await Permission.location.request()` again
5. **Result:**  New permission request works normally, dialog appears again

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
