### PR TITLE
bug: build fails due to deprecated compiler option

### DIFF
--- a/permission_handler/CHANGELOG.md
+++ b/permission_handler/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 12.0.2
+
+- Fixes the Windows build with Visual Studio 18.6.1 or newer by removing a deprecated compiler option.
+
 ## 12.0.1
 
 - Updates the correspondence between permission groups and the key values of Info.plist in the README.md.

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   permission_handler_android: ^13.0.0
   permission_handler_apple: ^9.4.6
   permission_handler_html: ^0.1.1
-  permission_handler_windows: ^0.2.1
+  permission_handler_windows: ^0.2.2
   permission_handler_platform_interface: ^4.3.0
 
 dev_dependencies:

--- a/permission_handler/pubspec.yaml
+++ b/permission_handler/pubspec.yaml
@@ -2,7 +2,7 @@ name: permission_handler
 description: Permission plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API to request and check permissions.
 repository: https://github.com/baseflow/flutter-permission-handler
 issue_tracker: https://github.com/Baseflow/flutter-permission-handler/issues
-version: 12.0.1
+version: 12.0.2
 
 environment:
   sdk: ^3.5.0

--- a/permission_handler_windows/CHANGELOG.md
+++ b/permission_handler_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2
+
+* Fixes the Windows build with Visual Studio 18.6.1 or newer by removing a deprecated compiler option.
+
 ## 0.2.1
 
 * Updates the dependency on `permission_handler_platform_interface` to version 4.1.0 (SiriKit support is only available for iOS and macOS).

--- a/permission_handler_windows/pubspec.yaml
+++ b/permission_handler_windows/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler_windows
 description: Permission plugin for Flutter. This plugin provides the Windows API to request and check permissions.
-version: 0.2.1
+version: 0.2.2
 homepage: https://github.com/baseflow/flutter-permission-handler
 
 flutter:

--- a/permission_handler_windows/windows/CMakeLists.txt
+++ b/permission_handler_windows/windows/CMakeLists.txt
@@ -47,7 +47,6 @@ add_library(${PLUGIN_NAME} SHARED
 apply_standard_settings(${PLUGIN_NAME})
 set_target_properties(${PLUGIN_NAME} PROPERTIES CXX_VISIBILITY_PRESET hidden)
 target_compile_features(${PLUGIN_NAME} PRIVATE cxx_std_20)
-target_compile_options(${PLUGIN_NAME} PRIVATE /await)
 target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
 target_include_directories(${PLUGIN_NAME} INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/include")


### PR DESCRIPTION
Build failed with latest version of Visual Studio due to deprecated compiler option. I removed the compiler option from the CMakeLists.txt file.

Fixes #1534 

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`). **--> Not required**
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.**--> Not required**
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
