### PR TITLE
Fix production crash: SecurityException in canRequestPackageInstalls()

### DIFF
--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
@@ -117,9 +117,15 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
             }
         } else if (requestCode == PermissionConstants.PERMISSION_CODE_REQUEST_INSTALL_PACKAGES) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                status = activity.getPackageManager().canRequestPackageInstalls()
-                    ? PermissionConstants.PERMISSION_STATUS_GRANTED
-                    : PermissionConstants.PERMISSION_STATUS_DENIED;
+                try {
+                    status = activity.getPackageManager().canRequestPackageInstalls()
+                        ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                        : PermissionConstants.PERMISSION_STATUS_DENIED;
+                } catch (SecurityException e) {
+                    // App has not declared REQUEST_INSTALL_PACKAGES in manifest.
+                    Log.d(PermissionConstants.LOG_TAG, "Cannot call canRequestPackageInstalls: " + e.getMessage());
+                    status = PermissionConstants.PERMISSION_STATUS_DENIED;
+                }
                 permission = PermissionConstants.PERMISSION_GROUP_REQUEST_INSTALL_PACKAGES;
             } else {
                 return false;
@@ -532,10 +538,16 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
                     permissionStatuses.add(status);
                 } else if (permission == PermissionConstants.PERMISSION_GROUP_REQUEST_INSTALL_PACKAGES) {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                        int status = context.getPackageManager().canRequestPackageInstalls()
-                            ? PermissionConstants.PERMISSION_STATUS_GRANTED
-                            : PermissionConstants.PERMISSION_STATUS_DENIED;
-                        permissionStatuses.add(status);
+                        try {
+                            int status = context.getPackageManager().canRequestPackageInstalls()
+                                ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                                : PermissionConstants.PERMISSION_STATUS_DENIED;
+                            permissionStatuses.add(status);
+                        } catch (SecurityException e) {
+                            // App has not declared REQUEST_INSTALL_PACKAGES in manifest.
+                            Log.d(PermissionConstants.LOG_TAG, "Cannot call canRequestPackageInstalls: " + e.getMessage());
+                            permissionStatuses.add(PermissionConstants.PERMISSION_STATUS_DENIED);
+                        }
                     }
                 } else if (permission == PermissionConstants.PERMISSION_GROUP_ACCESS_NOTIFICATION_POLICY) {
                     NotificationManager notificationManager = (NotificationManager) context.getSystemService(Application.NOTIFICATION_SERVICE);

--- a/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
+++ b/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionManager.java
@@ -117,9 +117,15 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
             }
         } else if (requestCode == PermissionConstants.PERMISSION_CODE_REQUEST_INSTALL_PACKAGES) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                status = activity.getPackageManager().canRequestPackageInstalls()
