### PR TITLE
permission_handler_windows: lazily create Geolocator

### DIFF
--- a/permission_handler_windows/CHANGELOG.md
+++ b/permission_handler_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2
+
+* Lazily creates the Windows `Geolocator` only when checking location service status.
+
 ## 0.2.1
 
 * Updates the dependency on `permission_handler_platform_interface` to version 4.1.0 (SiriKit support is only available for iOS and macOS).

--- a/permission_handler_windows/pubspec.yaml
+++ b/permission_handler_windows/pubspec.yaml
@@ -1,6 +1,6 @@
 name: permission_handler_windows
 description: Permission plugin for Flutter. This plugin provides the Windows API to request and check permissions.
-version: 0.2.1
+version: 0.2.2
 homepage: https://github.com/baseflow/flutter-permission-handler
 
 flutter:

--- a/permission_handler_windows/windows/permission_handler_windows_plugin.cpp
+++ b/permission_handler_windows/windows/permission_handler_windows_plugin.cpp
@@ -63,9 +63,6 @@ class PermissionHandlerWindowsPlugin : public Plugin {
  private:
   void IsLocationServiceEnabled(std::unique_ptr<MethodResult<>> result);
   winrt::fire_and_forget IsBluetoothServiceEnabled(std::unique_ptr<MethodResult<>> result);
-
-  winrt::Windows::Devices::Geolocation::Geolocator geolocator;
-  winrt::Windows::Devices::Geolocation::Geolocator::PositionChanged_revoker m_positionChangedRevoker;
 };
 
 // static
@@ -86,12 +83,7 @@ void PermissionHandlerWindowsPlugin::RegisterWithRegistrar(
   registrar->AddPlugin(std::move(plugin));
 }
 
-PermissionHandlerWindowsPlugin::PermissionHandlerWindowsPlugin(){
-  m_positionChangedRevoker = geolocator.PositionChanged(winrt::auto_revoke,
-    [this](Geolocator const& geolocator, PositionChangedEventArgs e)
-    {
-    });
-}
+PermissionHandlerWindowsPlugin::PermissionHandlerWindowsPlugin() = default;
 
 PermissionHandlerWindowsPlugin::~PermissionHandlerWindowsPlugin() = default;
 
@@ -149,6 +141,7 @@ void PermissionHandlerWindowsPlugin::HandleMethodCall(
 }
 
 void PermissionHandlerWindowsPlugin::IsLocationServiceEnabled(std::unique_ptr<MethodResult<>> result) {
+  Geolocator geolocator;
   result->Success(EncodableValue((int)(geolocator.LocationStatus() != PositionStatus::NotAvailable
         ? PermissionConstants::ServiceStatus::ENABLED
         : PermissionConstants::ServiceStatus::DISABLED)));


### PR DESCRIPTION
`permission_handler_windows` currently creates a Windows `Geolocator` and subscribes to `PositionChanged` while the plugin is registering. That can make apps appear to access location even when they only depend on `permission_handler` and never request location.

This PR removes the eager `Geolocator` member and `PositionChanged` subscription. `Geolocator` is now created only inside `IsLocationServiceEnabled()`, so location service-status checks still work without touching the Windows location API during plugin registration.

Fixes #983.
Fixes #1394.
Related to #1470 and #1389.

Verification performed:

- `flutter pub get` in `permission_handler_windows`
- `dart format --set-exit-if-changed .` in `permission_handler_windows`
- `flutter analyze` in `permission_handler_windows`
- `flutter analyze` in `permission_handler_windows/example`
- `flutter test` in `permission_handler_windows` reports no `test/` directory, so there is no package test suite for this change
- Fork-only Windows smoke: https://github.com/prismplural/flutter-permission-handler/actions/runs/28682163749, example app location registry entries stayed unchanged (`0` before launch, `0` after launch)
- Downstream Prism Windows smoke: https://github.com/prismplural/prism-app/actions/runs/28686868188, Prism resolved this fork, built and launched `prism_plurality.exe`, and location registry entries stayed unchanged (`1` before launch, `1` after launch)

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`), or this PR does not need documentation changes.
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-permission-handler/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