-                    ? PermissionConstants.PERMISSION_STATUS_GRANTED
-                    : PermissionConstants.PERMISSION_STATUS_DENIED;
+                try {
+                    status = activity.getPackageManager().canRequestPackageInstalls()
+                            ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                            : PermissionConstants.PERMISSION_STATUS_DENIED;
+                } catch (SecurityException e) {
+                    // App has not declared REQUEST_INSTALL_PACKAGES in manifest.
+                    Log.d(PermissionConstants.LOG_TAG, "Cannot call canRequestPackageInstalls: " + e.getMessage());
+                    status = PermissionConstants.PERMISSION_STATUS_DENIED;
+                }
                 permission = PermissionConstants.PERMISSION_GROUP_REQUEST_INSTALL_PACKAGES;
             } else {
                 return false;
@@ -532,10 +538,16 @@ final class PermissionManager implements PluginRegistry.ActivityResultListener, 
                     permissionStatuses.add(status);
                 } else if (permission == PermissionConstants.PERMISSION_GROUP_REQUEST_INSTALL_PACKAGES) {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                        int status = context.getPackageManager().canRequestPackageInstalls()
-                            ? PermissionConstants.PERMISSION_STATUS_GRANTED
-                            : PermissionConstants.PERMISSION_STATUS_DENIED;
-                        permissionStatuses.add(status);
+                        try {
+                            int status = context.getPackageManager().canRequestPackageInstalls()
+                                    ? PermissionConstants.PERMISSION_STATUS_GRANTED
+                                    : PermissionConstants.PERMISSION_STATUS_DENIED;
+                            permissionStatuses.add(status);
+                        } catch (SecurityException e) {
+                            // App has not declared REQUEST_INSTALL_PACKAGES in manifest.
+                            Log.d(PermissionConstants.LOG_TAG, "Cannot call canRequestPackageInstalls: " + e.getMessage());
+                            permissionStatuses.add(PermissionConstants.PERMISSION_STATUS_DENIED);
+                        }
                     }
                 } else if (permission == PermissionConstants.PERMISSION_GROUP_ACCESS_NOTIFICATION_POLICY) {
                     NotificationManager notificationManager = (NotificationManager) context.getSystemService(Application.NOTIFICATION_SERVICE);

--- a/permission_handler_android/example/android/app/build.gradle
+++ b/permission_handler_android/example/android/app/build.gradle
@@ -28,7 +28,7 @@ if (flutterVersionName == null) {
 
 android {
     namespace 'com.baseflow.permissionhandler.example'
-    compileSdkVersion 35
+    compileSdkVersion 36
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).

--- a/permission_handler_android/example/android/app/build.gradle
+++ b/permission_handler_android/example/android/app/build.gradle
@@ -39,6 +39,11 @@ android {
         versionName flutterVersionName
     }
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
     buildTypes {
         release {
             // TODO: Add your own signing config for the release build.

--- a/permission_handler_android/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/permission_handler_android/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip

--- a/permission_handler_android/example/android/settings.gradle
+++ b/permission_handler_android/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.7.0" apply false
+    id "com.android.application" version "8.9.1" apply false
 }
 
 include ":app"

--- a/permission_handler_android/example/lib/main.dart
+++ b/permission_handler_android/example/lib/main.dart
@@ -1,36 +1,30 @@
-import 'package:baseflow_plugin_template/baseflow_plugin_template.dart';
+// ignore_for_file: public_member_api_docs
+
 import 'package:flutter/material.dart';
 import 'package:permission_handler_platform_interface/permission_handler_platform_interface.dart';
 
 void main() {
-  runApp(
-    BaseflowPluginExample(
-      pluginName: 'Permission Handler',
-      githubURL: 'https://github.com/Baseflow/flutter-permission-handler',
-      pubDevURL: 'https://pub.dev/packages/permission_handler',
-      pages: [PermissionHandlerWidget.createPage()],
-    ),
-  );
+  runApp(const PermissionHandlerExampleApp());
 }
 
-///Defines the main theme color
-final MaterialColor themeMaterialColor =
-    BaseflowPluginExample.createMaterialColor(
-      const Color.fromRGBO(48, 49, 60, 1),
-    );
+class PermissionHandlerExampleApp extends StatelessWidget {
+  const PermissionHandlerExampleApp({super.key});
 
-/// A Flutter application demonstrating the functionality of this plugin
-class PermissionHandlerWidget extends StatefulWidget {
-  /// Creates a [PermissionHandlerWidget].
-  const PermissionHandlerWidget({super.key});
-
-  /// Create a page containing the functionality of this plugin
-  static ExamplePage createPage() {
-    return ExamplePage(
-      Icons.location_on,
-      (context) => const PermissionHandlerWidget(),
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Permission Handler Example',
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+        useMaterial3: true,
+      ),
+      home: const PermissionHandlerWidget(),
     );
   }
+}
+
+class PermissionHandlerWidget extends StatefulWidget {
+  const PermissionHandlerWidget({super.key});
 
   @override
   State<PermissionHandlerWidget> createState() =>
@@ -40,31 +34,32 @@ class PermissionHandlerWidget extends StatefulWidget {
 class _PermissionHandlerWidgetState extends State<PermissionHandlerWidget> {
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: ListView(
-        children:
-            Permission.values
-                .where((permission) {
-                  return permission != Permission.unknown &&
-                      permission != Permission.mediaLibrary &&
-                      permission != Permission.photosAddOnly &&
-                      permission != Permission.reminders &&
-                      permission != Permission.bluetooth &&
-                      permission != Permission.appTrackingTransparency &&
-                      permission != Permission.criticalAlerts &&
-                      permission != Permission.assistant &&
-                      permission != Permission.backgroundRefresh;
-                })
-                .map((permission) => PermissionWidget(permission))
-                .toList(),
+    return Scaffold(
+      appBar: AppBar(title: const Text('Permission Handler')),
+      body: Center(
+        child: ListView(
+          children:
+              Permission.values
+                  .where((permission) {
+                    return permission != Permission.unknown &&
+                        permission != Permission.mediaLibrary &&
+                        permission != Permission.photosAddOnly &&
+                        permission != Permission.reminders &&
+                        permission != Permission.bluetooth &&
+                        permission != Permission.appTrackingTransparency &&
+                        permission != Permission.criticalAlerts &&
+                        permission != Permission.assistant &&
+                        permission != Permission.backgroundRefresh;
+                  })
+                  .map((permission) => PermissionWidget(permission))
+                  .toList(),
+        ),
       ),
     );
   }
 }
 
-/// Permission widget containing information about the passed [Permission]
 class PermissionWidget extends StatefulWidget {
-  /// Constructs a [PermissionWidget] for the supplied [Permission]
   const PermissionWidget(this._permission, {super.key});
 
   final Permission _permission;
@@ -121,7 +116,7 @@ class _PermissionState extends State<PermissionWidget> {
       trailing:
           (widget._permission is PermissionWithService)
               ? IconButton(
-                icon: const Icon(Icons.info, color: Colors.white),
+                icon: const Icon(Icons.info),
                 onPressed: () {
                   checkServiceStatus(
                     context,

--- a/permission_handler_android/example/pubspec.yaml
+++ b/permission_handler_android/example/pubspec.yaml
@@ -5,7 +5,6 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  baseflow_plugin_template: ^2.1.2
   flutter:
     sdk: flutter
   permission_handler_platform_interface: ^4.2.0
@@ -22,11 +21,5 @@ dev_dependencies:
     # the parent directory to use the current plugin's version.
     path: ../
 
-  url_launcher: ^6.0.12
-
 flutter:
   uses-material-design: true
-
-  assets:
-    - res/images/baseflow_logo_def_light-02.png
-    - res/images/poweredByBaseflowLogoLight@3x.png

--- a/permission_handler_android/example/pubspec.yaml
+++ b/permission_handler_android/example/pubspec.yaml
@@ -5,7 +5,6 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  baseflow_plugin_template: 2.1.2
   flutter:
     sdk: flutter
   permission_handler_platform_interface: ^4.2.0
@@ -22,11 +21,5 @@ dev_dependencies:
     # the parent directory to use the current plugin's version.
     path: ../
 
-  url_launcher: ^6.0.12
-
 flutter:
   uses-material-design: true
-
-  assets:
-    - res/images/baseflow_logo_def_light-02.png
-    - res/images/poweredByBaseflowLogoLight@3x.png

--- a/permission_handler_android/example/pubspec.yaml
+++ b/permission_handler_android/example/pubspec.yaml
@@ -5,7 +5,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  baseflow_plugin_template: ^2.1.2
+  baseflow_plugin_template: 2.1.2
   flutter:
     sdk: flutter
   permission_handler_platform_interface: ^4.2.0


### PR DESCRIPTION
This PR attempts to fix https://github.com/Baseflow/flutter-permission-handler/issues/1502

Apps that do not declare `REQUEST_INSTALL_PACKAGES` in their AndroidManifest.xml will crash with `SecurityException` when `canRequestPackageInstalls()` is called. This commonly affects apps that cannot add this permission due to Google Play Store policy restrictions.

*Wrap `canRequestPackageInstalls()` calls in try-catch for `SecurityException` in both*

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
